### PR TITLE
feat: add pre-commit hooks with Husky for formatting and linting checks

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,2 @@
+npm run format:check
+npm run lint:check

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,18 +1,20 @@
 {
-    "extends": ["react-app", "eslint-config-prettier"],
-    "rules": {
-      // Accessibility rules
-      "jsx-a11y/click-events-have-key-events": "off",
-      "jsx-a11y/no-static-element-interactions": "off",
-      "jsx-a11y/img-redundant-alt": "off",
-      "jsx-a11y/no-noninteractive-element-interactions": "off",
-      "jsx-a11y/anchor-is-valid": "off",
-      "jsx-a11y/anchor-has-content": "off",
-      "jsx-a11y/media-has-caption": "off",
-      // React Hook rules
-      "react-hooks/exhaustive-deps": "off",
-      // Temporarily turn warnings into errors to suppress them
-      "no-warning-comments": ["error", { "terms": ["todo", "fixme"], "location": "anywhere" }]
-    }
+  "extends": ["react-app", "eslint-config-prettier"],
+  "rules": {
+    // Accessibility rules
+    "jsx-a11y/click-events-have-key-events": "off",
+    "jsx-a11y/no-static-element-interactions": "off",
+    "jsx-a11y/img-redundant-alt": "off",
+    "jsx-a11y/no-noninteractive-element-interactions": "off",
+    "jsx-a11y/anchor-is-valid": "off",
+    "jsx-a11y/anchor-has-content": "off",
+    "jsx-a11y/media-has-caption": "off",
+    // React Hook rules
+    "react-hooks/exhaustive-deps": "off",
+    // Temporarily turn warnings into errors to suppress them
+    "no-warning-comments": [
+      "error",
+      { "terms": ["todo", "fixme"], "location": "anywhere" }
+    ]
   }
-  
+}

--- a/frontend/.prettierignore
+++ b/frontend/.prettierignore
@@ -1,2 +1,5 @@
 node_modules/
 dist/
+.npm/
+src-tauri/target/
+src-tauri/gen/schemas/

--- a/frontend/src/components/AITagging/FilterControls.tsx
+++ b/frontend/src/components/AITagging/FilterControls.tsx
@@ -67,7 +67,7 @@ export default function FilterControls({
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent
-            className="w-[200px] bg-white dark:text-foreground max-h-[500px] overflow-y-auto"
+            className="max-h-[500px] w-[200px] overflow-y-auto bg-white dark:text-foreground"
             align="end"
           >
             <DropdownMenuRadioGroup

--- a/frontend/src/components/Album/Album.tsx
+++ b/frontend/src/components/Album/Album.tsx
@@ -32,7 +32,9 @@ const AlbumsView: React.FC = () => {
   const transformedAlbums = albums.map((album: Album) => ({
     id: album.album_name,
     title: album.album_name,
-    coverImage: album.image_paths[0] || `D:/Data/Pictopy/PictoPy/frontend/public/tauri.svg`,
+    coverImage:
+      album.image_paths[0] ||
+      `D:/Data/Pictopy/PictoPy/frontend/public/tauri.svg`,
     imageCount: album.image_paths.length,
   }));
 

--- a/frontend/src/components/Album/ImageSelection.tsx
+++ b/frontend/src/components/Album/ImageSelection.tsx
@@ -26,7 +26,7 @@ const ImageSelectionPage: React.FC<ImageSelectionPageProps> = ({
     useAddMultipleImagesToAlbum();
 
   // Extract the array of image paths
-  const allImages: string[] = allImagesData??[];;
+  const allImages: string[] = allImagesData ?? [];
 
   useEffect(() => {
     if (error) {

--- a/frontend/src/components/Navigation/Navbar/Navbar.tsx
+++ b/frontend/src/components/Navigation/Navbar/Navbar.tsx
@@ -2,21 +2,21 @@ export function Navbar(props: { title?: string }) {
   return (
     <>
       <header className="flex w-full flex-row items-center justify-center align-middle">
-      < div className="flex h-16 items-center justify-between bg-[#333333] px-16 w-[50%] mt-3 rounded-3xl ">
-        <div className="flex items-center gap-4">
-          <div className="flex items-center gap-2">
-            <img src="/Pictopy.svg" alt="" />
-            <span className="font-sans text-lg font-bold text-gray-50">
-              Pictopy
+        <div className="mt-3 flex h-16 w-[50%] items-center justify-between rounded-3xl bg-[#333333] px-16">
+          <div className="flex items-center gap-4">
+            <div className="flex items-center gap-2">
+              <img src="/Pictopy.svg" alt="" />
+              <span className="font-sans text-lg font-bold text-gray-50">
+                Pictopy
+              </span>
+            </div>
+          </div>
+          <div className="flex items-center gap-4">
+            <span className="font-sans text-lg font-medium text-gray-50">
+              Welcome {props.title || 'User'}
             </span>
           </div>
         </div>
-        <div className="flex items-center gap-4">
-          <span className="font-sans text-lg font-medium text-gray-50">
-            Welcome {props.title || 'User'}
-          </span>
-        </div>
-      </div>
       </header>
     </>
   );

--- a/frontend/src/components/Navigation/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/Navigation/Sidebar/Sidebar.tsx
@@ -20,7 +20,7 @@ function Sidebar() {
     }`;
 
   return (
-    <div className="sidebar flex w-40 flex-col justify-between space-y-4 border-r border-gray-700 bg-[#333333] p-4 dark:border-gray-700 m-4 rounded-3xl">
+    <div className="sidebar m-4 flex w-40 flex-col justify-between space-y-4 rounded-3xl border-r border-gray-700 bg-[#333333] p-4 dark:border-gray-700">
       <div className="mt-2 flex flex-col gap-10">
         <Link to="/home" className={linkClasses('/home')}>
           <HomeIcon

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,26 @@
     "packages": {
         "": {
             "name": "pictopy",
-            "version": "0.0.0"
+            "version": "0.0.0",
+            "devDependencies": {
+                "husky": "^9.1.7"
+            }
+        },
+        "node_modules/husky": {
+            "version": "9.1.7",
+            "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+            "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "husky": "bin.js"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/typicode"
+            }
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,11 +1,14 @@
 {
-    "name": "pictopy",
-    "private": true,
-    "version": "0.0.0",
-    "type": "module",
-    "scripts": {
-        "linux-dev": "bash ./scripts/linux-dev.sh",
-        "win-dev": "cd scripts && win-dev.bat"
-    }
-   
+  "name": "pictopy",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "linux-dev": "bash ./scripts/linux-dev.sh",
+    "win-dev": "cd scripts && win-dev.bat",
+    "prepare": "husky"
+  },
+  "devDependencies": {
+    "husky": "^9.1.7"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,11 @@
   "scripts": {
     "linux-dev": "bash ./scripts/linux-dev.sh",
     "win-dev": "cd scripts && win-dev.bat",
-    "prepare": "husky"
+    "prepare": "husky",
+    "lint:check": "cd frontend && eslint --max-warnings 0 --config .eslintrc.json .",
+    "lint:fix": "cd frontend && eslint --max-warnings 0 --config .eslintrc.json . --fix",
+    "format:fix": "cd frontend && prettier --write \"**/*.{ts,tsx,json}\"",
+    "format:check": "cd frontend && prettier --check \"**/*.{ts,tsx,json}\""
   },
   "devDependencies": {
     "husky": "^9.1.7"


### PR DESCRIPTION
### Summary
- Implemented Husky for Git hooks to enforce pre-commit formatting and linting checks.
- Added `pre-commit` hook to run formatting (e.g., Prettier) and linting (e.g., ESLint).
- Updated `package.json` with Husky configuration and scripts.
- Included image and video demonstrating the pre-commit hook in action.

### Testing
- Verified that formatting and linting checks run before commits.
- Ensured commits are blocked if there are issues.

### media

![Untitled design](https://github.com/user-attachments/assets/aa63fbe2-d49f-4e06-84af-6ab1d38693a6)
![Untitled design (1)](https://github.com/user-attachments/assets/d489531f-ff81-48b6-a8cf-37fd1fa76166)


https://github.com/user-attachments/assets/d956974f-e677-48bc-98c6-7276cf24efb7



### Checklist
- [x] Husky is installed and configured.
- [x] remove unneceesary checks in formatting  
- [x] added linting and formatting rules in pre commit hook
- [x] Pre-commit hook runs successfully.

### Developer Notes

- To bypass checks in emergencies: git commit -m "message" --no-verify

### related issue
 closes #94 
