### PR TITLE
fix(setup): center align folder picker icon in smaller resolutions

### DIFF
--- a/frontend/src/components/FolderPicker/FolderPicker.tsx
+++ b/frontend/src/components/FolderPicker/FolderPicker.tsx
@@ -52,7 +52,7 @@ const FolderPicker: React.FC<FolderPickerProps> = ({
     }
   };
   return (
-    <div className="flex w-full gap-3">
+    <div className="flex w-full gap-3 justify-center">
       <Button
         onClick={pickFolder}
         variant="outline"


### PR DESCRIPTION
On the Setup screen, the "Add folder" button text gets hidden in smaller widths, leaving only the icon visible. Previously, the icon was not center-aligned, affecting the UI appearance.  

Added `justify-center` to the parent `flex` container to properly align the icon.  


Before:
![before](https://github.com/user-attachments/assets/83922c61-0256-42a5-970e-a4e939b368bd)

After:
![after](https://github.com/user-attachments/assets/70a078ee-3e59-4fd4-bab0-f9fae50d92bc)

