### PR TITLE
Fix: MediaCard fallback mechanism for broken thumbnails

### DIFF
--- a/frontend/src/components/Media/MediaCard.tsx
+++ b/frontend/src/components/Media/MediaCard.tsx
@@ -6,6 +6,7 @@ import { cn } from '@/lib/utils';
 export default function MediaCard({ item, type }: MediaCardProps) {
   const [isLoading, setIsLoading] = useState(true);
   const [isError, setIsError] = useState(false);
+  const [fallbackImage, setFallbackImage] = useState<string | null>(null);
   const [isMuted, setIsMuted] = useState(true);
   const videoRef = useRef<HTMLVideoElement>(null);
 
@@ -15,8 +16,12 @@ export default function MediaCard({ item, type }: MediaCardProps) {
   };
 
   const handleError = () => {
-    setIsLoading(false);
-    setIsError(true);
+    console.warn("Failed to load thumbnail, falling back to full image:", item.thumbnailUrl);
+    if (item.thumbnailUrl) {
+      setFallbackImage(item.url); 
+    } else {
+      setIsError(true);
+    }
   };
 
   const toggleMute = (e: React.MouseEvent) => {
@@ -45,6 +50,7 @@ export default function MediaCard({ item, type }: MediaCardProps) {
       tabIndex={0}
       aria-label={`${type === 'video' ? 'Play' : 'View'} ${item.title}`}
     >
+
       {isLoading && (
         <div className="absolute inset-0 flex items-center justify-center bg-gray-900/20 backdrop-blur-sm">
           <Loader2 className="h-8 w-8 animate-spin text-blue-500" />
@@ -65,15 +71,14 @@ export default function MediaCard({ item, type }: MediaCardProps) {
 
       {type === 'image' ? (
         <img
-          src={item.thumbnailUrl || item.url}
+          src={fallbackImage || item.thumbnailUrl || item.url}
           alt={item.title}
           className={cn(
             'rounded-xl h-full w-full object-cover transition-all duration-700 ease-in-out group-hover:rotate-1 group-hover:scale-110',
-            isLoading && 'opacity-0',
-            isError && 'hidden',
+            isLoading && 'opacity-0'
           )}
           onLoad={handleLoadComplete}
-          onError={handleError}
+          onError={handleError} // Triggers fallback mechanism
         />
       ) : (
         <>
@@ -82,8 +87,7 @@ export default function MediaCard({ item, type }: MediaCardProps) {
             src={item.url}
             className={cn(
               'rounded-xl h-full w-full object-cover transition-all duration-700 ease-in-out group-hover:rotate-1 group-hover:scale-110',
-              isLoading && 'opacity-0',
-              isError && 'hidden',
+              isLoading && 'opacity-0'
             )}
             playsInline
             muted={isMuted}


### PR DESCRIPTION
### **Description**  
This PR fixes [Issue #333] by improving the fallback mechanism in the **MediaCard** component when thumbnails fail to load.  

🔹 **What was the issue?**  
- If the `thumbnailUrl` failed to load, the UI displayed a broken image.  

🔹 **Fix Implemented:**  
- Now, when the thumbnail fails, it **automatically falls back to the main image (`item.url`)**.  
- **Improved error handling** to prevent UI glitches.  
  

### **Changes Made**  
- Updated `MediaCard.tsx`:  
  ✅ Implemented a **thumbnail fallback strategy**.  
  ✅ Improved **error handling** for media loading.  


### **How to Test?**  
1. Run the frontend locally.  

2. Verify that the main image is displayed as a fallback instead of a broken thumbnail.  
3. Ensure videos and images load correctly in other scenarios.  

### **Screenshots (If Applicable)**  

**### Before**
![WhatsApp Image 2025-02-16 at 08 36 43_eca55646](https://github.com/user-attachments/assets/796e4d0d-37f6-4a7a-ac19-7aaf2827c633)

**### After**
![WhatsApp Image 2025-02-16 at 08 38 00_9ca67ea1](https://github.com/user-attachments/assets/ffcea213-07fe-4de2-a96c-3be9f89f30c9)

### **Linked Issues**  
Closes [#333]

### **Checklist**  
✅ Code follows project guidelines.  
✅ No breaking changes.  
✅ Tested across different scenarios.  