### PR TITLE
fix: prevent text overflow in Image Details panel (#533)

### DIFF
--- a/frontend/src/components/Media/MediaInfoPanel.tsx
+++ b/frontend/src/components/Media/MediaInfoPanel.tsx
@@ -57,7 +57,7 @@ export const MediaInfoPanel: React.FC<MediaInfoPanelProps> = ({
           <div className="rounded-lg bg-white/10 p-2">
             <ImageLucide className="h-5 w-5 text-blue-400" />
           </div>
-          <div>
+          <div className='min-w-0 flex-1'>
             <p className="text-xs text-white/50">Name</p>
             <p className="truncate font-medium text-white">{getImageName()}</p>
           </div>
@@ -77,7 +77,7 @@ export const MediaInfoPanel: React.FC<MediaInfoPanelProps> = ({
           <div className="rounded-lg bg-white/10 p-2">
             <MapPin className="h-5 w-5 text-red-400" />
           </div>
-          <div>
+          <div className='min-w-0 flex-1'>
             <p className="text-xs text-white/50">Location</p>
             <p className="font-medium text-white">
               {currentImage?.metadata || 'No location data'}

--- a/frontend/src/components/Media/MediaInfoPanel.tsx
+++ b/frontend/src/components/Media/MediaInfoPanel.tsx
@@ -34,7 +34,8 @@ export const MediaInfoPanel: React.FC<MediaInfoPanelProps> = ({
 
   const getImageName = () => {
     if (!currentImage) return 'Image';
-    return currentImage.path?.split('/').pop() || 'Image';
+    // Handle both Unix (/) and Windows (\) path separators
+    return currentImage.path?.split(/[/\\]/).pop() || 'Image';
   };
 
   if (!show) return null;
@@ -57,9 +58,14 @@ export const MediaInfoPanel: React.FC<MediaInfoPanelProps> = ({
           <div className="rounded-lg bg-white/10 p-2">
             <ImageLucide className="h-5 w-5 text-blue-400" />
           </div>
-          <div className='min-w-0 flex-1'>
+          <div className="min-w-0 flex-1">
             <p className="text-xs text-white/50">Name</p>
-            <p className="truncate font-medium text-white">{getImageName()}</p>
+            <p
+              className="truncate font-medium text-white"
+              title={getImageName()}
+            >
+              {getImageName()}
+            </p>
           </div>
         </div>
 
@@ -77,7 +83,7 @@ export const MediaInfoPanel: React.FC<MediaInfoPanelProps> = ({
           <div className="rounded-lg bg-white/10 p-2">
             <MapPin className="h-5 w-5 text-red-400" />
           </div>
-          <div className='min-w-0 flex-1'>
+          <div className="min-w-0 flex-1">
             <p className="text-xs text-white/50">Location</p>
             <p className="font-medium text-white">
               {currentImage?.metadata || 'No location data'}


### PR DESCRIPTION
Fixes a UI bug where long text in the Image Details panel overflowed outside the container.

### Changes
- Applied CSS to prevent file path text from overflowing the panel
- Applied same fix to the Location field to avoid overflow
- Ensures text stays within panel boundaries for better UI

Fixes #533

Screenshot (Before Fix)
![pictopybefore](https://github.com/user-attachments/assets/9a872105-aaa3-48b5-a7b3-127a56839245)


### Screenshot (After Fix)
<img width="1919" height="1018" alt="pictopy1" src="https://github.com/user-attachments/assets/e0d75595-cf72-42d1-bd0e-6af6f0f09ce0" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved Media Info Panel layout for Name and Location to better handle long text: sizing and truncation updated to prevent overflow and keep readability on narrow screens.
* **New Features**
  * Full values available on hover via tooltips while displayed text is truncated for a cleaner, responsive presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->