### PR TITLE
Fix: Improve marquee animation for smooth, continuous right-to-left scrolling

### DIFF
--- a/landing-page/src/Pages/Demo/marqu.tsx
+++ b/landing-page/src/Pages/Demo/marqu.tsx
@@ -1,8 +1,14 @@
-
+import { useLayoutEffect, useRef, useState } from "react";
 import { motion } from "framer-motion";
 import { ImageIcon, FolderSync, Search, Code } from "lucide-react";
 
+const MARQUEE_DURATION = 20;
+const WIDTH_MULTIPLIER = 2; 
+
 export default function TechMarquee() {
+  const [repeatCount, setRepeatCount] = useState(2);
+  const trackRef = useRef<HTMLDivElement>(null);
+
   const technologies = [
     { 
       text: "PictoAI", 
@@ -22,6 +28,20 @@ export default function TechMarquee() {
     }
   ];
 
+  useLayoutEffect(() => {
+    if (trackRef.current && trackRef.current.parentElement) {
+      const parentWidth = trackRef.current.parentElement.offsetWidth;
+      const itemWidth = 160;
+      const itemsNeeded = Math.ceil((parentWidth * WIDTH_MULTIPLIER) / itemWidth);
+      const setsNeeded = Math.ceil(itemsNeeded / technologies.length);
+      setRepeatCount(Math.max(setsNeeded, 2)); 
+    }
+  }, [technologies.length]);
+
+  // Create two identical halves
+  const halfChunk = Array(repeatCount).fill(technologies).flat();
+  const marqueeItems = [...halfChunk, ...halfChunk];
+
   return (
     <div className="relative w-full overflow-hidden 
       bg-white 
@@ -30,42 +50,35 @@ export default function TechMarquee() {
       dark:shadow-[0_0_50px_rgba(255,255,255,0.1)]
       transition-shadow duration-500">
       <motion.div
-        className="flex space-x-6 items-center"
-        initial={{ x: '0%' }}
-        animate={{ x: '-100%' }}
+        ref={trackRef}
+        className="flex items-center"
+        style={{ width: "max-content" }}
+        animate={{ x: ["0%", "-50%"] }}
         transition={{
-          duration: 10,
+          duration: MARQUEE_DURATION,
           ease: "linear",
           repeat: Infinity,
-          repeatType: "loop"
+          repeatType: "loop",
         }}
       >
-        {[...technologies, ...technologies, ...technologies].map((tech, index) => (
+        {marqueeItems.map((tech, index) => (
           <div
-            key={index}
+            key={`${tech.text}-${index}`}
             className="flex-shrink-0 flex items-center text-gray-600 dark:text-gray-300 text-xs font-medium"
           >
-            <motion.span 
-              className="flex items-center 
-                bg-gray-100 dark:bg-white/5
-                hover:bg-gray-200 dark:hover:bg-white/10
-                px-3 py-1 
-                rounded-full 
-                transition-all duration-300
-                border border-gray-200 dark:border-white/10
-                shadow-sm"
-              whileHover={{ 
-                scale: 1.05,
-                transition: { duration: 0.2 }
-              }}
+            <motion.span
+              className="flex items-center bg-gray-100
+                dark:bg-white/5 hover:bg-gray-200
+                dark:hover:bg-white/10 px-3 py-1 rounded-full
+                transition-all duration-300 border border-gray-200
+                dark:border-white/10 shadow-sm"
+              whileHover={{ scale: 1.05, transition: { duration: 0.2 } }}
               whileTap={{ scale: 0.95 }}
             >
               {tech.text}
-              <span className="ml-2 opacity-70">
-                {tech.icon}
-              </span>
+              <span className="ml-2 opacity-70">{tech.icon}</span>
             </motion.span>
-            <span className="mx-3 text-gray-300 dark:text-gray-600">•</span>
+            <span className="mx-5 text-gray-300 dark:text-gray-600">•</span>
           </div>
         ))}
       </motion.div>


### PR DESCRIPTION
Related issue: Fixes #703

### What was changed?
Implemented a smooth, continuous right-to-left marquee animation on the landing page.  
The previous animation scrolled in visible chunks and jumped back to the start, which caused a noticeable reset.

### Key Improvements
- Created a seamless looping effect by duplicating content and animating only half the track width.
- Switched to a continuous `x: ["0%", "-50%"]` translation to remove abrupt resets.
- Dynamically calculated the number of required items for fluid scrolling across screen sizes.
- Increased animation duration for a calmer, more natural movement.
- Cleaned up structure with a more flexible marquee track (`max-content` width + ref-based measurements).

### Why this change?
This update makes the landing page marquee feel more polished, modern, and visually smooth.  
It avoids visible jumps, maintains consistent spacing, and adapts to varying screen widths.

### Demo
Here is a short video showing the updated behavior:

[Demo.webm](https://github.com/user-attachments/assets/ac66af8c-9d17-45fc-8a46-1771308a88e1)


### Notes
- Hover interactions, icons, and styling remain the same.
- No breaking UI changes; only movement logic improved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Marquee scrolling animation is now responsive to your container width, automatically optimizing display across all screen sizes and devices.
  * Technology item spacing has been improved for better visual presentation and balance, and animation smoothness has been refined for a more polished user experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->