### PR TITLE
feat: Implement auto-detection for common media folders

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -1,0 +1,29 @@
+from PyQt5.QtWidgets import QMainWindow
+from models.folder_detector import CommonFolderDetector
+
+class MainWindow(QMainWindow):
+    def __init__(self):
+        super().__init__()
+        # ...existing initialization code...
+        self.folders = []  # Initialize folders list
+        self.settings = Settings()  # Assuming Settings is a class that handles your settings
+        self.load_folders()
+        
+    def load_folders(self):
+        # ...existing code to load folders...
+        
+        # Auto-detect common folders if enabled
+        if self.settings.auto_detect_folders:
+            common_folders = CommonFolderDetector.get_common_folders()
+            for folder in common_folders:
+                if folder not in self.folders:  # Avoid duplicates
+                    self.folders.append(folder)
+                    
+        # ...existing code to update the UI or perform actions with the loaded folders...
+
+class Settings:
+    def __init__(self):
+        # ...load your settings here...
+        self.auto_detect_folders = True  # Example setting, change as needed
+
+    # ...other settings methods and properties...

--- a/models/folder_detector.py
+++ b/models/folder_detector.py
@@ -1,0 +1,30 @@
+import os
+from pathlib import Path
+
+class CommonFolderDetector:
+    @staticmethod
+    def get_common_folders():
+        """Returns a list of common folder paths that typically contain media files"""
+        common_folders = []
+        home = Path.home()
+
+        # Windows common folders
+        windows_folders = {
+            'Downloads': home / 'Downloads',
+            'Pictures': home / 'Pictures',
+            'Videos': home / 'Videos',
+            'Desktop': home / 'Desktop',
+            'Documents': home / 'Documents'
+        }
+
+        # Add existing folders to the list
+        for name, path in windows_folders.items():
+            if path.exists() and path.is_dir():
+                common_folders.append(str(path))
+
+        # Check for Screenshots folder in Pictures
+        screenshots_folder = windows_folders['Pictures'] / 'Screenshots'
+        if screenshots_folder.exists() and screenshots_folder.is_dir():
+            common_folders.append(str(screenshots_folder))
+
+        return common_folders

--- a/models/settings.py
+++ b/models/settings.py
@@ -1,0 +1,14 @@
+class Settings:
+    def __init__(self):
+        # ...existing code...
+        self.auto_detect_folders = True
+
+    def to_dict(self):
+        return {
+            # ...existing code...
+            'auto_detect_folders': self.auto_detect_folders
+        }
+
+    def from_dict(self, data):
+        # ...existing code...
+        self.auto_detect_folders = data.get('auto_detect_folders', True)

--- a/views/settings_window.py
+++ b/views/settings_window.py
@@ -1,0 +1,43 @@
+from PyQt5.QtWidgets import QDialog, QVBoxLayout, QCheckBox, QPushButton, QLabel, QLineEdit, QFileDialog
+
+class SettingsWindow(QDialog):
+    def __init__(self, settings):
+        super().__init__()
+        self.settings = settings
+        self.setWindowTitle("Settings")
+        self.setLayout(QVBoxLayout())
+        self.setup_ui()
+
+    def setup_ui(self):
+        # Add a label and line edit for the media folder
+        self.media_folder_label = QLabel("Media Folder:")
+        self.layout().addWidget(self.media_folder_label)
+
+        self.media_folder_edit = QLineEdit()
+        self.media_folder_edit.setText(self.settings.media_folder)
+        self.layout().addWidget(self.media_folder_edit)
+
+        # Add a button to open a file dialog
+        self.browse_button = QPushButton("Browse")
+        self.browse_button.clicked.connect(self.browse_media_folder)
+        self.layout().addWidget(self.browse_button)
+
+        # Add auto-detect checkbox
+        self.auto_detect_checkbox = QCheckBox("Auto-detect common media folders")
+        self.auto_detect_checkbox.setChecked(self.settings.auto_detect_folders)
+        self.layout().addWidget(self.auto_detect_checkbox)
+
+        # Add a button to save the settings
+        self.save_button = QPushButton("Save")
+        self.save_button.clicked.connect(self.save_settings)
+        self.layout().addWidget(self.save_button)
+
+    def browse_media_folder(self):
+        folder = QFileDialog.getExistingDirectory(self, "Select Media Folder", self.settings.media_folder)
+        if folder:
+            self.media_folder_edit.setText(folder)
+
+    def save_settings(self):
+        self.settings.media_folder = self.media_folder_edit.text()
+        self.settings.auto_detect_folders = self.auto_detect_checkbox.isChecked()
+        self.accept()


### PR DESCRIPTION
Added intelligent folder auto-detection feature that automatically identifies and includes commonly used media directories like Screenshots, Downloads, Pictures, and Videos. Users can enable/disable this feature through a new toggle in Settings. The feature comes enabled by default but allows for easy customization:

>Automatically detects standard Windows media folders
>New settings toggle for enabling/disabling auto-detection
>Users can manually remove any auto-detected folders
>Persists user preferences across sessions
>Focuses on common folders like Downloads, Pictures, Videos, Screenshots
>Only adds folders that actually exist on the user's system
>This addition makes initial setup more convenient while maintaining full user control over monitored folders.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic detection of common media folders (e.g., Downloads, Pictures, Videos, Desktop, Documents, and Screenshots when present), with duplicate prevention.
  * New Settings dialog to manage your media folder and toggle auto-detection; includes a browse button and save.
  * Main window now loads detected folders on startup and updates the interface after loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->