### PR TITLE
Fix: Prevent progress bar overflow in onboarding steps

### DIFF
--- a/frontend/src/components/OnboardingSteps/AvatarSelectionStep.tsx
+++ b/frontend/src/components/OnboardingSteps/AvatarSelectionStep.tsx
@@ -67,12 +67,12 @@ export const AvatarSelectionStep: React.FC<AvatarNameSelectionStepProps> = ({
             <span>
               Step {stepIndex + 1} of {totalSteps}
             </span>
-            <span>{Math.round(((stepIndex + 1) / totalSteps) * 100)}%</span>
+            <span>{Math.min(100, Math.round(((stepIndex + 1) / totalSteps) * 100))}%</span>
           </div>
           <div className="bg-muted mb-2 h-1.5 w-full rounded-full">
             <div
               className="bg-primary h-full rounded-full transition-all duration-300"
-              style={{ width: `${((stepIndex + 1) / totalSteps) * 100}%` }}
+              style={{ width: `${Math.min(100, ((stepIndex + 1) / totalSteps) * 100)}%` }}
             />
           </div>
           <CardTitle className="mt-1 text-xl font-semibold">

--- a/frontend/src/components/OnboardingSteps/FolderSetupStep.tsx
+++ b/frontend/src/components/OnboardingSteps/FolderSetupStep.tsx
@@ -64,7 +64,7 @@ export function FolderSetupStep({
   if (localStorage.getItem('folderChosen') === 'true') {
     return null;
   }
-  const progressPercent = Math.round(((stepIndex + 1) / totalSteps) * 100);
+  const progressPercent = Math.min(100, Math.round(((stepIndex + 1) / totalSteps) * 100));
 
   return (
     <>

--- a/frontend/src/components/OnboardingSteps/OnboardingStep.tsx
+++ b/frontend/src/components/OnboardingSteps/OnboardingStep.tsx
@@ -23,8 +23,11 @@ export const OnboardingStep: React.FC<OnboardingStepProps> = ({
   stepIndex,
   stepName,
 }) => {
+  // Map the current step name to its index within VISIBLE_STEPS
+  const visibleStepIndex = VISIBLE_STEPS.indexOf(stepName);
+
   const sharedProps = {
-    stepIndex,
+    stepIndex: visibleStepIndex >= 0 ? visibleStepIndex : stepIndex,
     totalSteps: VISIBLE_STEPS.length,
   };
 

--- a/frontend/src/components/OnboardingSteps/ThemeSelectionStep.tsx
+++ b/frontend/src/components/OnboardingSteps/ThemeSelectionStep.tsx
@@ -51,7 +51,7 @@ export const ThemeSelectionStep: React.FC<ThemeSelectionStepProps> = ({
     return null;
   }
 
-  const progressPercent = Math.round(((stepIndex + 1) / totalSteps) * 100);
+  const progressPercent = Math.min(100, Math.round(((stepIndex + 1) / totalSteps) * 100));
   return (
     <>
       <Card className="flex max-h-full w-1/2 flex-col border p-4">


### PR DESCRIPTION
Related issue #638  


This pull request improves the onboarding progress calculation and display logic to ensure that progress percentages and progress bars never exceed 100%, and that step indices accurately reflect only visible steps. The changes increase the accuracy and robustness of the onboarding UI.

Progress calculation and display improvements:

* All onboarding steps now use `Math.min(100, ...)` to cap progress percentages and progress bar widths at 100%, preventing UI overflow or incorrect displays. (`AvatarSelectionStep.tsx`, `FolderSetupStep.tsx`, `ThemeSelectionStep.tsx`) [[1]](diffhunk://#diff-4bc0f7c2c91a18bc638001b1156d0c79742944d8ea69690a95581ab72214fd98L70-R75) [[2]](diffhunk://#diff-57e019345147b77083eefdd95e8d41ef465c540a73c5cdfee7df69026994a0ccL67-R67) [[3]](diffhunk://#diff-1923bbac4d7e78d3ba2c127176cf357950d809ddc6608825c961cac732cf8de8L54-R54)

Step index logic update:

* The `OnboardingStep` component now maps the current step name to its index within `VISIBLE_STEPS`, ensuring that progress indicators are based only on visible steps rather than all possible steps. (`OnboardingStep.tsx`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed progress indicator from exceeding 100% during the onboarding flow, ensuring the progress bar displays correctly throughout all setup steps.
* Improved step index tracking in the onboarding sequence to accurately reflect visible steps in the process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->