### PR TITLE
Fix: Ensure consistent variant state when hiding info dialog  #623

### DIFF
--- a/frontend/src/features/infoDialogSlice.ts
+++ b/frontend/src/features/infoDialogSlice.ts
@@ -32,7 +32,7 @@ const infoDialogSlice = createSlice({
       state.isOpen = false;
       state.title = '';
       state.message = '';
-      state.variant = 'info';
+      state.variant = state.variant || 'info';
       state.showCloseButton = true;
     },
   },


### PR DESCRIPTION
fixes: BUG: InfoDialog Flickers to blue variant when closing error dialog. #623

Solution: preserve the infoDialog state while closing it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dialog state persistence: the info dialog now retains its previously selected settings when closed and reopened, instead of resetting to default settings each time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->