### PR TITLE
Add InfoDialog component and integrate with Redux for state management

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,10 +5,12 @@ import { AppRoutes } from '@/routes/AppRoutes';
 import { ThemeProvider } from '@/contexts/ThemeContext';
 import QueryClientProviders from '@/config/QueryClientProvider';
 import { GlobalLoader } from './components/Loader/GlobalLoader';
+import { InfoDialog } from './components/Dialog/InfoDialog';
 import { useSelector } from 'react-redux';
 import { RootState } from './app/store';
 const App: React.FC = () => {
   const { loading, message } = useSelector((state: RootState) => state.loader);
+  const { isOpen, title, message: infoMessage } = useSelector((state: RootState) => state.infoDialog);
   return (
     <ThemeProvider>
       <QueryClientProviders>
@@ -16,6 +18,7 @@ const App: React.FC = () => {
           <AppRoutes />
         </BrowserRouter>
         <GlobalLoader loading={loading} message={message} />
+        <InfoDialog isOpen={isOpen} title={title} message={infoMessage} />
       </QueryClientProviders>
     </ThemeProvider>
   );

--- a/frontend/src/app/store.ts
+++ b/frontend/src/app/store.ts
@@ -1,10 +1,13 @@
 import { configureStore } from '@reduxjs/toolkit';
 import loaderReducer from '@/features/loaderSlice';
 import onboardingReducer from '@/features/onboardingSlice';
+import infoDialogReducer from '@/features/infoDialogSlice';
+
 export const store = configureStore({
   reducer: {
     loader: loaderReducer,
     onboarding: onboardingReducer,
+    infoDialog: infoDialogReducer,
   },
 });
 

--- a/frontend/src/components/Dialog/InfoDialog.tsx
+++ b/frontend/src/components/Dialog/InfoDialog.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Info } from 'lucide-react';
+import { 
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { InfoDialogProps } from '@/types/infoDialog';
+import { useDispatch } from 'react-redux';
+import { hideInfoDialog } from '@/features/infoDialogSlice';
+
+export const InfoDialog: React.FC<InfoDialogProps> = ({
+  isOpen,
+  title,
+  message
+}) => {
+  const dispatch = useDispatch();
+
+  const handleClose = () => {
+    dispatch(hideInfoDialog());
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => {
+      if (!open) handleClose();
+    }}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Info className="h-5 w-5 text-primary" />
+            {title}
+          </DialogTitle>
+          <DialogDescription>
+            {message}
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button onClick={handleClose}>
+            Close
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/frontend/src/features/infoDialogSlice.ts
+++ b/frontend/src/features/infoDialogSlice.ts
@@ -1,0 +1,33 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+interface InfoDialogState {
+  isOpen: boolean;
+  title: string;
+  message: string;
+}
+
+const initialState: InfoDialogState = {
+  isOpen: false,
+  title: '',
+  message: '',
+};
+
+const infoDialogSlice = createSlice({
+  name: 'infoDialog',
+  initialState,
+  reducers: {
+    showInfoDialog(state, action: PayloadAction<{ title: string; message: string }>) {
+      state.isOpen = true;
+      state.title = action.payload.title;
+      state.message = action.payload.message;
+    },
+    hideInfoDialog(state) {
+      state.isOpen = false;
+      state.title = '';
+      state.message = '';
+    },
+  },
+});
+
+export const { showInfoDialog, hideInfoDialog } = infoDialogSlice.actions;
+export default infoDialogSlice.reducer;

--- a/frontend/src/pages/SettingsPage/Settings.tsx
+++ b/frontend/src/pages/SettingsPage/Settings.tsx
@@ -17,6 +17,7 @@ import { usePictoMutation } from '@/hooks/useQueryExtensio';
 
 import { useDispatch } from 'react-redux';
 import { showLoader, hideLoader } from '@/features/loaderSlice';
+import { showInfoDialog } from '@/features/infoDialogSlice';
 
 import {
   deleteFolder,
@@ -84,6 +85,12 @@ const Settings: React.FC = () => {
       const hasUpdate = await checkForUpdates();
       if (hasUpdate) {
         setUpdateDialogOpen(true);
+      } else {
+        // Show info dialog when no updates are available
+        dispatch(showInfoDialog({
+          title: 'No Updates Available',
+          message: 'Your application is already up to date with the latest version.'
+        }));
       }
       dispatch(hideLoader());
     };

--- a/frontend/src/types/infoDialog.ts
+++ b/frontend/src/types/infoDialog.ts
@@ -1,0 +1,5 @@
+export interface InfoDialogProps {
+  isOpen: boolean;
+  title: string;
+  message: string;
+}


### PR DESCRIPTION
- Fixes: #443
- This pull request adds a reusable info dialog component to the frontend, allowing the application to display informational messages to users via a modal dialog. The main changes include introducing the `InfoDialog` component, implementing Redux state management for dialog visibility and content, and integrating the dialog into the app and settings page.

**Info Dialog Feature Implementation**

* Added a new `InfoDialog` component in `components/Dialog/InfoDialog.tsx` that displays a modal with a title, message, and close button, using the Lucide React icon library and custom UI components.
* Created a Redux slice in `features/infoDialogSlice.ts` to manage the dialog's open state, title, and message, with actions to show and hide the dialog.
* Defined the `InfoDialogProps` interface in `types/infoDialog.ts` for type safety of dialog properties.

**Integration with Application State**

* Registered the new `infoDialog` reducer in the Redux store (`app/store.ts`) and connected its state to the main `App` component, rendering the dialog when appropriate.

**Usage Example**

https://github.com/user-attachments/assets/f6db97cf-263f-4668-9be5-f79a9fcd31ce


* Updated the settings page (`pages/SettingsPage/Settings.tsx`) to show the info dialog when no updates are available, providing user feedback. 