### PR TITLE
fix: update FastAPI command for Windows compatibility

### DIFF
--- a/backend/app/utils/microservice.py
+++ b/backend/app/utils/microservice.py
@@ -28,16 +28,16 @@ def microservice_util_start_sync_service(
     """
     try:
         # Check if running as a frozen executable (PyInstaller)
-
         if getattr(sys, "frozen", False):
             logger.info(
                 "Running as frozen executable, using bundled sync microservice..."
             )
             return _start_frozen_sync_service()
-        # Development mode - use virtual environment setup
 
+        # Development mode - use virtual environment setup
         logger.info("Running in development mode, using virtual environment...")
         return _start_dev_sync_service(sync_service_path)
+
     except Exception as e:
         logger.error(f"Error starting sync microservice: {e}")
         return False
@@ -50,35 +50,32 @@ def _start_frozen_sync_service() -> bool:
     """
     try:
         # Get the directory where the current executable is located
-
         if getattr(sys, "frozen", False):
             # When frozen, sys.executable points to the main executable
-
             app_dir = Path(sys.executable).parent.parent
         else:
             # Fallback (shouldn't happen in this function)
-
             app_dir = Path(__file__).parent.parent.parent.parent
-        # Look for the sync-microservice directory and executable
 
+        # Look for the sync-microservice directory and executable
         sync_dir = app_dir / "sync-microservice"
 
         # Determine executable name based on platform
-
         system = platform.system().lower()
         if system == "windows":
             sync_executable = sync_dir / "PictoPy_Sync.exe"
         else:
             sync_executable = sync_dir / "PictoPy_Sync"
+
         if not sync_executable.exists():
             logger.error(
                 f"Sync microservice executable not found at: {sync_executable}"
             )
             return False
+
         logger.info(f"Starting sync microservice from: {sync_executable}")
 
         # Start the sync microservice executable
-
         process = subprocess.Popen(
             [str(sync_executable)],
             stdout=subprocess.PIPE,
@@ -91,6 +88,7 @@ def _start_frozen_sync_service() -> bool:
         logger.info("Service should be available at http://localhost:8001")
 
         return True
+
     except Exception as e:
         logger.error(f"Error starting frozen sync microservice: {e}")
         return False
@@ -102,46 +100,45 @@ def _start_dev_sync_service(sync_service_path: Optional[str] = None) -> bool:
     """
     try:
         # Determine the sync service path
-
         if sync_service_path is None:
             # Get project root (assuming this file is in backend/app/utils/)
-
             current_file = Path(__file__)
             project_root = current_file.parent.parent.parent.parent
             sync_service_path = project_root / "sync-microservice"
         else:
             sync_service_path = Path(sync_service_path)
+
         if not sync_service_path.exists():
             logger.error(f"Sync service directory not found: {sync_service_path}")
             return False
-        # Define virtual environment path
 
+        # Define virtual environment path
         venv_path = sync_service_path / ".sync-env"
 
         # Check if virtual environment exists
-
         if not venv_path.exists():
             logger.info("Virtual environment not found. Creating .sync-env...")
             if not _create_virtual_environment(venv_path):
                 logger.error("Failed to create virtual environment")
                 return False
-        # Get the Python executable path from the virtual environment
 
+        # Get the Python executable path from the virtual environment
         python_executable = _get_venv_python_executable(venv_path)
         if not python_executable:
             logger.error("Failed to locate Python executable in virtual environment")
             return False
-        # Install dependencies if requirements.txt exists
 
+        # Install dependencies if requirements.txt exists
         requirements_file = sync_service_path / "requirements.txt"
         if requirements_file.exists():
             logger.info("Installing dependencies...")
             if not _install_requirements(python_executable, requirements_file):
                 logger.warning("Failed to install requirements, but continuing...")
-        # Start the FastAPI service
 
+        # Start the FastAPI service
         logger.info("Starting sync microservice on port 8001...")
         return _start_fastapi_service(python_executable, sync_service_path)
+
     except Exception as e:
         logger.error(f"Error starting dev sync microservice: {e}")
         return False
@@ -151,7 +148,6 @@ def _create_virtual_environment(venv_path: Path) -> bool:
     """Create a virtual environment at the specified path."""
     try:
         # Use the current Python interpreter to create the virtual environment
-
         cmd = [sys.executable, "-m", "venv", str(venv_path)]
 
         result = subprocess.run(
@@ -167,6 +163,7 @@ def _create_virtual_environment(venv_path: Path) -> bool:
         else:
             logger.error(f"Failed to create virtual environment: {result.stderr}")
             return False
+
     except subprocess.TimeoutExpired:
         logger.error("Virtual environment creation timed out")
         return False
@@ -181,12 +178,11 @@ def _get_venv_python_executable(venv_path: Path) -> Optional[Path]:
 
     if system == "windows":
         # Windows: .sync-env/Scripts/python.exe
-
         python_exe = venv_path / "Scripts" / "python.exe"
     else:
         # Unix/Linux/macOS: .sync-env/bin/python
-
         python_exe = venv_path / "bin" / "python"
+
     if python_exe.exists():
         return python_exe
     else:
@@ -219,6 +215,7 @@ def _install_requirements(python_executable: Path, requirements_file: Path) -> b
         else:
             logger.error(f"Failed to install requirements: {result.stderr}")
             return False
+
     except subprocess.TimeoutExpired:
         logger.error("Requirements installation timed out")
         return False
@@ -231,17 +228,17 @@ def _start_fastapi_service(python_executable: Path, service_path: Path) -> bool:
     """Start the FastAPI service using the virtual environment Python."""
     try:
         # Change to the service directory
-
         original_cwd = os.getcwd()
         os.chdir(service_path)
 
+        # Command to start FastAPI dev server
+        print(python_executable)
         host = "127.0.0.1"
         port = "8001"
         # On Windows, use a different approach with scripts path
 
         if platform.system().lower() == "windows":
             # Use uvicorn directly to run the FastAPI app
-
             cmd = [
                 str(python_executable),
                 "-m",
@@ -255,28 +252,26 @@ def _start_fastapi_service(python_executable: Path, service_path: Path) -> bool:
             ]
         else:
             # For non-Windows platforms
-
             cmd = [str(python_executable), "-m", "fastapi", "dev", "--port", "8001"]
+
         logger.info(f"Executing command: {' '.join(cmd)}")
 
-        # Start the process
-
+        # Start the process (non-blocking)
         process = subprocess.Popen(
             cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
         )
 
         # Restore original working directory
-
         os.chdir(original_cwd)
 
         logger.info(f"Sync microservice started with PID: {process.pid}")
         logger.info("Service should be available at http://localhost:8001")
 
         return True
+
     except Exception as e:
         logger.error(f"Error starting FastAPI service: {e}")
         # Restore original working directory in case of error
-
         try:
             os.chdir(original_cwd)
         except Exception:


### PR DESCRIPTION
Fixes :  #506 
This pull request updates the logic for starting the FastAPI development server in the `_start_fastapi_service` function to support both Windows and non-Windows platforms. The most important change is the introduction of platform-specific commands to ensure compatibility.

**Platform compatibility improvements:**

* Updated `_start_fastapi_service` in `backend/app/utils/microservice.py` to use a different command for Windows—running `uvicorn` directly instead of `fastapi dev`—to properly start the FastAPI app across operating systems.
* Added a log statement to provide visibility into the exact command being executed when starting the service.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of background service startup across platforms, ensuring the app restores its working directory after startup or on failure to prevent side effects.

* **Chores**
  * Enhanced startup logging with the executed command, process ID, and service URL; more consistent non-blocking startup behavior and clearer logs for troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->