### PR TITLE
Fix Loose Equality Warning in MediaView.tsx (#290)

### DIFF
--- a/frontend/src/components/Media/MediaView.tsx
+++ b/frontend/src/components/Media/MediaView.tsx
@@ -472,7 +472,7 @@ const MediaView: React.FC<MediaViewProps> = ({
           <ChevronRight className="h-6 w-6" />
         </button>
       </div>
-      {type == 'image' ? (
+      {type === 'image' ? (
         <div className="absolute bottom-20 right-4 flex gap-2">
           <button
             onClick={handleZoomOut}


### PR DESCRIPTION
This pull request fixes the loose equality (==) warning in MediaView.tsx by replacing it with strict equality (===).

