### PR TITLE
Fixed navbar responsiveness for mobile screen #151

### DIFF
--- a/frontend/src/components/Navigation/Navbar/Navbar.tsx
+++ b/frontend/src/components/Navigation/Navbar/Navbar.tsx
@@ -3,17 +3,17 @@ import { ThemeToggle } from '@/components/ThemeToggle';
 export function Navbar(props: { title?: string }) {
   return (
     <header className="flex w-full flex-row items-center justify-center align-middle">
-      <div className="bg-theme-light mb-4 mt-3 flex h-16 items-center justify-between rounded-2xl border border-gray-200 px-16 shadow-md backdrop-blur-md backdrop-saturate-150 dark:border-white/10 dark:bg-white/5 sm:w-[70%] md:w-[55%]">
-        <div className="flex items-center gap-4">
+      <div className="bg-theme-light mb-4 mt-3 flex h-16 items-center justify-between rounded-2xl border border-gray-200 px-4 sm:px-8 md:px-16 shadow-md backdrop-blur-md backdrop-saturate-150 dark:border-white/10 dark:bg-white/5 w-[90%] sm:w-[70%] md:w-[55%]">
+        <div className="flex items-center gap-2 sm:gap-4">
           <div className="flex items-center gap-2">
-            <img src="/public/PictoPy_Logo.png" className="h-7" alt="" />
-            <span className="text-theme-dark dark:text-theme-light font-sans text-lg font-bold drop-shadow-sm">
+            <img src="/public/PictoPy_Logo.png" className="h-7" alt="PictoPy Logo" />
+            <span className="text-theme-dark dark:text-theme-light font-sans text-base sm:text-lg font-bold drop-shadow-sm">
               PictoPy
             </span>
           </div>
         </div>
-        <div className="flex items-center gap-4">
-          <span className="text-theme-dark dark:text-theme-light font-sans text-lg font-medium">
+        <div className="flex items-center gap-2 sm:gap-4">
+          <span className="text-theme-dark dark:text-theme-light font-sans text-sm sm:text-lg font-medium">
             Welcome {props.title || 'User'}
           </span>
           <ThemeToggle />


### PR DESCRIPTION
Closes issue - #151

This PR improves the responsiveness of the header component to ensure better usability on mobile devices. The following changes have been made:
- Adjusted padding and gaps for smaller screens to prevent content overlapping which was happening earlier.
- Implemented responsive width handling (`w-[90%]` for small screens).
- Added dynamic font size scaling for text elements. Scales text size down for small screens while keeping it larger for medium and larger screens to prevent the problem that was occurring. 

PFA the screenshots.

![Screenshot 2024-12-28 235952](https://github.com/user-attachments/assets/c3da6f5b-9b3c-4859-bb10-bd5ca18e798a)
