### PR TITLE
Implement file locking in CacheRepository to resolve concurrency issues

### DIFF
--- a/frontend/src-tauri/src/repositories/cache_repository.rs
+++ b/frontend/src-tauri/src/repositories/cache_repository.rs
@@ -1,6 +1,7 @@
 use std::fs::{File, OpenOptions};
 use std::io::{BufRead, BufReader, Write};
 use std::path::PathBuf;
+use fs2::FileExt;
 
 pub struct CacheRepository;
 
@@ -20,12 +21,16 @@ impl CacheRepository {
             .create(true)
             .truncate(true)
             .open(cache_file_path)?;
+        
+        file.lock_exclusive()?;
 
         for path in paths {
             if let Some(path_str) = path.to_str() {
                 writeln!(file, "{}", path_str)?;
             }
         }
+
+        file.unlock()?;
         Ok(())
     }
 


### PR DESCRIPTION
### **Summary**  
This PR enhances the `CacheRepository` to address concurrency issues during cache file operations.

### **Changes Made**  
1. Added file locking using the `fs2` crate to ensure exclusive access during writes.  
2. Modified the `write_cache` method to lock the file during the writing process and unlock it after completion.  
3. Improved reliability and data integrity by preventing simultaneous writes to cache files.

### **Purpose**  
To resolve concurrency issues and ensure thread-safe access to cache files.

### **Issue Reference**  
Fixes #234
