### PR TITLE
Fix #708 – Clear exc_info and stack_info before formatting in InterceptHandler

### DIFF
--- a/backend/app/logging/setup_logging.py
+++ b/backend/app/logging/setup_logging.py
@@ -62,7 +62,11 @@ class ColorFormatter(logging.Formatter):
 
     def format(self, record: logging.LogRecord) -> str:
         """Format the log record with colors and component prefix."""
-        # Clear exc_info and stack_info before formatting
+        # Save original exc_info and stack_info to restore later (safer for other handlers)
+        original_exc_info = record.exc_info
+        original_stack_info = record.stack_info
+        
+        # Clear exc_info and stack_info before formatting to prevent traceback output
         record.exc_info = None
         record.stack_info = None
         
@@ -72,6 +76,10 @@ class ColorFormatter(logging.Formatter):
 
         # Format the message
         formatted_message = super().format(record)
+        
+        # Restore original values to avoid affecting other handlers
+        record.exc_info = original_exc_info
+        record.stack_info = original_stack_info
 
         if not self.use_colors:
             return formatted_message

--- a/sync-microservice/app/logging/setup_logging.py
+++ b/sync-microservice/app/logging/setup_logging.py
@@ -62,12 +62,24 @@ class ColorFormatter(logging.Formatter):
 
     def format(self, record: logging.LogRecord) -> str:
         """Format the log record with colors and component prefix."""
+        # Save original exc_info and stack_info to restore later (safer for other handlers)
+        original_exc_info = record.exc_info
+        original_stack_info = record.stack_info
+        
+        # Clear exc_info and stack_info before formatting to prevent traceback output
+        record.exc_info = None
+        record.stack_info = None
+        
         # Add component information to the record
         component_prefix = self.component_config.get("prefix", "")
         record.component = component_prefix
 
         # Format the message
         formatted_message = super().format(record)
+        
+        # Restore original values to avoid affecting other handlers
+        record.exc_info = original_exc_info
+        record.stack_info = original_stack_info
 
         if not self.use_colors:
             return formatted_message


### PR DESCRIPTION
This PR fixes a logging issue where exc_info and stack_info were preserved before formatting, causing unwanted tracebacks in logs. These fields are now cleared before rerouting logs.

Problem (Before Fix):
`[APP] | ERROR | Division by zero occurred!
Traceback (most recent call last):
  File "test_logging.py", line 8, in <module>
    1 / 0
ZeroDivisionError: division by zero
`

Changes Made:
- Cleared record.exc_info and record.stack_info before formatting in setup_logging.py.
- Verified manually that rerouted logs no longer include tracebacks.

After Fix:
`[APP] | ERROR | Division by zero occurred!
`

Testing:
- Manual tests with ColorFormatter confirmed tracebacks are removed.
- Normal info and error messages still work correctly.

Closes: #708

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted logging formatting to suppress tracebacks in formatted output while preserving original exception and stack details for other logging handlers, resulting in cleaner logs without losing underlying error information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->