### PR TITLE
fix: Remove uvloop dependency for Windows compatibility

### DIFF
--- a/sync-microservice/requirements.txt
+++ b/sync-microservice/requirements.txt
@@ -35,6 +35,5 @@ typing_extensions==4.14.1
 typing-inspection==0.4.1
 urllib3==2.5.0
 uvicorn==0.35.0
-uvloop==0.21.0
 watchfiles==1.1.0
 websockets==15.0.1


### PR DESCRIPTION
The sync-microservice was failing to install dependencies on Windows due to  uvloop not supporting the Windows platform. Since uvloop is an optional  dependency of uvicorn, removing it resolves the installation issue while maintaining functionality on Windows systems.

This pull request makes a minor update to the dependency list in `sync-microservice/requirements.txt` by removing the `uvloop` package. 