### PR TITLE
fix(docs): Replaced favicon with transparent icon (#446)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,8 +5,8 @@ edit_uri: edit/main/docs/
 
 theme:
   name: material
-  logo: assets/PictoPy-logo.png
-  favicon: assets/PictoPy-logo.png
+  logo: assets/favicon.png
+  favicon: assets/favicon.png
   icon:
     repo: fontawesome/brands/github
   features:


### PR DESCRIPTION
Replaced the docs site favicon with a transparent version of the PictoPy icon.

- Used `icon.png` from `frontend/src-tauri/icons/`
- Renamed it to `favicon.png` and placed it in `docs/assets/`
- Updated `mkdocs.yml` to reference the new icon

Fixes #446

![image](https://github.com/user-attachments/assets/4be1a629-b755-4c5c-9f20-302fd41c328b)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the logo and favicon images used in the site theme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->