### PR TITLE
Fix: Favorite Icon Updates Correctly on PersonImages Page #681

### DIFF
--- a/backend/app/database/face_clusters.py
+++ b/backend/app/database/face_clusters.py
@@ -301,6 +301,7 @@ def db_get_images_by_cluster_id(
                 i.path as image_path,
                 i.thumbnailPath as thumbnail_path,
                 i.metadata,
+                i.isFavourite,
                 f.face_id,
                 f.confidence,
                 f.bbox
@@ -321,6 +322,7 @@ def db_get_images_by_cluster_id(
                 image_path,
                 thumbnail_path,
                 metadata,
+                is_favourite,
                 face_id,
                 confidence,
                 bbox_json,
@@ -340,6 +342,7 @@ def db_get_images_by_cluster_id(
                     "image_path": image_path,
                     "thumbnail_path": thumbnail_path,
                     "metadata": metadata_dict,
+                    "isFavourite": is_favourite,
                     "face_id": face_id,
                     "confidence": confidence,
                     "bbox": bbox,

--- a/backend/app/routes/face_clusters.py
+++ b/backend/app/routes/face_clusters.py
@@ -172,11 +172,11 @@ def get_cluster_images(cluster_id: str):
         formatted_images = []
         for img in images:
             formatted_images.append({
-                "id": img["image_id"],  # Changed from image_id to id
-                "path": img["image_path"],  # Changed from image_path to path
-                "thumbnailPath": img["thumbnail_path"],  # Changed from thumbnail_path to thumbnailPath
+                "id": img["image_id"],
+                "path": img["image_path"],
+                "thumbnailPath": img["thumbnail_path"],
                 "metadata": img["metadata"],
-                "isFavourite": bool(img["isFavourite"]),  # Ensure boolean
+                "isFavourite": bool(img["isFavourite"]),
                 "face_id": img["face_id"],
                 "confidence": img["confidence"],
                 "bbox": img["bbox"],
@@ -187,7 +187,7 @@ def get_cluster_images(cluster_id: str):
             message=f"Successfully retrieved {len(formatted_images)} images for cluster",
             data=GetClusterImagesData(
                 cluster_id=cluster_id,
-                cluster_name=cluster.get("cluster_name"),
+                cluster_name=cluster["cluster_name"],  # ✅ CHANGE THIS LINE - Remove .get()
                 images=formatted_images,
                 total_images=len(formatted_images),
             ),

--- a/backend/app/routes/face_clusters.py
+++ b/backend/app/routes/face_clusters.py
@@ -153,7 +153,7 @@ def get_all_clusters():
 def get_cluster_images(cluster_id: str):
     """Get all images that contain faces belonging to a specific cluster."""
     try:
-        # Step 1: Validate cluster exists
+        # Check if cluster exists
         cluster = db_get_cluster_by_id(cluster_id)
         if not cluster:
             raise HTTPException(
@@ -161,48 +161,48 @@ def get_cluster_images(cluster_id: str):
                 detail=ErrorResponse(
                     success=False,
                     error="Cluster Not Found",
-                    message=f"Cluster with ID '{cluster_id}' does not exist.",
+                    message=f"Cluster with ID '{cluster_id}' does not exist",
                 ).model_dump(),
             )
 
-        # Step 2: Get images for this cluster
-        images_data = db_get_images_by_cluster_id(cluster_id)
+        # Get images for this cluster
+        images = db_get_images_by_cluster_id(cluster_id)
 
-        # Step 3: Convert to response models
-        images = [
-            ImageInCluster(
-                id=img["image_id"],
-                path=img["image_path"],
-                thumbnailPath=img["thumbnail_path"],
-                metadata=img["metadata"],
-                face_id=img["face_id"],
-                confidence=img["confidence"],
-                bbox=img["bbox"],
-            )
-            for img in images_data
-        ]
+        # Transform the data to match the frontend schema
+        formatted_images = []
+        for img in images:
+            formatted_images.append({
+                "id": img["image_id"],  # Changed from image_id to id
+                "path": img["image_path"],  # Changed from image_path to path
+                "thumbnailPath": img["thumbnail_path"],  # Changed from thumbnail_path to thumbnailPath
+                "metadata": img["metadata"],
+                "isFavourite": bool(img["isFavourite"]),  # Ensure boolean
+                "face_id": img["face_id"],
+                "confidence": img["confidence"],
+                "bbox": img["bbox"],
+            })
 
         return GetClusterImagesResponse(
             success=True,
-            message=f"Successfully retrieved {len(images)} image(s) for cluster '{cluster_id}'",
+            message=f"Successfully retrieved {len(formatted_images)} images for cluster",
             data=GetClusterImagesData(
                 cluster_id=cluster_id,
-                cluster_name=cluster["cluster_name"],
-                images=images,
-                total_images=len(images),
+                cluster_name=cluster.get("cluster_name"),
+                images=formatted_images,
+                total_images=len(formatted_images),
             ),
         )
 
     except HTTPException as e:
-        # Re-raise HTTPExceptions to preserve the status code and detail
         raise e
     except Exception as e:
+        logger.error(f"Error getting cluster images: {str(e)}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=ErrorResponse(
                 success=False,
-                error="Internal server error",
-                message=f"Unable to retrieve images for cluster: {str(e)}",
+                error="Internal Server Error",
+                message=f"Failed to retrieve cluster images: {str(e)}",
             ).model_dump(),
         )
 

--- a/backend/app/schemas/face_clusters.py
+++ b/backend/app/schemas/face_clusters.py
@@ -51,6 +51,7 @@ class ImageInCluster(BaseModel):
     path: str
     thumbnailPath: Optional[str] = None
     metadata: Optional[Dict[str, Any]] = None
+    isFavourite: bool = False  # Add this field
     face_id: int
     confidence: Optional[float] = None
     bbox: Optional[Dict[str, Union[int, float]]] = None

--- a/docs/backend/backend_python/openapi.json
+++ b/docs/backend/backend_python/openapi.json
@@ -2212,6 +2212,11 @@
             ],
             "title": "Metadata"
           },
+          "isFavourite": {
+            "type": "boolean",
+            "title": "Isfavourite",
+            "default": false
+          },
           "face_id": {
             "type": "integer",
             "title": "Face Id"

--- a/frontend/src/hooks/useToggleFav.ts
+++ b/frontend/src/hooks/useToggleFav.ts
@@ -1,16 +1,72 @@
 import { usePictoMutation } from '@/hooks/useQueryExtension';
 import { useMutationFeedback } from '@/hooks/useMutationFeedback';
 import { togglefav } from '@/api/api-functions/togglefav';
+import { useQueryClient } from '@tanstack/react-query';
 
 export const useToggleFav = () => {
+  const queryClient = useQueryClient();
+  
   const toggleFavouriteMutation = usePictoMutation({
     mutationFn: async (image_id: string) => togglefav(image_id),
     autoInvalidateTags: ['images'],
+    onSuccess: () => {
+      // Invalidate person-images queries to refetch cluster images
+      queryClient.invalidateQueries({ queryKey: ['person-images'] });
+    },
+    onMutate: async (image_id: string) => {
+      // Cancel outgoing refetches
+      await queryClient.cancelQueries({ queryKey: ['images'] });
+
+      // Snapshot the previous value
+      const previousImages = queryClient.getQueryData(['images']);
+
+      // Optimistically update images query
+      queryClient.setQueryData(['images'], (old: any) => {
+        if (!old?.data) return old;
+        
+        return {
+          ...old,
+          data: old.data.map((img: any) => 
+            img.id === image_id 
+              ? { ...img, isFavourite: !img.isFavourite }
+              : img
+          )
+        };
+      });
+
+      // Optimistically update person-images queries
+      queryClient.setQueriesData({ queryKey: ['person-images'] }, (old: any) => {
+        if (!old?.data?.images) return old;
+        
+        return {
+          ...old,
+          data: {
+            ...old.data,
+            images: old.data.images.map((img: any) => 
+              img.id === image_id 
+                ? { ...img, isFavourite: !img.isFavourite }
+                : img
+            )
+          }
+        };
+      });
+
+      return { previousImages };
+    },
+    onError: (err, image_id, context) => {
+      if (context?.previousImages) {
+        queryClient.setQueryData(['images'], context.previousImages);
+      }
+      // Refetch to restore correct state
+      queryClient.invalidateQueries({ queryKey: ['person-images'] });
+    },
   });
+
   useMutationFeedback(toggleFavouriteMutation, {
     showLoading: false,
     showSuccess: false,
   });
+
   return {
     toggleFavourite: (id: any) => toggleFavouriteMutation.mutate(id),
     toggleFavouritePending: toggleFavouriteMutation.isPending,


### PR DESCRIPTION
Fixes #681

This PR fixes the issue where the favorite (heart) icon on the PersonImages page does not update immediately after toggling favorites.

Issue: #681 – Favorite Icon Does Not Update on PersonImages Page

Changes:
- PersonImages UI now immediately reflects the new favorite state.
- Heart icon updates color (red/grey) instantly.
- React Query invalidates and refetches using the correct key.
- Keeps frontend in sync with backend updates without full page reload.

Steps to verify:
1. Open any face collection → go to PersonImages.
2. Click the heart icon → icon changes immediately.
3. Open Favorites tab → image shows correctly as favorited/unfavorited.
4. Return to PersonImages → UI remains consistent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Images in clusters now include a favorite flag visible to the UI.
  * Optimistic updates for toggling favorites to make toggles feel instant.
  * Client now listens for query cache updates to keep cluster images in sync.

* **Bug Fixes / Reliability**
  * Improved error handling and clearer failure responses when retrieving cluster images.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->