### PR TITLE
Fix: Return metadata as dict instead of string in db_get_images_by_cluster_id

### DIFF
--- a/backend/app/database/face_clusters.py
+++ b/backend/app/database/face_clusters.py
@@ -1,6 +1,7 @@
 import sqlite3
 from typing import Optional, List, Dict, TypedDict, Union
 from app.config.settings import DATABASE_PATH
+from app.utils.images import image_util_parse_metadata
 
 # Type definitions
 ClusterId = str
@@ -306,12 +307,15 @@ def db_get_images_by_cluster_id(
 
                 bbox = json.loads(bbox_json)
 
+            # Normalize metadata to a dict; downstream schemas expect an object
+            metadata_dict = image_util_parse_metadata(metadata)
+
             images.append(
                 {
                     "image_id": image_id,
                     "image_path": image_path,
                     "thumbnail_path": thumbnail_path,
-                    "metadata": metadata,
+                    "metadata": metadata_dict,
                     "face_id": face_id,
                     "confidence": confidence,
                     "bbox": bbox,

--- a/docs/backend/backend_python/openapi.json
+++ b/docs/backend/backend_python/openapi.json
@@ -2003,7 +2003,6 @@
           "metadata": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {


### PR DESCRIPTION
### What does this PR do?
Fixes the issue where `db_get_images_by_cluster_id` returned metadata as a
JSON string instead of a Python dict. This caused inconsistencies while
processing images on the backend.

### What was changed?
- Parsed the metadata field using `json.loads` before returning the response.
- Ensures all returned metadata is a proper dict.

### Why is this needed?
Downstream functions expect metadata as a dictionary. Returning it as a string
was causing unexpected behavior and required extra parsing.

### How was it tested?
- Ran the backend locally.
- Retrieved images by cluster ID and verified metadata is now a dict.

### Related Issue
Fixes #705 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed image metadata handling in cluster operations—metadata is now properly normalized and formatted for consistency.
  * Improved logging system stability and prevented potential logging loop issues.

* **Documentation**
  * Updated API schema to enforce stricter validation rules for image metadata fields, ensuring data conformity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->