### PR TITLE
fix: removed share button from all components (#616)

### DIFF
--- a/frontend/src/components/Media/ImageCard.tsx
+++ b/frontend/src/components/Media/ImageCard.tsx
@@ -83,17 +83,6 @@ export function ImageCard({
               />
               <span className="sr-only">Favorite</span>
             </Button>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="cursor-pointer rounded-full bg-white/20 text-white hover:!bg-white/40 hover:!text-white"
-              onClick={(e) => e.stopPropagation()}
-              title="Share"
-              aria-label="Share"
-            >
-              <Share2 className="h-5 w-5" />
-              <span className="sr-only">Share</span>
-            </Button>
           </div>
         </AspectRatio>
 

--- a/frontend/src/components/Media/MediaViewControls.tsx
+++ b/frontend/src/components/Media/MediaViewControls.tsx
@@ -46,13 +46,6 @@ export const MediaViewControls: React.FC<MediaViewControlsProps> = ({
         <Folder className="h-5 w-5" />
       </button>
 
-      <button
-        className="cursor-pointer rounded-full bg-black/50 p-2.5 text-white/90 transition-all duration-200 hover:bg-black/20 hover:text-white hover:shadow-lg"
-        aria-label="Share"
-        title="Share"
-      >
-        <Share2 className="h-5 w-5" />
-      </button>
 
       <button
         onClick={onToggleFavorite}


### PR DESCRIPTION
This pull request removes the “Share” button from all parts of the application where it was displayed.
The Share functionality is not required at this stage, so it has been temporarily disabled to keep the UI clean.

Files Modefied are:
ImageCard.tsx
MediaViewControls.tsx

Changes made:

Removed the Share button from affected components/pages

Deleted related event handlers and imports

Verified that layout and styling remain consistent after removal

Linked Issue:
Closes #616



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Share button from image card hover interactions.
  * Removed Share button from media view controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->