### PR TITLE
FIX: #684 Navbar height is oversized on first load and fixes only after refresh

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,7 +10,8 @@ theme:
   icon:
     repo: fontawesome/brands/github
   features:
-    - navigation.tabs
+    # Navigation Tabs creating an extra Nav Tab containing single element of Nav List
+    # - navigation.tabs
     - navigation.sections
     - toc.integrate
     - navigation.top


### PR DESCRIPTION
### Summary

This PR fixes issue #684 in the docs UI where an extra **“Home”** item appeared in the navbar and the header height behaved inconsistently between first load, scroll, and refresh.

The root cause was the `navigation.tabs` feature being enabled in **MkDocs Material** while the docs only define a single top-level page (`Home`). This caused Material to render a top tabs bar with a redundant “Home” tab, leading to apparent duplication and layout instability.

---

### What was happening

<img width="631" height="218" alt="Screenshot 2025-12-07 at 7 35 36 PM" src="https://github.com/user-attachments/assets/24be98fe-8028-4efe-8de5-357521d999fd" />

- On initial page load, MkDocs Material rendered:
  - the header (logo + title), **and**
  - a top tabs bar (`<nav class="md-tabs">`) containing a single “Home” tab
- This resulted in:
  - an extra “Home” entry in the UI
  - a taller-than-expected navbar on first load
- On scroll or refresh, layout recalculation made the issue appear inconsistent

---

### ✅ Fix

- Disabled the `navigation.tabs` feature in `mkdocs.yml`
- This prevents MkDocs Material from generating the top tabs bar entirely

**Result:**
- No duplicate “Home” item
- Consistent navbar height across:
  - initial load
  - scroll
  - refresh
- Cleaner and more predictable docs navigation

---



### Changes

- Removed `navigation.tabs` from the MkDocs Material theme configuration
- No changes to content or structure of documentation pages

---

### Screenshots / Recording
*Before: Duplicate “Home” tab visible at the top*

https://github.com/user-attachments/assets/117e1c39-7bb2-48a4-94fe-f368482309a0

---
*After: Single “Home” entry with stable navbar*

https://github.com/user-attachments/assets/b23fa4e6-65c1-44b3-8021-402d12935c5f


---

### Checklist

- [x] I agree to follow this project's Code of Conduct
- [x] Docs UI renders correctly on first load, scroll, and refresh
- [x] No visual duplication in navigation
- [x] No breaking changes introduced
- [ ] Unit tests — Not applicable (docs configuration change only)

---

### Additional Notes

If top-level tabs are needed in the future (e.g., multiple sections such as *Docs*, *API*, *Guides*), `navigation.tabs` can be safely re-enabled once multiple root navigation entries exist.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled navigation tabs feature in the documentation interface. The navigation tabs will no longer be displayed in the documentation system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->