### PR TITLE
fix: navbar disable on scroll

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ videos_cache.txt
 images_cache.txt
 videos_cache.txt
 venv/
+site/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,7 +53,6 @@ markdown_extensions:
   - attr_list
 
 extra_css:
-  - stylesheets/output.css
   - stylesheets/extra.css
 
 nav:


### PR DESCRIPTION
This PR provides the base to debug and analyze a very critical issue, most users tend to look for the navbar instead of the sidebar. The current implementation of the material docs built static website for documentation has a glitch that WHEN a user scrolls down the navbar disappears (expected) but when scrolled to top again the navbar should REAPPEAR which isn't happening.

This PR aims to provide the solution for it.