### PR TITLE
Fixes #102 - Changes X logo from twitter bird to X

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -97,6 +97,6 @@ extra:
     - icon: fontawesome/brands/discord
       link: https://discord.com/invite/6mFZ2S846n
       name: Join AOSSIE on Discord
-    - icon: fontawesome/brands/twitter
+    - icon: fontawesome/brands/x-twitter
       link: https://x.com/aossie_org
       name: Follow AOSSIE on Twitter


### PR DESCRIPTION
Fixes #102 

This PR will replace the twitter bird logo with X's new logo on the footer