### PR TITLE
Image details (i.e. Path) overflow issue fixed #533

### DIFF
--- a/frontend/src/components/Media/MediaViewControls.tsx
+++ b/frontend/src/components/Media/MediaViewControls.tsx
@@ -37,7 +37,7 @@ export const MediaViewControls: React.FC<MediaViewControlsProps> = ({
     <div className="absolute top-4 right-4 z-50 flex items-center gap-3">
       <button
         onClick={onToggleInfo}
-        className={`rounded-full ${
+        className={`rounded-full cursor-pointer${
           showInfo ? 'bg-blue-500/70' : 'bg-white/10'
         } p-2.5 text-white/90 transition-all duration-200 hover:bg-white/20 hover:text-white hover:shadow-lg`}
         aria-label="Show Info"
@@ -46,28 +46,28 @@ export const MediaViewControls: React.FC<MediaViewControlsProps> = ({
       </button>
 
       <button
-        className="rounded-full bg-white/10 p-2.5 text-white/90 transition-all duration-200 hover:bg-white/20 hover:text-white hover:shadow-lg"
+        className="cursor-pointer rounded-full bg-white/10 p-2.5 text-white/90 transition-all duration-200 hover:bg-white/20 hover:text-white hover:shadow-lg"
         aria-label="Set as Wallpaper"
       >
         <ImageIcon className="h-5 w-5" />
       </button>
 
       <button
-        className="rounded-full bg-white/10 p-2.5 text-white/90 transition-all duration-200 hover:bg-white/20 hover:text-white hover:shadow-lg"
+        className="cursor-pointer rounded-full bg-white/10 p-2.5 text-white/90 transition-all duration-200 hover:bg-white/20 hover:text-white hover:shadow-lg"
         aria-label="Open Folder"
       >
         <Folder className="h-5 w-5" />
       </button>
 
       <button
-        className="rounded-full bg-white/10 p-2.5 text-white/90 transition-all duration-200 hover:bg-white/20 hover:text-white hover:shadow-lg"
+        className="cursor-pointer rounded-full bg-white/10 p-2.5 text-white/90 transition-all duration-200 hover:bg-white/20 hover:text-white hover:shadow-lg"
         aria-label="Open With"
       >
         <ExternalLink className="h-5 w-5" />
       </button>
 
       <button
-        className="rounded-full bg-white/10 p-2.5 text-white/90 transition-all duration-200 hover:bg-white/20 hover:text-white hover:shadow-lg"
+        className="cursor-pointer rounded-full bg-white/10 p-2.5 text-white/90 transition-all duration-200 hover:bg-white/20 hover:text-white hover:shadow-lg"
         aria-label="Share"
       >
         <Share2 className="h-5 w-5" />
@@ -75,7 +75,7 @@ export const MediaViewControls: React.FC<MediaViewControlsProps> = ({
 
       <button
         onClick={onToggleFavorite}
-        className={`rounded-full p-2.5 text-white transition-all duration-300 ${
+        className={`cursor-pointer rounded-full p-2.5 text-white transition-all duration-300 ${
           isFavorite
             ? 'bg-rose-500/80 hover:bg-rose-600 hover:shadow-lg'
             : 'bg-white/10 hover:bg-white/20 hover:text-white hover:shadow-lg'
@@ -86,7 +86,7 @@ export const MediaViewControls: React.FC<MediaViewControlsProps> = ({
       </button>
 
       <button
-        className="rounded-full bg-white/10 p-2.5 text-white/90 transition-all duration-200 hover:bg-white/20 hover:text-white hover:shadow-lg"
+        className="cursor-pointer rounded-full bg-white/10 p-2.5 text-white/90 transition-all duration-200 hover:bg-white/20 hover:text-white hover:shadow-lg"
         aria-label="Move to Secure Folder"
       >
         <Lock className="h-5 w-5" />
@@ -95,7 +95,7 @@ export const MediaViewControls: React.FC<MediaViewControlsProps> = ({
       {type === 'image' && (
         <button
           onClick={onToggleSlideshow}
-          className="flex items-center gap-2 rounded-full bg-indigo-500/70 px-4 py-2 text-white transition-all duration-200 hover:bg-indigo-600/80 hover:shadow-lg"
+          className="flex cursor-pointer items-center gap-2 rounded-full bg-indigo-500/70 px-4 py-2 text-white transition-all duration-200 hover:bg-indigo-600/80 hover:shadow-lg"
           aria-label="Toggle Slideshow"
         >
           {isSlideshowActive ? (
@@ -111,7 +111,7 @@ export const MediaViewControls: React.FC<MediaViewControlsProps> = ({
 
       <button
         onClick={onClose}
-        className="ml-2 rounded-full bg-white/10 p-2.5 text-white/90 transition-all duration-200 hover:bg-white/20 hover:text-white hover:shadow-lg"
+        className="ml-2 cursor-pointer rounded-full bg-white/10 p-2.5 text-white/90 transition-all duration-200 hover:bg-white/20 hover:text-white hover:shadow-lg"
         aria-label="Close"
       >
         <X className="h-5 w-5" />

--- a/frontend/src/components/Media/MediaViewControls.tsx
+++ b/frontend/src/components/Media/MediaViewControls.tsx
@@ -37,7 +37,7 @@ export const MediaViewControls: React.FC<MediaViewControlsProps> = ({
     <div className="absolute top-4 right-4 z-50 flex items-center gap-3">
       <button
         onClick={onToggleInfo}
-        className={`rounded-full cursor-pointer${
+        className={`rounded-full cursor-pointer ${
           showInfo ? 'bg-blue-500/70' : 'bg-white/10'
         } p-2.5 text-white/90 transition-all duration-200 hover:bg-white/20 hover:text-white hover:shadow-lg`}
         aria-label="Show Info"

--- a/frontend/src/components/Navigation/Navbar/Navbar.tsx
+++ b/frontend/src/components/Navigation/Navbar/Navbar.tsx
@@ -41,7 +41,7 @@ export function Navbar() {
               {isSearchActive && (
                 <button
                   onClick={() => dispatch(clearSearch())}
-                  className="absolute -top-1 -right-1 flex h-3 w-3 items-center justify-center rounded-full bg-red-600 text-[10px] leading-none text-white"
+                  className="absolute -top-1 -right-1 flex h-3 w-3 cursor-pointer items-center justify-center rounded-full bg-red-600 text-[10px] leading-none text-white"
                 >
                   ✕
                 </button>
@@ -59,7 +59,7 @@ export function Navbar() {
           {/* FaceSearch Dialog */}
           <FaceSearchDialog />
 
-          <button className="text-muted-foreground mx-1 hover:text-white">
+          <button className="text-muted-foreground mx-1 cursor-pointer hover:text-white">
             <Search className="h-4 w-4" />
           </button>
         </div>

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all cursor-pointer disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {


### PR DESCRIPTION
Solves Issue #533 

There was an issue in `MediaInfoPanel.tsx` under Image Details where the path text was overflowing and didn’t look good. I’ve fixed it.
```css
Path -> frontend\src\components\Media\MediaInfoPanel.tsx
```

Approach ->

1. Gave the container a width.
2. Used **break-words** and **whitespace-normal** (you can use either, but I used both as a good practice).

`break-words`  -> Breaks long words onto the next line if they exceed the container width.
`whitespace-normal` -> breaks at spaces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Added pointer cursor to media viewer action buttons (Info toggle, Slideshow Play/Pause, Set as Wallpaper, Open Folder, Open With, Share, Move to Secure Folder, Close) for clearer click affordance.
  * Applied pointer cursor to Navbar search icon and clear (✕) button.
  * Updated base button styling to use pointer cursor by default across the app.
  * Improves visual feedback and consistency; no functional behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->