### PR TITLE
feat: allow renaming a face using Enter key in addition to  button

### DIFF
--- a/frontend/src/pages/PersonImages/PersonImages.tsx
+++ b/frontend/src/pages/PersonImages/PersonImages.tsx
@@ -60,6 +60,12 @@ export const PersonImages = () => {
   const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setClusterName(e.target.value);
   };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      handleSaveName();
+    }
+  };
   return (
     <div className="p-6">
       <div className="mb-6 flex items-center justify-between">
@@ -77,6 +83,7 @@ export const PersonImages = () => {
             <Input
               value={clusterName}
               onChange={handleNameChange}
+              onKeyDown={handleKeyDown}
               className="max-w-xs"
               placeholder="Enter person name"
             />


### PR DESCRIPTION
##  Summary
This PR adds support for triggering the **rename action when the Enter key is pressed**, in addition to the existing ✅ button click.  
It improves the overall user experience by making the renaming process faster and more intuitive.

## What Changed
- Added an `onKeyDown` event handler to detect the Enter key and trigger the rename logic when Enter is pressed.
- Ensured behavior is consistent between pressing Enter and clicking the ✅ button.

## Testing
- [x] Verified renaming works with the ✅ button.
- [x] Verified renaming works by pressing Enter.
- [x] Checked for console warnings and lint errors.
- [x] Confirmed all unit tests pass.

## Documentation
No documentation changes were necessary since this is a small UX enhancement.

## Checklist
- [x] Code formatted (`npm run format`)
- [x] Lint passed (`npm run lint:check`)
- [x] Tests passed
- [x] Pre-commit hooks applied
- [x] Follows PictoPy’s Code of Conduct

---

Closes: #580 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Press Enter to save a person’s name while editing, eliminating the need to click a save button.
  * The name field now supports keyboard submission in the editing view, improving speed and accessibility for keyboard-first workflows.
  * Applies across the person images editing UI for a more seamless, consistent editing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->