### PR TITLE
fix: update Tauri environment detection for v2 compatibility

### DIFF
--- a/frontend/src/utils/tauriUtils.ts
+++ b/frontend/src/utils/tauriUtils.ts
@@ -36,14 +36,3 @@ export const isTauriEnvironment = (): boolean => {
 
   return false;
 };
-
-// Alternative: You can also use the official API directly
-export const isTauriEnvironmentOfficial = async (): Promise<boolean> => {
-  try {
-    const { isTauri } = await import('@tauri-apps/api/core');
-    return isTauri();
-  } catch (error) {
-    // Fallback if @tauri-apps/api is not available
-    return isTauriEnvironment();
-  }
-};


### PR DESCRIPTION
## Summary
Fixed Tauri environment detection to work correctly with Tauri v2, resolving the issue where the desktop app was incorrectly showing the browser warning.

## Problem
The existing `isTauriEnvironment()` function used the deprecated `window.__TAURI__` check, which is no longer available by default in Tauri v2 unless `withGlobalTauri: true` is explicitly set.

## Solution
- ✅ Added `window.isTauri` check (official API since Tauri 2.0.0-beta.9)
- ✅ Added `window.__TAURI_INTERNALS__` fallback for Tauri v2 compatibility  
- ✅ Kept `window.__TAURI__` as final fallback for backward compatibility
- ✅ Added TypeScript declarations for better type safety
- ✅ Added alternative `isTauriEnvironmentOfficial()` using `@tauri-apps/api/core`

## Testing
- [x] Desktop app no longer shows browser warning
- [x] Browser detection still works correctly
- [x] Build passes without TypeScript errors

## References
- [Tauri Discussion #6119](https://github.com/tauri-apps/tauri/discussions/6119)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved detection of the Tauri environment, increasing reliability across different setups.
  * Added an advanced detection method that uses the official Tauri API when available, with fallback to legacy checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->