### PR TITLE
Add empty state placeholders for AI tagging and home pages

### DIFF
--- a/frontend/src/pages/AITagging/AITagging.tsx
+++ b/frontend/src/pages/AITagging/AITagging.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/features/imageSelectors';
 import { usePictoQuery } from '@/hooks/useQueryExtension';
 import { fetchAllImages } from '@/api/api-functions';
+import { Bot, Tags, Image as ImageIcon } from 'lucide-react';
 
 export const AITagging = () => {
   const dispatch = useDispatch();
@@ -52,16 +53,49 @@ export const AITagging = () => {
       {/* Image Grid */}
       <div className="mb-6">
         <h2 className="mb-4 text-xl font-semibold">All Images</h2>
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
-          {taggedImages.map((image, index) => (
-            <ImageCard
-              key={image.id}
-              image={image}
-              imageIndex={index}
-              className="w-full"
-            />
-          ))}
-        </div>
+
+        {/* Empty State Placeholder */}
+        {taggedImages.length === 0 && !imagesLoading && (
+          <div className="flex flex-col items-center justify-center py-16 text-center">
+            <div className="mb-6 rounded-full bg-gray-100 p-4 dark:bg-gray-800">
+              <Bot className="h-16 w-16 text-gray-400" />
+            </div>
+            <h2 className="mb-2 text-xl font-semibold text-gray-700 dark:text-gray-300">
+              No AI Tagged Images
+            </h2>
+            <p className="mb-6 max-w-md text-gray-500 dark:text-gray-400">
+              Your images haven't been processed by AI yet. Add some images to
+              your gallery and they will be automatically tagged with AI-powered
+              labels.
+            </p>
+            <div className="flex flex-col gap-2 text-sm text-gray-400 dark:text-gray-500">
+              <div className="flex items-center gap-2">
+                <Tags className="h-4 w-4" />
+                <span>
+                  AI will automatically detect objects, people, and scenes
+                </span>
+              </div>
+              <div className="flex items-center gap-2">
+                <ImageIcon className="h-4 w-4" />
+                <span>Supports PNG, JPG, JPEG, GIF, BMP image formats</span>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Image Grid */}
+        {taggedImages.length > 0 && (
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+            {taggedImages.map((image, index) => (
+              <ImageCard
+                key={image.id}
+                image={image}
+                imageIndex={index}
+                className="w-full"
+              />
+            ))}
+          </div>
+        )}
       </div>
 
       {/* Media Viewer Modal */}

--- a/frontend/src/pages/Home/Home.tsx
+++ b/frontend/src/pages/Home/Home.tsx
@@ -10,6 +10,7 @@ import { usePictoQuery } from '@/hooks/useQueryExtension';
 import { fetchAllImages } from '@/api/api-functions';
 import { RootState } from '@/app/store';
 import { showInfoDialog } from '@/features/infoDialogSlice';
+import { FolderOpen, Image as ImageIcon } from 'lucide-react';
 
 export const Home = () => {
   const dispatch = useDispatch();
@@ -64,17 +65,45 @@ export const Home = () => {
     <div className="p-6">
       <h1 className="mb-6 text-2xl font-bold">{title}</h1>
 
+      {/* Empty State Placeholder */}
+      {displayImages.length === 0 && !isLoading && (
+        <div className="flex flex-col items-center justify-center py-16 text-center">
+          <div className="mb-6 rounded-full bg-gray-100 p-4 dark:bg-gray-800">
+            <FolderOpen className="h-16 w-16 text-gray-400" />
+          </div>
+          <h2 className="mb-2 text-xl font-semibold text-gray-700 dark:text-gray-300">
+            No Images to Display
+          </h2>
+          <p className="mb-6 max-w-md text-gray-500 dark:text-gray-400">
+            Your gallery is empty. Please add a folder containing images to get
+            started.
+          </p>
+          <div className="flex flex-col gap-2 text-sm text-gray-400 dark:text-gray-500">
+            <div className="flex items-center gap-2">
+              <ImageIcon className="h-4 w-4" />
+              <span>Supported formats: PNG, JPG, JPEG, GIF, BMP</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <FolderOpen className="h-4 w-4" />
+              <span>Go to Settings to add folders</span>
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* Image Grid */}
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
-        {displayImages.map((image, index) => (
-          <ImageCard
-            key={image.id}
-            image={image}
-            imageIndex={index}
-            className="w-full"
-          />
-        ))}
-      </div>
+      {displayImages.length > 0 && (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+          {displayImages.map((image, index) => (
+            <ImageCard
+              key={image.id}
+              image={image}
+              imageIndex={index}
+              className="w-full"
+            />
+          ))}
+        </div>
+      )}
 
       {/* Media Viewer Modal */}
       {isImageViewOpen && (


### PR DESCRIPTION
This pull request enhances the user experience in the `Home` and `AITagging` pages by introducing visually appealing and informative empty state placeholders. These placeholders guide users when there are no images to display, providing clear instructions and context-aware suggestions. Additionally, relevant icon imports have been added to support these UI updates.

**UI/UX Improvements:**

* Added a detailed empty state placeholder to the `Home` page when no images are available, including icons, helpful text, and action prompts for users to add folders or images.
* Added a similar empty state placeholder to the `AITagging` page for cases when no images have been AI-tagged yet, informing users about AI tagging features and supported formats.

**Conditional Rendering:**

* Modified both pages to conditionally render the image grids only when images are present, ensuring the empty state UI and image grid do not appear simultaneously. 

<img width="1917" height="1016" alt="Screenshot 2025-10-02 052337" src="https://github.com/user-attachments/assets/6ecb8e83-f540-454f-b59d-4805fc199b2b" />


<img width="1919" height="1012" alt="Screenshot 2025-10-02 052350" src="https://github.com/user-attachments/assets/0faab027-873d-4b35-958f-bb46ff729f82" />
