### PR TITLE
Fix JSON serialization errors and handle interrupted server shutdowns…

### DIFF
--- a/backend/app/utils/metadata.py
+++ b/backend/app/utils/metadata.py
@@ -2,6 +2,7 @@ import os
 from PIL import Image
 from PIL.ExifTags import TAGS
 from datetime import datetime
+from PIL.TiffImagePlugin import IFDRational
 
 
 def extract_metadata(image_path):
@@ -24,6 +25,12 @@ def extract_metadata(image_path):
         for tag_id in exifdata:
             tag = TAGS.get(tag_id, tag_id)
             data = exifdata.get(tag_id)
+
+            if isinstance(data,tuple) or isinstance(data,list) : 
+                data = [float(d) if isinstance(d,IFDRational) else d for d in data ]
+            elif isinstance(data,IFDRational) : 
+                data = float(data)
+
             if isinstance(data, bytes):
                 data = data.decode()
             metadata[str(tag).lower().replace(" ", "_")] = data


### PR DESCRIPTION
This pull request resolves the issue described in #82 , Handling JSON Serialization Errors and Interrupted Server Shutdowns Gracefully

### Problem-1 : JSON Serialization Error

Problem-1 occured because internally in 

File : backend/app/utils/metadata.py 
--------------------------------------
here in this **extract_metadata** function 

![image](https://github.com/user-attachments/assets/2eb74c97-84be-4a9c-ad32-5aa74a244ac1)
 
directly we are mappling the key with assosiated data    

`
if isinstance(data, bytes) :
    data = data.decode()
metadata[str(tag).lower().replace(" ", "_")] = data
`


for this Internally JSON object becomes to 

 obj = {  
    'image_size': (1010, 1024), 
    'image_format': 'JPEG', 
    'image_mode': 'RGB', 
    'copyright': 'VIDOK', '
    'xresolution':  IFDRational(300.0), 
    'yresolution':  IFDRational(300.0), 
    'imagedescription': 'Yellow flower on white background', 
    'file_size': 74129, 
    'creation_date': '2024-11-27 22:16:41'
}

now if json.dumps(obj) so it will give error 

#### Solution : 

![image](https://github.com/user-attachments/assets/222455ab-549a-4266-9cf7-bd3ed9d006f8)

`
from PIL.TiffImagePlugin import IFDRational
data = exifdata.get(tag_id)
if isinstance(data,tuple) or isinstance(data,list) : 
    data = [float(d) if isinstance(d,IFDRational) else d for d in data ]
elif isinstance(data,IFDRational) : 
    data = float(data)

if isinstance(data, bytes):
    data = data.decode()
metadata[str(tag).lower().replace(" ", "_")] = data

`
here it is check is the data like (IFDRational(300.0),IFDRational(200.0)) or [IFDRational(300.0),IFDRational(200.0)] or IFDRational(300.0)

if it is a instance of IFDRational then firstly convert it to float number then add it to metadata thus **Problem-1** is solved



### Problem-2 : Server Shutdown Error

When stopping the backend server using Ctrl+C, the server terminates but raises a complex traceback error. The critical parts of the error include:

**This Problem is for Windows Users Only in Linux Server shutdown works finely without any error**

So in the backend folder **run-server.ps1**

## Problems : 

1. Ctrl+C was not working unable to stop the server using Ctrl+C or Ctrl+X or Ctrl+d nothing was working need to delete the terminal and again need to start the server

2. Fixed this problem of Ctrl+C now this Server Shutdown Error raises 

**Reason** : Hypercorn, being an **ASGI** server, typically runs with multiple worker processes when deployed in production. When you use multiprocessing. On Windows,**wait** might get interrupted in ways that prevent the process from being cleanly terminated when you press Ctrl+C, resulting in the InterruptedError.

**Solution** : Instead of using hypercorn for running the backend server have used python now It works no error in termination because  using python , you're directly invoking the ASGI app through the main.py script, which can handle the process termination differently. This approach bypasses the direct use of hypercorn's multiprocessing features, and Python's default handling of signals works more smoothly. Essentially, this avoids triggering the problematic signal handling inside the worker management of hypercorn.


**But in this approach using python instead of hypercorn a lot of problems are there :** 

1. Loss of Multi-worker Scalability
2. Manual Worker Management
3. Potential Compatibility Issues
4. No Built-in ASGI Features
5. And also for Linux The conversion to python main.py might be disadvantageous in production because Hypercorn or uvicorn is generally the better choice for multi-worker management and asynchronous request handling. 



That's why my Final Solution for **Windows Users**

converted run-server.ps1 

![image](https://github.com/user-attachments/assets/0e8bcc4d-677c-41a4-b582-704785e32cee) 

**to : **

![image](https://github.com/user-attachments/assets/52648bdf-fdc8-436f-8e24-424cef002232)



**Advantages than previous run-server.ps1** : 

1. Graceful Process Management:  Uses $process to track and terminate the running server process cleanly. The second script does not directly manage the process in production mode.

2. Better Ctrl+C Handling : The first script uses PowerShell’s built-in event handling (Register-EngineEvent) for Ctrl+C. The second script implements a custom solution with a background job, which can be less efficient and less reliable.

3. Structured Restart Logic: In the first script, the restart mechanism for the test environment is more robust (waits for 3 seconds after a crash).

4. Improved Log Handling : Redirects logs to hypercorn.log and processes them continuously, which can help debug issues more effectively.

5. Cleaner Exit: Ensures no leftover processes by checking $process before killing it in both test and production modes.


### Final Result works finely : 



https://github.com/user-attachments/assets/2ad5e9f8-8ad5-4220-895a-cdc3583184ca


