### PR TITLE
Fixed Sidebar overflowing & overlapping on Footer

### DIFF
--- a/docs/stylesheets/output.css
+++ b/docs/stylesheets/output.css
@@ -595,3 +595,13 @@ video {
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
 }
+
+
+.md-footer {
+  z-index: 50 !important;
+  background-color: #1e1e1e !important;
+}
+
+.md-footer .md-navigation {
+  background-color: inherit;
+}


### PR DESCRIPTION
This PR resolves the issue #85 of the sidebar overflowing and overlapping on the footer due to a bug in the library "Material for MkDocs" which has been used for the documentation. I made the following custom changes to resolve the same:

- Added custom css to change the z-indexing of the sidebar and footer elements.
- Tweaked the footer background color property to remove the transparency while mantaining the same color to continue the consistency in colors being used.

PFA the screenshot of the resolved layout.

![image](https://github.com/user-attachments/assets/764975a4-bf25-4c2c-ab47-8cd8f061a462)
