### PR TITLE
 add automatic port detection for Tauri dev server

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "test:watch": "jest --watch",
     "preview": "vite preview",
     "tauri": "tauri",
+    "tauri:dev": "node scripts/tauri-dev-auto-port.js",
     "setup:linux": "cd scripts &&  ./setup_env.sh",
     "lint:check": "eslint --max-warnings 0 --config .eslintrc.json .",
     "lint:fix": "eslint --max-warnings 0 --config .eslintrc.json . --fix",

--- a/frontend/scripts/tauri-dev-auto-port.js
+++ b/frontend/scripts/tauri-dev-auto-port.js
@@ -1,6 +1,5 @@
 const net = require('net');
-const fs = require('fs');
-const path = require('path');
+const { spawn } = require('child_process');
 
 // Range of ports to check (Vite's default + alternatives)
 const PORT_RANGE_START = 5173;
@@ -14,21 +13,22 @@ const PORT_RANGE_END = 5182;
 function isPortAvailable(port) {
   return new Promise((resolve) => {
     const server = net.createServer();
-    
+
     server.once('error', (err) => {
       if (err.code === 'EADDRINUSE') {
         resolve(false);
       } else {
+        console.warn(`Unexpected error checking port ${port}:`, err.message);
         resolve(false);
       }
     });
-    
+
     server.once('listening', () => {
       server.close();
       resolve(true);
     });
-    
-    server.listen(port);
+
+    server.listen(port, 'localhost');
   });
 }
 
@@ -46,60 +46,58 @@ async function findAvailablePort() {
 }
 
 /**
- * Update tauri.conf.json with the selected port
- * @param {number} port - Port to use
- */
-function updateTauriConfig(port) {
-  const configPath = path.join(__dirname, '..', 'src-tauri', 'tauri.conf.json');
-  
-  try {
-    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
-    
-    // Update devUrl and beforeDevCommand
-    config.build.devUrl = `http://localhost:${port}`;
-    config.build.beforeDevCommand = `npm run dev -- --port ${port}`;
-    
-    fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
-    console.log(`✓ Updated Tauri config to use port ${port}`);
-  } catch (error) {
-    console.error('Error updating Tauri config:', error);
-    process.exit(1);
-  }
-}
-
-/**
  * Main function
  */
 async function main() {
-  console.log('\nDetecting available port for Tauri development...');
-  
+  console.log('\n🔍 Detecting available port for Tauri development...');
+
   const port = await findAvailablePort();
-  
+
   if (!port) {
-    console.error(`\n✗ No available ports found in range ${PORT_RANGE_START}-${PORT_RANGE_END}`);
-    console.error('Please free up a port or manually configure the port in tauri.conf.json');
+    console.error(
+      `\n❌ No available ports found in range ${PORT_RANGE_START}-${PORT_RANGE_END}`,
+    );
+    console.error(
+      'Please free up a port or manually configure the port in tauri.conf.json',
+    );
     process.exit(1);
   }
-  
-  console.log(`Found available port: ${port}`);
-  updateTauriConfig(port);
-  
-  // Set environment variables
-  process.env.VITE_PORT = port.toString();
-  process.env.TAURI_MODE = 'development';
-  
-  console.log('Starting Tauri dev server...\n');
-  
-  // Start Tauri dev
-  const { spawn } = require('child_process');
-  const tauri = spawn('npm', ['run', 'tauri', 'dev'], {
-    stdio: 'inherit',
-    shell: true,
-    env: { ...process.env, VITE_PORT: port.toString() }
+
+  console.log(`✅ Found available port: ${port}`);
+  console.log('🚀 Starting Tauri dev server...\n');
+
+  // Start Tauri dev with CLI flags (no config file modification)
+  const tauri = spawn(
+    'npm',
+    [
+      'run',
+      'tauri',
+      'dev',
+      '--',
+      '--dev-url',
+      `http://localhost:${port}`,
+      '--port',
+      port.toString(),
+    ],
+    {
+      stdio: 'inherit',
+      shell: true,
+      env: {
+        ...process.env,
+        VITE_PORT: port.toString(),
+        TAURI_CLI_PORT: port.toString(),
+        TAURI_DEV_HOST: 'localhost',
+      },
+    },
+  );
+
+  tauri.on('error', (error) => {
+    console.error('Failed to start Tauri dev server:', error);
+    process.exit(1);
   });
-  
+
   tauri.on('exit', (code) => {
-    process.exit(code);
+    process.exit(code || 0);
   });
 }
 

--- a/frontend/scripts/tauri-dev-auto-port.js
+++ b/frontend/scripts/tauri-dev-auto-port.js
@@ -1,0 +1,109 @@
+const net = require('net');
+const fs = require('fs');
+const path = require('path');
+
+// Range of ports to check (Vite's default + alternatives)
+const PORT_RANGE_START = 5173;
+const PORT_RANGE_END = 5182;
+
+/**
+ * Check if a port is available
+ * @param {number} port - Port to check
+ * @returns {Promise<boolean>} - True if port is available
+ */
+function isPortAvailable(port) {
+  return new Promise((resolve) => {
+    const server = net.createServer();
+    
+    server.once('error', (err) => {
+      if (err.code === 'EADDRINUSE') {
+        resolve(false);
+      } else {
+        resolve(false);
+      }
+    });
+    
+    server.once('listening', () => {
+      server.close();
+      resolve(true);
+    });
+    
+    server.listen(port);
+  });
+}
+
+/**
+ * Find the first available port in range
+ * @returns {Promise<number|null>} - Available port or null
+ */
+async function findAvailablePort() {
+  for (let port = PORT_RANGE_START; port <= PORT_RANGE_END; port++) {
+    if (await isPortAvailable(port)) {
+      return port;
+    }
+  }
+  return null;
+}
+
+/**
+ * Update tauri.conf.json with the selected port
+ * @param {number} port - Port to use
+ */
+function updateTauriConfig(port) {
+  const configPath = path.join(__dirname, '..', 'src-tauri', 'tauri.conf.json');
+  
+  try {
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    
+    // Update devUrl and beforeDevCommand
+    config.build.devUrl = `http://localhost:${port}`;
+    config.build.beforeDevCommand = `npm run dev -- --port ${port}`;
+    
+    fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+    console.log(`✓ Updated Tauri config to use port ${port}`);
+  } catch (error) {
+    console.error('Error updating Tauri config:', error);
+    process.exit(1);
+  }
+}
+
+/**
+ * Main function
+ */
+async function main() {
+  console.log('\nDetecting available port for Tauri development...');
+  
+  const port = await findAvailablePort();
+  
+  if (!port) {
+    console.error(`\n✗ No available ports found in range ${PORT_RANGE_START}-${PORT_RANGE_END}`);
+    console.error('Please free up a port or manually configure the port in tauri.conf.json');
+    process.exit(1);
+  }
+  
+  console.log(`Found available port: ${port}`);
+  updateTauriConfig(port);
+  
+  // Set environment variables
+  process.env.VITE_PORT = port.toString();
+  process.env.TAURI_MODE = 'development';
+  
+  console.log('Starting Tauri dev server...\n');
+  
+  // Start Tauri dev
+  const { spawn } = require('child_process');
+  const tauri = spawn('npm', ['run', 'tauri', 'dev'], {
+    stdio: 'inherit',
+    shell: true,
+    env: { ...process.env, VITE_PORT: port.toString() }
+  });
+  
+  tauri.on('exit', (code) => {
+    process.exit(code);
+  });
+}
+
+main().catch((error) => {
+  console.error('Error:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
**Added tauri-dev-auto-port.js for dynamic port selection**
- Scan ports 5173-5182 to find available port
- Update package.json to use auto-port script
- Prevent conflicts when running multiple dev instances

**Features:**
- Automatic port conflict resolution
- Supports multiple simultaneous dev environments
- Graceful fallback if all ports occupied
- Environment variables set correctly (VITE_PORT, TAURI_MODE)

Resolves issue where multiple dev environments couldn't run simultaneously due to hardcoded port configuration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a development helper that automatically finds an available port and starts the Tauri dev server, simplifying local startup and eliminating manual port configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->