### PR TITLE
UI: Add Padding to Images Grid in ChronologicalGallery

### DIFF
--- a/frontend/src/components/Media/ChronologicalGallery.tsx
+++ b/frontend/src/components/Media/ChronologicalGallery.tsx
@@ -148,7 +148,7 @@ export const ChronologicalGallery = ({
                 </div>
 
                 {/* Images Grid */}
-                <div className="grid grid-cols-[repeat(auto-fill,_minmax(224px,_1fr))] gap-4">
+                <div className="grid grid-cols-[repeat(auto-fill,_minmax(224px,_1fr))] gap-4 p-2">
                   {imgs.map((img) => {
                     const reduxIndex = imageIndexMap.get(img.id) ?? -1;
 


### PR DESCRIPTION
This PR includes a small UI enhancement that complements the visual update implemented in #552 

Previously, the gallery’s image grid lacked adequate padding, causing images on the top, leftmost, and bottom edges to get partially cut off when hovered (due to the scale effect).
A padding layer has now been added to ensure proper spacing and consistent hover behavior.

https://github.com/user-attachments/assets/b82c2273-ca73-4ec0-8d3d-5c4e535c5568

All images in Image Grid now scale equally👇

https://github.com/user-attachments/assets/0383d48b-0ef5-40d7-825d-0cce3b59e305



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced spacing in the media gallery layout for improved visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->