### PR TITLE
Fix Albums heading visibility in dark mode (Fixes #435)

### DIFF
--- a/frontend/src/components/Album/Album.tsx
+++ b/frontend/src/components/Album/Album.tsx
@@ -58,7 +58,7 @@ const AlbumsView: React.FC = () => {
             Create New Album
           </Button>
         </div>
-        <div className="text-center">No albums found.</div>
+        <div className="text-xl text-center font-bold text-gray-900 dark:text-gray-100 px-4 py-2 rounded-lg">No albums found.</div>
         <CreateAlbumForm
           isOpen={isCreateFormOpen}
           closeForm={() => setIsCreateFormOpen(false)}

--- a/frontend/src/components/Album/Album.tsx
+++ b/frontend/src/components/Album/Album.tsx
@@ -49,7 +49,7 @@ const AlbumsView: React.FC = () => {
     return (
       <div className="container mx-auto pb-4">
         <div className="mb-4 flex items-center justify-between">
-          <h1 className="text-2xl font-bold">Albums</h1>
+          <h1 className="text-2xl font-bold text-gray-100 dark:text-gray-900 bg-gray-800 dark:bg-gray-100 px-4 py-2 rounded-lg">Albums</h1>
           <Button
             onClick={() => setIsCreateFormOpen(true)}
             variant="outline"
@@ -114,7 +114,7 @@ const AlbumsView: React.FC = () => {
       ) : (
         <>
           <div className="mb-4 flex items-center justify-between">
-            <h1 className="text-2xl font-bold">Albums</h1>
+            <h1 className="text-2xl font-bold text-gray-100 dark:text-gray-900 bg-gray-800 dark:bg-gray-100 px-4 py-2 rounded-lg">Albums</h1>
             <Button
               onClick={() => setIsCreateFormOpen(true)}
               variant="outline"


### PR DESCRIPTION
## Problem
The "Albums" heading text was not properly visible in dark mode, making it difficult for users to read and navigate the interface.

## Solution
- Added background colors for better contrast in both light and dark modes
- Applied proper text colors: `text-gray-100 dark:text-gray-900`
- Added background styling: `bg-gray-800 dark:bg-gray-100`
- Added padding (`px-4 py-2`) and rounded corners (`rounded-lg`) for improved visual appeal
- Fixed both instances of Albums heading in the component

## Changes Made
- Updated `frontend/src/components/Album/Album.tsx` (lines 52, 102)
- Enhanced styling for both light and dark mode compatibility

## Testing
- ✅ Verified heading is visible in light mode with dark background
- ✅ Verified heading is visible in dark mode with light background
- ✅ Confirmed proper contrast ratios for accessibility
- ✅ Verified consistent styling across both instances

## Before/After
**Before:** Albums heading invisible/hard to read in dark mode, no background styling
![Screenshot 2025-07-03 172717](https://github.com/user-attachments/assets/bbff1f0a-5587-4960-9aa6-8346737d7271)
**After:** Albums heading clearly visible in both modes with attractive background styling
![image](https://github.com/user-attachments/assets/c9f57a82-87ee-46b8-8069-8ec770c6cfbb)

Fixes #435

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **Style**
  * Enhanced the appearance of the "Albums" heading with improved background color, padding, rounded corners, and support for light and dark modes.
  * Restyled the "No albums found." message with larger font size, bold text, padding, rounded corners, and color adjustments for light and dark themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->