### PR TITLE
fix(navigation): prevent full reload when clicking profile avatar (#636)

### DIFF
--- a/frontend/src/components/Navigation/Navbar/Navbar.tsx
+++ b/frontend/src/components/Navigation/Navbar/Navbar.tsx
@@ -15,8 +15,8 @@ export function Navbar() {
   const searchState = useSelector((state: any) => state.search);
   const isSearchActive = searchState.active;
   const queryImage = searchState.queryImage;
-   
-    const navigate = useNavigate();
+
+  const navigate = useNavigate();
   const dispatch = useDispatch();
   return (
     <div className="sticky top-0 z-40 flex h-14 w-full items-center justify-between border-b pr-4 backdrop-blur">
@@ -84,13 +84,18 @@ export function Navbar() {
           <span className="hidden text-sm sm:inline-block">
             Welcome <span className="text-muted-foreground">{userName}</span>
           </span>
-           <div className="p-2 cursor-pointer" onClick={() => navigate("/settings")}>
+          <button
+            className="p-2 cursor-pointer border-0 bg-transparent"
+            onClick={() => navigate("/settings")}
+            aria-label="Go to settings"
+          >
             <img
               src={userAvatar || '/photo1.png'}
               className="hover:ring-primary/50 h-8 w-8 rounded-full transition-all hover:ring-2"
               alt="User avatar"
             />
-          </div>
+          </button>
+
         </div>
       </div>
     </div>

--- a/frontend/src/components/Navigation/Navbar/Navbar.tsx
+++ b/frontend/src/components/Navigation/Navbar/Navbar.tsx
@@ -6,6 +6,7 @@ import { selectAvatar, selectName } from '@/features/onboardingSelectors';
 import { clearSearch } from '@/features/searchSlice';
 import { convertFileSrc } from '@tauri-apps/api/core';
 import { FaceSearchDialog } from '@/components/Dialog/FaceSearchDialog';
+import { useNavigate } from "react-router";
 
 export function Navbar() {
   const userName = useSelector(selectName);
@@ -14,7 +15,8 @@ export function Navbar() {
   const searchState = useSelector((state: any) => state.search);
   const isSearchActive = searchState.active;
   const queryImage = searchState.queryImage;
-
+   
+    const navigate = useNavigate();
   const dispatch = useDispatch();
   return (
     <div className="sticky top-0 z-40 flex h-14 w-full items-center justify-between border-b pr-4 backdrop-blur">
@@ -82,13 +84,13 @@ export function Navbar() {
           <span className="hidden text-sm sm:inline-block">
             Welcome <span className="text-muted-foreground">{userName}</span>
           </span>
-          <a href="/settings" className="p-2">
+           <div className="p-2 cursor-pointer" onClick={() => navigate("/settings")}>
             <img
               src={userAvatar || '/photo1.png'}
-              className="hover:ring-primary/50 h-8 w-8 cursor-pointer rounded-full transition-all hover:ring-2"
+              className="hover:ring-primary/50 h-8 w-8 rounded-full transition-all hover:ring-2"
               alt="User avatar"
             />
-          </a>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## What this PR fixes
Fixes the white-screen flash when clicking the profile avatar in the navbar.

The issue was caused by using `<a href="/settings">`, which triggers a full page reload in React/Vite/Tauri. This produces a white flash before the settings page loads.

## What I changed
- Replaced `<a href="/settings">` with client-side navigation using `useNavigate()`.
- This ensures smooth SPA navigation without reloading the page.

## Related Issue
Closes #636

## Checklist
- [x] Smooth navigation to /settings
- [x] No white-screen flash
- [x] Code formatted correctly
- [x] Tests pass locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated user avatar styling to remove the click cursor, clarifying it is non-clickable while retaining hover visual feedback.

* **Improvements**
  * Reworked the settings link to use programmatic navigation for more reliable in-app routing and interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->