### PR TITLE
fix: Open Original File Button in Image Details Panel  (#536)fix: Open Original File Button in Image Details Panel  (#536)

### DIFF
--- a/frontend/src/components/Media/MediaInfoPanel.tsx
+++ b/frontend/src/components/Media/MediaInfoPanel.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { open } from '@tauri-apps/plugin-shell';
 import {
   X,
   ImageIcon as ImageLucide,
@@ -128,10 +129,10 @@ export const MediaInfoPanel: React.FC<MediaInfoPanelProps> = ({
 
         <div className="mt-4 border-t border-white/10 pt-3">
           <button
-            className="w-full rounded-lg bg-white/10 py-2 text-white transition-colors hover:bg-white/20"
+            className="w-full cursor-pointer rounded-lg bg-white/10 py-2 text-white transition-colors hover:bg-white/20"
             onClick={() => {
               if (currentImage?.path) {
-                window.open(currentImage.path, '_blank');
+                open(currentImage.path);
               }
             }}
           >


### PR DESCRIPTION
Solves Issue #536 

There was an issue in MediaInfoPanel.tsx under *Image Details* where the *Open Original File* Button did not open the file. This PR fixes the problem by using the correct Tauri API.
css
Path -> frontend\src\components\Media\MediaInfoPanel.tsx


### Approach 

* *Problem:*
   * window.open() only works with URLs, not local files in a native desktop environment. For local files in desktop app, it  
        may not work as expected.”

* *Solution:*
  * Replaced window.open() with Tauri’s shell API.
  * Used open() from @tauri-apps/plugin-shell, which correctly opens local files with their default system applications.
### Testing Done
* Verified that clicking *Open Original File* now opens the image in its default system viewer.
* [Click here to see the update](https://drive.google.com/file/d/1raVRMVCzJJpCCA1R6YLYrLu8OxZfdiuc/view?usp=sharing)