### PR TITLE
Fixed: issue#215 | Set minimum window size to prevent layout breakage

### DIFF
--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -48,6 +48,8 @@
         "title": "PictoPy",
         "width": 800,
         "height": 600,
+        "minWidth": 1280,
+        "minHeight": 720,
         "resizable": true,
         "fullscreen": false,
         "maximized": false


### PR DESCRIPTION
Fixes issue [#215](https://github.com/AOSSIE-Org/PictoPy/issues/215)
Prevents layout distortion when the window is resized below a usable threshold.
## Changes:
 - Set minimum width to 1280
 - Set minimum height to 720

## Test:
https://github.com/user-attachments/assets/9b7574b1-53fc-4bd4-b186-9ddb94323072

