### PR TITLE
added .env to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
-
+.env
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json


### PR DESCRIPTION
fixes #71 

what i have done:
Added .env in .gitignore file

this PR will make the env file get removed from repo online and in future it will not get pushed back to repo if any changes detected by git

additonal note:
To fully address the issue, the .env file should be removed from the Git history using tools like BFG Repo-Cleaner or git filter-branch. Additionally, any sensitive keys or credentials should be rotated to ensure they are secure.
AND
repo owner should replace the old variable values used in current env to new values  