### PR TITLE
Fix: release-drafter workflow error

### DIFF
--- a/.github/workflows/update-release-drafter.yml
+++ b/.github/workflows/update-release-drafter.yml
@@ -7,8 +7,14 @@ on:
   pull_request:
     types: [closed]
 
+permissions:
+  contents: read
+
 jobs:
   update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo


### PR DESCRIPTION
Added explicit permissions for contents and pull-requests in the update-release-drafter workflow to improve security and clarify required access levels.

```yml
permissions:
  contents: write
  pull-requests: read
```

This should resolve the `Resource not accessible by integration` error when creating a release.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow permissions for the release drafting process to enhance security and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->