### PR TITLE
Fix conditional rendering of layout routes in AppRoutes

### DIFF
--- a/frontend/src/routes/AppRoutes.tsx
+++ b/frontend/src/routes/AppRoutes.tsx
@@ -8,20 +8,22 @@ import { InitialPage } from '@/pages/Setupscreen/Setup';
 
 export const AppRoutes: React.FC = () => {
   const location = useLocation();
-  const isLayoutRoute = Object.values(ROUTES.LAYOUT).includes(
-    location.pathname,
-  );
+  const isLayoutRoute = Object.values(ROUTES.LAYOUT).includes(location.pathname);
 
   return (
-    <>
-      <Routes>
-        <Route path={ROUTES.INITIAL} element={<InitialPage />} />
-      </Routes>
+    <Routes>
+      <Route path={ROUTES.INITIAL} element={<InitialPage />} />
       {isLayoutRoute && (
-        <Layout>
-          <LayoutRoutes />
-        </Layout>
+        <Route
+          path="*"
+          element={
+            <Layout>
+              <LayoutRoutes />
+            </Layout>
+          }
+        />
       )}
-    </>
+    </Routes>
   );
 };
+


### PR DESCRIPTION
-Fixed The issue of Layout being applied on Initial Page. 
-Now the layout only gets applied on the path that are mentioned in ROUTES.LAYOUT

-Initial Page Route: Displays InitialPage at the ROUTES.INITIAL path.
-Layout Routes: Applies a layout to routes in ROUTES.LAYOUT, using a wildcard path="*". This ensures the layout wraps around all matching routes.