### PR TITLE
Add Release Drafter configuration and workflow

### DIFF
--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -1,4 +1,4 @@
-name-template: 'v$RESOLVED_VERSION'
+name-template: PictoPy v$RESOLVED_VERSION
 tag-template: 'v$RESOLVED_VERSION'
 
 categories:

--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -1,0 +1,30 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+
+categories:
+  - title: 'Features:'
+    labels:
+      - 'UI'
+      - 'enhancement'
+
+  - title: 'Bug Fixes:'
+    labels:
+      - 'bug'
+
+  - title: 'Documentation:'
+    labels:
+      - 'documentation'
+
+  - title: 'Others:'
+    labels: []
+
+change-template: '- $TITLE (#$NUMBER) by @$AUTHOR'
+
+template: |
+  # What's Changed
+
+  $CHANGES
+
+  ## Special thanks to all our contributors:
+
+  $CONTRIBUTORS

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -3,6 +3,11 @@ on:
   release:
     types: [published]
   workflow_dispatch: # Ability to manually trigger the workflow
+    inputs:
+      tag:
+        description: 'Tag name for the release' # used when running manually
+        required: true
+        type: string
 
 jobs:
   build-server-windows:
@@ -192,8 +197,9 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
         with:
           projectPath: ./frontend
-          tagName: ${{ github.event.release.tag_name }}
+          tagName: ${{ github.event.release.tag_name || github.event.inputs.tag }}
           includeUpdaterJson: true
+          releaseId: ${{ github.event.release.id || '' }}
           releaseDraft: false
           prerelease: false
           args: ${{ matrix.args }}

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -1,5 +1,7 @@
 name: Build and Release App
 on:
+  release:
+    types: [published]
   workflow_dispatch: # Ability to manually trigger the workflow
 
 jobs:
@@ -190,10 +192,8 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
         with:
           projectPath: ./frontend
-          tagName: app-v__VERSION__
-          releaseName: "PictoPy v__VERSION__"
-          releaseBody: "See the assets to download this version and install."
+          tagName: ${{ github.event.release.tag_name }}
           includeUpdaterJson: true
-          releaseDraft: true
+          releaseDraft: false
           prerelease: false
           args: ${{ matrix.args }}

--- a/.github/workflows/update-release-drafter.yml
+++ b/.github/workflows/update-release-drafter.yml
@@ -17,6 +17,6 @@ jobs:
       - name: Update release draft
         uses: release-drafter/release-drafter@v5
         with:
-          config-name: .github/release-drafter-config.yml
+          config-name: release-drafter-config.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-release-drafter.yml
+++ b/.github/workflows/update-release-drafter.yml
@@ -17,6 +17,6 @@ jobs:
       - name: Update release draft
         uses: release-drafter/release-drafter@v5
         with:
-          config-name: release-drafter-config.yml
+          config-name: .github/release-drafter-config.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-release-drafter.yml
+++ b/.github/workflows/update-release-drafter.yml
@@ -1,0 +1,22 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [closed]
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Update release draft
+        uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter-config.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes #455
Introduces a Release Drafter config file and GitHub Actions workflow to automate release note generation and drafting on pushes to main and closed pull requests.

## Changes:
- Add `.github/release-drafter-config.yml` _(Configuration for the Release Drafter bot)_
- Add `.github/workflows/update-release-drafter.yml` _(GitHub Actions workflow that runs the Release Drafter bot on PR merge / push to main)_

## Test:
The example PR under "Features" was labeled `enhancement` or `UI`.
Similarly for "Bug Fixes" & "Documentation"; label was `bug` and `documentation` respectively.
All the PRs under "Others" had none of the above mentioned labels.
![image](https://github.com/user-attachments/assets/62bfa911-5b11-4f35-aa69-8f6f2322838a)
Changelog config goes like: `$TITLE (#$NUMBER) by @$AUTHOR`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated release note generation and categorization for pull requests.
  * Introduced a workflow to update release drafts automatically on main branch updates and closed pull requests.
  * Updated release workflow to trigger on release publishing and dynamically use release tags without creating draft releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->