### PR TITLE
Optimize Backend Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -7,12 +7,14 @@ RUN apt-get update && apt-get install -y \
     libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
 
-COPY . /app
-
-RUN chmod +x run.sh
+COPY requirements.txt /app/requirements.txt
 
 RUN pip install --no-cache-dir -r requirements.txt
 RUN pip uninstall uvcorn
+
+COPY . /app
+
+RUN chmod +x run.sh
 RUN mkdir ../images
 
 EXPOSE 8000


### PR DESCRIPTION
This PR optimizes the Dockerfile to improve build efficiency and caching by modifying the order of operations. Specifically, we install dependencies before copying the application code.

Partially Fixes #63 