### PR TITLE
Fix: prevent InfoDialog from flickering to blue variant on close

### DIFF
--- a/frontend/src/features/infoDialogSlice.ts
+++ b/frontend/src/features/infoDialogSlice.ts
@@ -32,7 +32,7 @@ const infoDialogSlice = createSlice({
       state.isOpen = false;
       state.title = '';
       state.message = '';
-      state.variant = 'info';
+      state.variant = state.variant || 'info';
       state.showCloseButton = true;
     },
   },


### PR DESCRIPTION
Closes #623 

Addresses the flickering issue in the InfoDialog component, where the dialog momentarily switches to the blue variant upon closing an error dialog.

This update begins refactoring the dialog state handling logic to ensure consistent visual feedback and transition behaviour.

Testing Videos before and after changes :

Before : 

https://github.com/user-attachments/assets/9e1ca616-fac2-4272-83db-830dea5a3212

After:

https://github.com/user-attachments/assets/4d57a890-28c7-4bf5-8b70-608189a1dbb6




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dialog variant state persistence. Dialogs now correctly maintain their previously configured variant type when hidden, instead of being reset to the default variant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->