### PR TITLE
Fix: Restrict CORS to localhost origins for security

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -110,10 +110,15 @@ def generate_openapi_json():
 # Add CORS middleware
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],  # Allows all origins
+    allow_origins=[
+        "http://localhost:1420",   # Tauri dev server
+        "http://localhost:5173",   # Vite dev server
+        "tauri://localhost",       # Tauri production
+        "https://tauri.localhost", # Tauri HTTPS
+    ],
     allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+    allow_headers=["Content-Type", "Accept", "Authorization"],
 )
 
 


### PR DESCRIPTION
Related issue : #640  

This pull request tightens the CORS (Cross-Origin Resource Sharing) policy in the backend by restricting allowed origins, methods, and headers, making the API more secure and better suited for the intended frontend environments.

**CORS configuration updates:**

* Restricted `allow_origins` in the CORS middleware to only specific development and production URLs used by Tauri and Vite, instead of allowing all origins.
* Limited `allow_methods` to only common HTTP methods (`GET`, `POST`, `PUT`, `DELETE`, `OPTIONS`) instead of allowing all methods.
* Limited `allow_headers` to only essential headers (`Content-Type`, `Accept`, `Authorization`) instead of allowing all headers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  - Restricted backend API access to specific client origins, allowed request methods, and permitted headers for improved configuration controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->