### PR TITLE
fix: add missing framer-motion dependency

### DIFF
--- a/web-ui/frontend/package.json
+++ b/web-ui/frontend/package.json
@@ -17,6 +17,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "constants": "^0.0.2",
+    "framer-motion": "^12.23.12",
     "install": "^0.13.0",
     "lottie": "^0.0.1",
     "lottie-react": "^2.4.1",


### PR DESCRIPTION
##Added this dependency

<img width="653" height="202" alt="Screenshot 2025-09-02 154345" src="https://github.com/user-attachments/assets/4ebb7af5-b934-4bc2-9aff-7c537dc0c68d" />
