### PR TITLE
Implement live progress tracking with 1s polling, animated progress b…

### DIFF
--- a/frontend/src/api/api-functions/folders.ts
+++ b/frontend/src/api/api-functions/folders.ts
@@ -1,6 +1,7 @@
 import { foldersEndpoints } from '../apiEndpoints';
-import { apiClient } from '../axiosConfig';
+import { apiClient, syncApiClient } from '../axiosConfig';
 import { APIResponse } from '@/types/API';
+import { FolderTaggingStatusResponse } from '@/types/FolderStatus';
 
 // Request Types
 export interface AddFolderRequest {
@@ -68,4 +69,16 @@ export const deleteFolders = async (
     { data: request },
   );
   return response.data;
+};
+
+export const getFoldersTaggingStatus = async (): Promise<APIResponse> => {
+  const response = await syncApiClient.get<FolderTaggingStatusResponse>(
+    foldersEndpoints.getTaggingStatus,
+  );
+  const res = response.data;
+  return {
+    data: res.data as any,
+    success: res.status === 'success',
+    message: res.message,
+  };
 };

--- a/frontend/src/api/apiEndpoints.ts
+++ b/frontend/src/api/apiEndpoints.ts
@@ -16,6 +16,7 @@ export const foldersEndpoints = {
   disableAITagging: '/folders/disable-ai-tagging',
   deleteFolders: '/folders/delete-folders',
   syncFolder: '/folders/sync-folder',
+  getTaggingStatus: '/folders/status',
 };
 
 export const userPreferencesEndpoints = {

--- a/frontend/src/app/store.ts
+++ b/frontend/src/app/store.ts
@@ -6,6 +6,7 @@ import imageReducer from '@/features/imageSlice';
 import faceClustersReducer from '@/features/faceClustersSlice';
 import infoDialogReducer from '@/features/infoDialogSlice';
 import folderReducer from '@/features/folderSlice';
+import taggingStatusReducer from '@/features/taggingStatusSlice';
 
 export const store = configureStore({
   reducer: {
@@ -16,6 +17,7 @@ export const store = configureStore({
     infoDialog: infoDialogReducer,
     folders: folderReducer,
     search: searchReducer,
+    taggingStatus: taggingStatusReducer,
   },
 });
 // Infer the `RootState` and `AppDispatch` types from the store itself

--- a/frontend/src/components/ui/progress.tsx
+++ b/frontend/src/components/ui/progress.tsx
@@ -3,23 +3,31 @@ import * as ProgressPrimitive from '@radix-ui/react-progress';
 
 import { cn } from '@/lib/utils';
 
+ type ProgressProps = React.ComponentProps<typeof ProgressPrimitive.Root> & {
+  indicatorClassName?: string;
+};
+
 function Progress({
   className,
   value,
+  indicatorClassName,
   ...props
-}: React.ComponentProps<typeof ProgressPrimitive.Root>) {
+}: ProgressProps) {
   return (
     <ProgressPrimitive.Root
       data-slot="progress"
       className={cn(
-        'bg-primary/20 relative h-2 w-full overflow-hidden rounded-full',
+        'bg-white relative h-2 w-full overflow-hidden rounded-full',
         className,
       )}
       {...props}
     >
       <ProgressPrimitive.Indicator
         data-slot="progress-indicator"
-        className="bg-primary h-full w-full flex-1 transition-all"
+        className={cn(
+          'bg-primary h-full w-full flex-1 will-change-transform transition-transform duration-700 ease-in-out',
+          indicatorClassName,
+        )}
         style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
       />
     </ProgressPrimitive.Root>

--- a/frontend/src/features/taggingStatusSlice.ts
+++ b/frontend/src/features/taggingStatusSlice.ts
@@ -1,0 +1,39 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { FolderTaggingInfo } from '@/types/FolderStatus';
+
+interface TaggingStatusState {
+  byFolderId: Record<string, FolderTaggingInfo>;
+  lastUpdatedAt?: number;
+}
+
+const initialState: TaggingStatusState = {
+  byFolderId: {},
+};
+
+const taggingStatusSlice = createSlice({
+  name: 'taggingStatus',
+  initialState,
+  reducers: {
+    setTaggingStatus(
+      state,
+      action: PayloadAction<FolderTaggingInfo[]>,
+    ) {
+      const map: Record<string, FolderTaggingInfo> = {};
+      for (const info of action.payload) {
+        map[info.folder_id] = info;
+      }
+      state.byFolderId = map;
+      state.lastUpdatedAt = Date.now();
+    },
+    clearTaggingStatus(state) {
+      state.byFolderId = {};
+      state.lastUpdatedAt = undefined;
+    },
+  },
+});
+
+export const { setTaggingStatus, clearTaggingStatus } = taggingStatusSlice.actions;
+export default taggingStatusSlice.reducer;
+
+
+

--- a/frontend/src/pages/SettingsPage/components/FolderManagementCard.tsx
+++ b/frontend/src/pages/SettingsPage/components/FolderManagementCard.tsx
@@ -1,8 +1,11 @@
 import React from 'react';
-import { Folder, Trash2 } from 'lucide-react';
+import { Folder, Trash2, Check } from 'lucide-react';
 
 import { Switch } from '@/components/ui/switch';
 import { Button } from '@/components/ui/button';
+import { Progress } from '@/components/ui/progress';
+import { useSelector } from 'react-redux';
+import { RootState } from '@/app/store';
 import FolderPicker from '@/components/FolderPicker/FolderPicker';
 
 import { useFolderOperations } from '@/hooks/useFolderOperations';
@@ -21,6 +24,10 @@ const FolderManagementCard: React.FC = () => {
     disableAITaggingPending,
     deleteFolderPending,
   } = useFolderOperations();
+
+  const taggingStatus = useSelector(
+    (state: RootState) => state.taggingStatus.byFolderId,
+  );
 
   return (
     <SettingsCard
@@ -43,6 +50,38 @@ const FolderManagementCard: React.FC = () => {
                       {folder.folder_path}
                     </span>
                   </div>
+                  {folder.AI_Tagging && (
+                    <div className="mt-3">
+                      <div className="text-muted-foreground mb-1 flex items-center justify-between text-xs">
+                        <span>AI Tagging Progress</span>
+                        <span
+                          className={
+                            (taggingStatus[folder.folder_id]?.tagging_percentage ?? 0) >= 100
+                              ? 'text-green-500 flex items-center gap-1'
+                              : 'text-muted-foreground'
+                          }
+                        >
+                          {(taggingStatus[folder.folder_id]?.tagging_percentage ?? 0) >= 100 && (
+                            <Check className="h-3 w-3" />
+                          )}
+                          {Math.round(
+                            taggingStatus[folder.folder_id]?.tagging_percentage ?? 0,
+                          )}
+                          %
+                        </span>
+                      </div>
+                      <Progress
+                        value={
+                          taggingStatus[folder.folder_id]?.tagging_percentage ?? 0
+                        }
+                        indicatorClassName={
+                          (taggingStatus[folder.folder_id]?.tagging_percentage ?? 0) >= 100
+                            ? 'bg-green-500'
+                            : 'bg-blue-500'
+                        }
+                      />
+                    </div>
+                  )}
                 </div>
 
                 <div className="ml-4 flex items-center gap-4">

--- a/frontend/src/types/FolderStatus.ts
+++ b/frontend/src/types/FolderStatus.ts
@@ -1,0 +1,15 @@
+export interface FolderTaggingInfo {
+  folder_id: string;
+  folder_path: string;
+  tagging_percentage: number; // 0 - 100
+}
+
+export interface FolderTaggingStatusResponse {
+  status: 'success' | 'error';
+  data: FolderTaggingInfo[];
+  total_folders: number;
+  message?: string;
+}
+
+
+


### PR DESCRIPTION
- Fixes : #545 

This pull request introduces a new feature to display real-time AI tagging progress for folders in the Settings page. It does so by polling the backend for tagging status, storing the results in Redux, and showing a progress bar for each folder with AI tagging enabled. The changes include new API integration, Redux state management, and UI enhancements.

**API integration and state management:**

* Added a new API endpoint and function `getFoldersTaggingStatus` in `folders.ts` to fetch the AI tagging progress for all folders from the sync microservice, and updated `apiEndpoints.ts` to include the new endpoint. 
* Created a new Redux slice `taggingStatusSlice` to store and manage tagging progress per folder, and integrated it into the main Redux store.
* Updated the `useFolderOperations` hook to poll the tagging status API every second (only when AI tagging is enabled) and update the Redux store with the latest progress. 

**UI enhancements:**

* Enhanced the `FolderManagementCard` component to display a progress bar and percentage for each folder with AI tagging enabled, with blue progress bars and green completion state including a checkmark when tagging is complete. 
* Improved the `Progress` UI component to support custom indicator colors and smoother animations, making it suitable for displaying tagging progress.

**Type definitions:**

* Added new type definitions in `FolderStatus.ts` to describe the structure of tagging status API responses and folder tagging information.


https://github.com/user-attachments/assets/4d35b5b3-f7d8-4a3c-943a-fcd3d3270383

