### PR TITLE
feat: Bulk AI Tagging & Progress Tracking for Folder Management (#725)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@radix-ui/react-aspect-ratio": "^1.1.7",
         "@radix-ui/react-avatar": "^1.1.10",
+        "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.15",
         "@radix-ui/react-label": "^2.1.7",
@@ -3407,6 +3408,36 @@
         "@radix-ui/react-use-callback-ref": "1.1.1",
         "@radix-ui/react-use-is-hydrated": "0.1.0",
         "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.3.tgz",
+      "integrity": "sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@radix-ui/react-aspect-ratio": "^1.1.7",
     "@radix-ui/react-avatar": "^1.1.10",
+    "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-label": "^2.1.7",

--- a/frontend/src/components/FolderManagement/FolderBulkActions.tsx
+++ b/frontend/src/components/FolderManagement/FolderBulkActions.tsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import { Sparkles, SparklesIcon } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+
+interface FolderBulkActionsProps {
+  totalCount: number;
+  selectedCount: number;
+  pendingCount: number;
+  enabledCount: number;
+  isAllSelected: boolean;
+  onSelectAll: () => void;
+  onDeselectAll: () => void;
+  onEnableAll: () => void;
+  onEnableSelected: () => void;
+  onDisableAll: () => void;
+  onDisableSelected: () => void;
+  isEnabling: boolean;
+  isDisabling: boolean;
+}
+
+/**
+ * Bulk action buttons for folder management
+ */
+export const FolderBulkActions: React.FC<FolderBulkActionsProps> = ({
+  totalCount,
+  selectedCount,
+  pendingCount,
+  enabledCount,
+  isAllSelected,
+  onSelectAll,
+  onDeselectAll,
+  onEnableAll,
+  onEnableSelected,
+  onDisableAll,
+  onDisableSelected,
+  isEnabling,
+  isDisabling,
+}) => {
+  if (totalCount === 0) return null;
+
+  const isLoading = isEnabling || isDisabling;
+
+  return (
+    <div className="border-border mb-4 flex flex-wrap items-center justify-between gap-3 rounded-lg border p-3">
+      {/* Selection Controls */}
+      <div className="flex items-center gap-3">
+        <div
+          className="flex cursor-pointer items-center gap-2"
+          onClick={isAllSelected ? onDeselectAll : onSelectAll}
+        >
+          <Checkbox
+            checked={isAllSelected}
+            onCheckedChange={isAllSelected ? onDeselectAll : onSelectAll}
+            className="cursor-pointer"
+          />
+          <span className="text-sm">
+            {isAllSelected ? 'Deselect All' : 'Select All'} ({totalCount})
+          </span>
+        </div>
+
+        {selectedCount > 0 && (
+          <span className="text-muted-foreground text-sm">
+            {selectedCount} selected
+          </span>
+        )}
+      </div>
+
+      {/* Action Buttons */}
+      <div className="flex flex-wrap gap-2">
+        {/* Enable Actions */}
+        {pendingCount > 0 && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onEnableAll}
+            disabled={isLoading}
+            className="gap-1.5"
+          >
+            <Sparkles className="h-3.5 w-3.5" />
+            AI Tag All ({pendingCount})
+          </Button>
+        )}
+
+        {selectedCount > 0 && (
+          <Button
+            variant="default"
+            size="sm"
+            onClick={onEnableSelected}
+            disabled={isLoading}
+            className="gap-1.5"
+          >
+            <SparklesIcon className="h-3.5 w-3.5" />
+            Tag Selected ({selectedCount})
+          </Button>
+        )}
+
+        {/* Disable Actions */}
+        {enabledCount > 0 && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onDisableAll}
+            disabled={isLoading}
+            className="text-muted-foreground hover:text-destructive gap-1.5"
+          >
+            Disable All ({enabledCount})
+          </Button>
+        )}
+
+        {selectedCount > 0 && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onDisableSelected}
+            disabled={isLoading}
+            className="text-muted-foreground hover:text-destructive gap-1.5"
+          >
+            Disable Selected
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default FolderBulkActions;

--- a/frontend/src/components/FolderManagement/FolderProgressSummary.tsx
+++ b/frontend/src/components/FolderManagement/FolderProgressSummary.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { CheckCircle2, Loader2, Clock } from 'lucide-react';
+import { Progress } from '@/components/ui/progress';
+import { FolderStats } from '@/utils/folderUtils';
+
+interface FolderProgressSummaryProps {
+  stats: FolderStats;
+}
+
+/**
+ * Displays overall AI tagging progress summary
+ */
+export const FolderProgressSummary: React.FC<FolderProgressSummaryProps> = ({
+  stats,
+}) => {
+  const { total, completed, inProgress, pending, overallPercentage } = stats;
+
+  if (total === 0) return null;
+
+  const foldersWithTagging = completed + inProgress;
+
+  return (
+    <div className="bg-muted/50 mb-4 rounded-lg p-4">
+      <div className="mb-3 flex items-center justify-between">
+        <h3 className="text-sm font-medium">AI Tagging Progress</h3>
+        <span className="text-muted-foreground text-sm">
+          {foldersWithTagging}/{total} folders enabled
+        </span>
+      </div>
+
+      <Progress
+        value={overallPercentage}
+        className="mb-3 h-2"
+        indicatorClassName={
+          overallPercentage >= 100 ? 'bg-green-500' : 'bg-blue-500'
+        }
+      />
+
+      <div className="flex flex-wrap gap-4 text-sm">
+        <div className="flex items-center gap-1.5">
+          <CheckCircle2 className="h-4 w-4 text-green-500" />
+          <span className="text-muted-foreground">Completed:</span>
+          <span className="font-medium">{completed}</span>
+        </div>
+
+        <div className="flex items-center gap-1.5">
+          <Loader2 className="h-4 w-4 text-blue-500" />
+          <span className="text-muted-foreground">In Progress:</span>
+          <span className="font-medium">{inProgress}</span>
+        </div>
+
+        <div className="flex items-center gap-1.5">
+          <Clock className="h-4 w-4 text-gray-400" />
+          <span className="text-muted-foreground">Pending:</span>
+          <span className="font-medium">{pending}</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default FolderProgressSummary;

--- a/frontend/src/components/FolderManagement/FolderSection.tsx
+++ b/frontend/src/components/FolderManagement/FolderSection.tsx
@@ -1,0 +1,211 @@
+import React from 'react';
+import {
+  ChevronDown,
+  ChevronRight,
+  Folder,
+  Trash2,
+  Check,
+  CheckCircle2,
+  Loader2,
+  Clock,
+} from 'lucide-react';
+import { Switch } from '@/components/ui/switch';
+import { Button } from '@/components/ui/button';
+import { Progress } from '@/components/ui/progress';
+import { Checkbox } from '@/components/ui/checkbox';
+import { FolderWithStatus } from '@/utils/folderUtils';
+
+type SectionType = 'completed' | 'inProgress' | 'pending';
+
+interface FolderSectionProps {
+  type: SectionType;
+  folders: FolderWithStatus[];
+  isCollapsed: boolean;
+  onToggleCollapse: () => void;
+  selectedIds: Set<string>;
+  onToggleSelection: (folderId: string) => void;
+  onToggleAITagging: (folder: FolderWithStatus) => void;
+  onDeleteFolder: (folderId: string) => void;
+  isTaggingPending: boolean;
+  isDeletePending: boolean;
+}
+
+const sectionConfig: Record<
+  SectionType,
+  { label: string; icon: React.ElementType; color: string }
+> = {
+  completed: {
+    label: 'Completed',
+    icon: CheckCircle2,
+    color: 'text-green-500',
+  },
+  inProgress: {
+    label: 'In Progress',
+    icon: Loader2,
+    color: 'text-blue-500',
+  },
+  pending: {
+    label: 'Pending',
+    icon: Clock,
+    color: 'text-gray-400',
+  },
+};
+
+/**
+ * Collapsible section for grouped folders
+ */
+export const FolderSection: React.FC<FolderSectionProps> = ({
+  type,
+  folders,
+  isCollapsed,
+  onToggleCollapse,
+  selectedIds,
+  onToggleSelection,
+  onToggleAITagging,
+  onDeleteFolder,
+  isTaggingPending,
+  isDeletePending,
+}) => {
+  if (folders.length === 0) return null;
+
+  const config = sectionConfig[type];
+  const Icon = config.icon;
+
+  return (
+    <div className="mb-4">
+      {/* Section Header */}
+      <button
+        onClick={onToggleCollapse}
+        className="hover:bg-muted/50 mb-2 flex w-full items-center gap-2 rounded-md p-2 transition-colors"
+      >
+        {isCollapsed ? (
+          <ChevronRight className="h-4 w-4" />
+        ) : (
+          <ChevronDown className="h-4 w-4" />
+        )}
+        <Icon className={`h-4 w-4 ${config.color}`} />
+        <span className="font-medium">{config.label}</span>
+        <span className="text-muted-foreground text-sm">({folders.length})</span>
+      </button>
+
+      {/* Folder List */}
+      {!isCollapsed && (
+        <div className="space-y-2 pl-2">
+          {folders.map((folder) => (
+            <FolderItem
+              key={folder.folder_id}
+              folder={folder}
+              isSelected={selectedIds.has(folder.folder_id)}
+              onToggleSelection={() => onToggleSelection(folder.folder_id)}
+              onToggleAITagging={() => onToggleAITagging(folder)}
+              onDelete={() => onDeleteFolder(folder.folder_id)}
+              isTaggingPending={isTaggingPending}
+              isDeletePending={isDeletePending}
+              showProgress={type !== 'pending'}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+interface FolderItemProps {
+  folder: FolderWithStatus;
+  isSelected: boolean;
+  onToggleSelection: () => void;
+  onToggleAITagging: () => void;
+  onDelete: () => void;
+  isTaggingPending: boolean;
+  isDeletePending: boolean;
+  showProgress: boolean;
+}
+
+const FolderItem: React.FC<FolderItemProps> = ({
+  folder,
+  isSelected,
+  onToggleSelection,
+  onToggleAITagging,
+  onDelete,
+  isTaggingPending,
+  isDeletePending,
+  showProgress,
+}) => {
+  const isComplete = folder.tagging_percentage >= 100;
+
+  return (
+    <div
+      className={`border-border bg-background/50 group relative rounded-lg border p-3 transition-all hover:border-gray-300 hover:shadow-sm dark:hover:border-gray-600 ${
+        isSelected ? 'border-primary bg-primary/5' : ''
+      }`}
+    >
+      <div className="flex items-center gap-3">
+        {/* Checkbox */}
+        <Checkbox
+          checked={isSelected}
+          onCheckedChange={onToggleSelection}
+          className="cursor-pointer"
+        />
+
+        {/* Folder Info */}
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <Folder className="h-4 w-4 shrink-0 text-gray-500 dark:text-gray-400" />
+            <span className="text-foreground truncate text-sm">
+              {folder.folder_path}
+            </span>
+          </div>
+
+          {/* Progress Bar */}
+          {showProgress && folder.AI_Tagging && (
+            <div className="mt-2">
+              <div className="text-muted-foreground mb-1 flex items-center justify-between text-xs">
+                <span>Progress</span>
+                <span
+                  className={
+                    isComplete
+                      ? 'flex items-center gap-1 text-green-500'
+                      : 'text-muted-foreground'
+                  }
+                >
+                  {isComplete && <Check className="h-3 w-3" />}
+                  {Math.round(folder.tagging_percentage)}%
+                </span>
+              </div>
+              <Progress
+                value={folder.tagging_percentage}
+                className="h-1.5"
+                indicatorClassName={isComplete ? 'bg-green-500' : 'bg-blue-500'}
+              />
+            </div>
+          )}
+        </div>
+
+        {/* Actions */}
+        <div className="flex items-center gap-3">
+          <div className="flex items-center gap-2">
+            <span className="text-muted-foreground text-xs">AI</span>
+            <Switch
+              className="cursor-pointer"
+              checked={folder.AI_Tagging}
+              onCheckedChange={onToggleAITagging}
+              disabled={isTaggingPending}
+            />
+          </div>
+
+          <Button
+            onClick={onDelete}
+            variant="ghost"
+            size="sm"
+            className="h-7 w-7 p-0 text-gray-400 hover:text-red-500"
+            disabled={isDeletePending}
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default FolderSection;

--- a/frontend/src/components/FolderManagement/index.ts
+++ b/frontend/src/components/FolderManagement/index.ts
@@ -1,0 +1,3 @@
+export { FolderProgressSummary } from './FolderProgressSummary';
+export { FolderBulkActions } from './FolderBulkActions';
+export { FolderSection } from './FolderSection';

--- a/frontend/src/components/ui/checkbox.tsx
+++ b/frontend/src/components/ui/checkbox.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import * as CheckboxPrimitive from '@radix-ui/react-checkbox';
+import { Check } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+const Checkbox = React.forwardRef<
+  React.ElementRef<typeof CheckboxPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <CheckboxPrimitive.Root
+    ref={ref}
+    className={cn(
+      'border-primary ring-offset-background focus-visible:ring-ring data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground peer h-4 w-4 shrink-0 rounded-sm border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+      className,
+    )}
+    {...props}
+  >
+    <CheckboxPrimitive.Indicator
+      className={cn('flex items-center justify-center text-current')}
+    >
+      <Check className="h-4 w-4" />
+    </CheckboxPrimitive.Indicator>
+  </CheckboxPrimitive.Root>
+));
+Checkbox.displayName = CheckboxPrimitive.Root.displayName;
+
+export { Checkbox };

--- a/frontend/src/hooks/useBulkFolderSelection.ts
+++ b/frontend/src/hooks/useBulkFolderSelection.ts
@@ -1,0 +1,96 @@
+import { useState, useCallback, useMemo } from 'react';
+import { FolderWithStatus } from '@/utils/folderUtils';
+
+interface UseBulkFolderSelectionReturn {
+  selectedIds: Set<string>;
+  isSelected: (folderId: string) => boolean;
+  toggleSelection: (folderId: string) => void;
+  selectAll: (folders: FolderWithStatus[]) => void;
+  deselectAll: () => void;
+  selectByStatus: (
+    folders: FolderWithStatus[],
+    status: 'completed' | 'inProgress' | 'pending',
+  ) => void;
+  selectedCount: number;
+  isAllSelected: (folders: FolderWithStatus[]) => boolean;
+  getSelectedFolders: (folders: FolderWithStatus[]) => FolderWithStatus[];
+}
+
+/**
+ * Hook for managing bulk folder selection state
+ */
+export const useBulkFolderSelection = (): UseBulkFolderSelectionReturn => {
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+
+  const isSelected = useCallback(
+    (folderId: string) => selectedIds.has(folderId),
+    [selectedIds],
+  );
+
+  const toggleSelection = useCallback((folderId: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(folderId)) {
+        next.delete(folderId);
+      } else {
+        next.add(folderId);
+      }
+      return next;
+    });
+  }, []);
+
+  const selectAll = useCallback((folders: FolderWithStatus[]) => {
+    setSelectedIds(new Set(folders.map((f) => f.folder_id)));
+  }, []);
+
+  const deselectAll = useCallback(() => {
+    setSelectedIds(new Set());
+  }, []);
+
+  const selectByStatus = useCallback(
+    (
+      folders: FolderWithStatus[],
+      status: 'completed' | 'inProgress' | 'pending',
+    ) => {
+      const filtered = folders.filter((folder) => {
+        if (status === 'pending') return !folder.AI_Tagging;
+        if (status === 'completed')
+          return folder.AI_Tagging && folder.tagging_percentage >= 100;
+        return folder.AI_Tagging && folder.tagging_percentage < 100;
+      });
+      setSelectedIds(new Set(filtered.map((f) => f.folder_id)));
+    },
+    [],
+  );
+
+  const selectedCount = useMemo(() => selectedIds.size, [selectedIds]);
+
+  const isAllSelected = useCallback(
+    (folders: FolderWithStatus[]) => {
+      if (folders.length === 0) return false;
+      return folders.every((f) => selectedIds.has(f.folder_id));
+    },
+    [selectedIds],
+  );
+
+  const getSelectedFolders = useCallback(
+    (folders: FolderWithStatus[]) => {
+      return folders.filter((f) => selectedIds.has(f.folder_id));
+    },
+    [selectedIds],
+  );
+
+  return {
+    selectedIds,
+    isSelected,
+    toggleSelection,
+    selectAll,
+    deselectAll,
+    selectByStatus,
+    selectedCount,
+    isAllSelected,
+    getSelectedFolders,
+  };
+};
+
+export default useBulkFolderSelection;

--- a/frontend/src/pages/SettingsPage/components/FolderManagementCard.tsx
+++ b/frontend/src/pages/SettingsPage/components/FolderManagementCard.tsx
@@ -1,33 +1,145 @@
-import React from 'react';
-import { Folder, Trash2, Check } from 'lucide-react';
-
-import { Switch } from '@/components/ui/switch';
-import { Button } from '@/components/ui/button';
-import { Progress } from '@/components/ui/progress';
+import React, { useState, useMemo, useEffect, useCallback } from 'react';
+import { Folder } from 'lucide-react';
 import { useSelector } from 'react-redux';
 import { RootState } from '@/app/store';
 import FolderPicker from '@/components/FolderPicker/FolderPicker';
-
 import { useFolderOperations } from '@/hooks/useFolderOperations';
-import { FolderDetails } from '@/types/Folder';
+import { useBulkFolderSelection } from '@/hooks/useBulkFolderSelection';
 import SettingsCard from './SettingsCard';
+import {
+  FolderProgressSummary,
+  FolderBulkActions,
+  FolderSection,
+} from '@/components/FolderManagement';
+import {
+  mergeFoldersWithStatus,
+  groupFoldersByStatus,
+  calculateFolderStats,
+  loadFolderPreferences,
+  saveFolderPreferences,
+  FolderPreferences,
+  FolderWithStatus,
+} from '@/utils/folderUtils';
 
 /**
  * Component for managing folder operations in settings
+ * Supports bulk AI tagging, progress tracking, and smart sorting
  */
 const FolderManagementCard: React.FC = () => {
   const {
     folders,
     toggleAITagging,
     deleteFolder,
+    bulkEnableAITagging,
+    bulkDisableAITagging,
     enableAITaggingPending,
     disableAITaggingPending,
     deleteFolderPending,
+    bulkEnablePending,
+    bulkDisablePending,
   } = useFolderOperations();
 
   const taggingStatus = useSelector(
     (state: RootState) => state.folders.taggingStatus,
   );
+
+  // Selection state
+  const {
+    selectedIds,
+    toggleSelection,
+    selectAll,
+    deselectAll,
+    selectedCount,
+    isAllSelected,
+    getSelectedFolders,
+  } = useBulkFolderSelection();
+
+  // Collapsed sections state (persisted)
+  const [preferences, setPreferences] = useState<FolderPreferences>(
+    loadFolderPreferences,
+  );
+
+  // Save preferences when they change
+  useEffect(() => {
+    saveFolderPreferences(preferences);
+  }, [preferences]);
+
+  // Merge folders with their tagging status
+  const foldersWithStatus: FolderWithStatus[] = useMemo(
+    () => mergeFoldersWithStatus(folders, taggingStatus),
+    [folders, taggingStatus],
+  );
+
+  // Group folders by status
+  const groupedFolders = useMemo(
+    () => groupFoldersByStatus(foldersWithStatus),
+    [foldersWithStatus],
+  );
+
+  // Calculate statistics
+  const stats = useMemo(
+    () => calculateFolderStats(groupedFolders),
+    [groupedFolders],
+  );
+
+  // Toggle section collapse
+  const toggleSectionCollapse = useCallback(
+    (section: 'completed' | 'inProgress' | 'pending') => {
+      setPreferences((prev) => ({
+        ...prev,
+        collapsedSections: {
+          ...prev.collapsedSections,
+          [section]: !prev.collapsedSections[section],
+        },
+      }));
+    },
+    [],
+  );
+
+  // Bulk action handlers
+  const handleSelectAll = useCallback(() => {
+    selectAll(foldersWithStatus);
+  }, [selectAll, foldersWithStatus]);
+
+  const handleEnableAll = useCallback(() => {
+    const pendingFolderIds = groupedFolders.pending.map((f) => f.folder_id);
+    bulkEnableAITagging(pendingFolderIds);
+  }, [groupedFolders.pending, bulkEnableAITagging]);
+
+  const handleEnableSelected = useCallback(() => {
+    const selectedFolders = getSelectedFolders(foldersWithStatus);
+    const pendingSelectedIds = selectedFolders
+      .filter((f) => !f.AI_Tagging)
+      .map((f) => f.folder_id);
+    if (pendingSelectedIds.length > 0) {
+      bulkEnableAITagging(pendingSelectedIds);
+    } else {
+      // If all selected already have AI tagging, enable anyway (re-trigger)
+      bulkEnableAITagging(selectedFolders.map((f) => f.folder_id));
+    }
+  }, [getSelectedFolders, foldersWithStatus, bulkEnableAITagging]);
+
+  const handleDisableAll = useCallback(() => {
+    const enabledFolderIds = [
+      ...groupedFolders.completed,
+      ...groupedFolders.inProgress,
+    ].map((f) => f.folder_id);
+    bulkDisableAITagging(enabledFolderIds);
+  }, [groupedFolders, bulkDisableAITagging]);
+
+  const handleDisableSelected = useCallback(() => {
+    const selectedFolders = getSelectedFolders(foldersWithStatus);
+    const enabledSelectedIds = selectedFolders
+      .filter((f) => f.AI_Tagging)
+      .map((f) => f.folder_id);
+    bulkDisableAITagging(enabledSelectedIds);
+  }, [getSelectedFolders, foldersWithStatus, bulkDisableAITagging]);
+
+  const isTaggingPending =
+    enableAITaggingPending ||
+    disableAITaggingPending ||
+    bulkEnablePending ||
+    bulkDisablePending;
 
   return (
     <SettingsCard
@@ -36,86 +148,69 @@ const FolderManagementCard: React.FC = () => {
       description="Configure your photo library folders and AI settings"
     >
       {folders.length > 0 ? (
-        <div className="space-y-3">
-          {folders.map((folder: FolderDetails, index: number) => (
-            <div
-              key={index}
-              className="group border-border bg-background/50 relative rounded-lg border p-4 transition-all hover:border-gray-300 hover:shadow-sm dark:hover:border-gray-600"
-            >
-              <div className="flex items-center justify-between">
-                <div className="min-w-0 flex-1">
-                  <div className="flex items-center gap-3">
-                    <Folder className="h-4 w-4 flex-shrink-0 text-gray-500 dark:text-gray-400" />
-                    <span className="text-foreground truncate">
-                      {folder.folder_path}
-                    </span>
-                  </div>
-                </div>
+        <>
+          {/* Progress Summary */}
+          <FolderProgressSummary stats={stats} />
 
-                <div className="ml-4 flex items-center gap-4">
-                  <div className="flex items-center gap-3">
-                    <span className="text-muted-foreground text-sm">
-                      AI Tagging
-                    </span>
-                    <Switch
-                      className="cursor-pointer"
-                      checked={folder.AI_Tagging}
-                      onCheckedChange={() => toggleAITagging(folder)}
-                      disabled={
-                        enableAITaggingPending || disableAITaggingPending
-                      }
-                    />
-                  </div>
+          {/* Bulk Actions */}
+          <FolderBulkActions
+            totalCount={stats.total}
+            selectedCount={selectedCount}
+            pendingCount={stats.pending}
+            enabledCount={stats.completed + stats.inProgress}
+            isAllSelected={isAllSelected(foldersWithStatus)}
+            onSelectAll={handleSelectAll}
+            onDeselectAll={deselectAll}
+            onEnableAll={handleEnableAll}
+            onEnableSelected={handleEnableSelected}
+            onDisableAll={handleDisableAll}
+            onDisableSelected={handleDisableSelected}
+            isEnabling={bulkEnablePending || enableAITaggingPending}
+            isDisabling={bulkDisablePending || disableAITaggingPending}
+          />
 
-                  <Button
-                    onClick={() => deleteFolder(folder.folder_id)}
-                    variant="outline"
-                    size="sm"
-                    className="h-8 w-8 cursor-pointer text-gray-500 hover:border-red-300 hover:text-red-600 dark:text-gray-400 dark:hover:text-red-400"
-                    disabled={deleteFolderPending}
-                  >
-                    <Trash2 className="h-4 w-4" />
-                  </Button>
-                </div>
-              </div>
+          {/* Folder Sections */}
+          <div className="space-y-2">
+            <FolderSection
+              type="inProgress"
+              folders={groupedFolders.inProgress}
+              isCollapsed={preferences.collapsedSections.inProgress}
+              onToggleCollapse={() => toggleSectionCollapse('inProgress')}
+              selectedIds={selectedIds}
+              onToggleSelection={toggleSelection}
+              onToggleAITagging={toggleAITagging}
+              onDeleteFolder={deleteFolder}
+              isTaggingPending={isTaggingPending}
+              isDeletePending={deleteFolderPending}
+            />
 
-              {folder.AI_Tagging && (
-                <div className="mt-3">
-                  <div className="text-muted-foreground mb-1 flex items-center justify-between text-xs">
-                    <span>AI Tagging Progress</span>
-                    <span
-                      className={
-                        (taggingStatus[folder.folder_id]?.tagging_percentage ??
-                          0) >= 100
-                          ? 'flex items-center gap-1 text-green-500'
-                          : 'text-muted-foreground'
-                      }
-                    >
-                      {(taggingStatus[folder.folder_id]?.tagging_percentage ??
-                        0) >= 100 && <Check className="h-3 w-3" />}
-                      {Math.round(
-                        taggingStatus[folder.folder_id]?.tagging_percentage ??
-                          0,
-                      )}
-                      %
-                    </span>
-                  </div>
-                  <Progress
-                    value={
-                      taggingStatus[folder.folder_id]?.tagging_percentage ?? 0
-                    }
-                    indicatorClassName={
-                      (taggingStatus[folder.folder_id]?.tagging_percentage ??
-                        0) >= 100
-                        ? 'bg-green-500'
-                        : 'bg-blue-500'
-                    }
-                  />
-                </div>
-              )}
-            </div>
-          ))}
-        </div>
+            <FolderSection
+              type="pending"
+              folders={groupedFolders.pending}
+              isCollapsed={preferences.collapsedSections.pending}
+              onToggleCollapse={() => toggleSectionCollapse('pending')}
+              selectedIds={selectedIds}
+              onToggleSelection={toggleSelection}
+              onToggleAITagging={toggleAITagging}
+              onDeleteFolder={deleteFolder}
+              isTaggingPending={isTaggingPending}
+              isDeletePending={deleteFolderPending}
+            />
+
+            <FolderSection
+              type="completed"
+              folders={groupedFolders.completed}
+              isCollapsed={preferences.collapsedSections.completed}
+              onToggleCollapse={() => toggleSectionCollapse('completed')}
+              selectedIds={selectedIds}
+              onToggleSelection={toggleSelection}
+              onToggleAITagging={toggleAITagging}
+              onDeleteFolder={deleteFolder}
+              isTaggingPending={isTaggingPending}
+              isDeletePending={deleteFolderPending}
+            />
+          </div>
+        </>
       ) : (
         <div className="py-8 text-center">
           <Folder className="mx-auto mb-3 h-12 w-12 text-gray-400" />

--- a/frontend/src/utils/__tests__/folderUtils.test.ts
+++ b/frontend/src/utils/__tests__/folderUtils.test.ts
@@ -1,0 +1,144 @@
+import {
+  mergeFoldersWithStatus,
+  groupFoldersByStatus,
+  calculateFolderStats,
+  FolderWithStatus,
+} from '../folderUtils';
+import { FolderDetails } from '@/types/Folder';
+import { FolderTaggingInfo } from '@/types/FolderStatus';
+
+describe('folderUtils', () => {
+  const mockFolders: FolderDetails[] = [
+    {
+      folder_id: '1',
+      folder_path: '/photos/vacation',
+      last_modified_time: 1000,
+      AI_Tagging: true,
+    },
+    {
+      folder_id: '2',
+      folder_path: '/photos/family',
+      last_modified_time: 2000,
+      AI_Tagging: true,
+    },
+    {
+      folder_id: '3',
+      folder_path: '/photos/work',
+      last_modified_time: 3000,
+      AI_Tagging: false,
+    },
+  ];
+
+  const mockTaggingStatus: Record<string, FolderTaggingInfo> = {
+    '1': { folder_id: '1', folder_path: '/photos/vacation', tagging_percentage: 100 },
+    '2': { folder_id: '2', folder_path: '/photos/family', tagging_percentage: 50 },
+  };
+
+  describe('mergeFoldersWithStatus', () => {
+    it('should merge folders with their tagging status', () => {
+      const result = mergeFoldersWithStatus(mockFolders, mockTaggingStatus);
+
+      expect(result).toHaveLength(3);
+      expect(result[0].tagging_percentage).toBe(100);
+      expect(result[1].tagging_percentage).toBe(50);
+      expect(result[2].tagging_percentage).toBe(0); // No status, defaults to 0
+    });
+
+    it('should handle empty folders', () => {
+      const result = mergeFoldersWithStatus([], mockTaggingStatus);
+      expect(result).toHaveLength(0);
+    });
+
+    it('should handle empty tagging status', () => {
+      const result = mergeFoldersWithStatus(mockFolders, {});
+      expect(result.every((f) => f.tagging_percentage === 0)).toBe(true);
+    });
+  });
+
+  describe('groupFoldersByStatus', () => {
+    it('should group folders correctly', () => {
+      const foldersWithStatus: FolderWithStatus[] = [
+        { ...mockFolders[0], tagging_percentage: 100 }, // completed
+        { ...mockFolders[1], tagging_percentage: 50 },  // in progress
+        { ...mockFolders[2], tagging_percentage: 0 },   // pending (AI_Tagging: false)
+      ];
+
+      const result = groupFoldersByStatus(foldersWithStatus);
+
+      expect(result.completed).toHaveLength(1);
+      expect(result.completed[0].folder_id).toBe('1');
+
+      expect(result.inProgress).toHaveLength(1);
+      expect(result.inProgress[0].folder_id).toBe('2');
+
+      expect(result.pending).toHaveLength(1);
+      expect(result.pending[0].folder_id).toBe('3');
+    });
+
+    it('should handle all folders being pending', () => {
+      const foldersWithStatus: FolderWithStatus[] = mockFolders.map((f) => ({
+        ...f,
+        AI_Tagging: false,
+        tagging_percentage: 0,
+      }));
+
+      const result = groupFoldersByStatus(foldersWithStatus);
+
+      expect(result.completed).toHaveLength(0);
+      expect(result.inProgress).toHaveLength(0);
+      expect(result.pending).toHaveLength(3);
+    });
+
+    it('should handle empty array', () => {
+      const result = groupFoldersByStatus([]);
+
+      expect(result.completed).toHaveLength(0);
+      expect(result.inProgress).toHaveLength(0);
+      expect(result.pending).toHaveLength(0);
+    });
+  });
+
+  describe('calculateFolderStats', () => {
+    it('should calculate stats correctly', () => {
+      const groupedFolders = {
+        completed: [{ ...mockFolders[0], tagging_percentage: 100 }],
+        inProgress: [{ ...mockFolders[1], tagging_percentage: 50 }],
+        pending: [{ ...mockFolders[2], tagging_percentage: 0 }],
+      };
+
+      const result = calculateFolderStats(groupedFolders);
+
+      expect(result.total).toBe(3);
+      expect(result.completed).toBe(1);
+      expect(result.inProgress).toBe(1);
+      expect(result.pending).toBe(1);
+      expect(result.overallPercentage).toBe(75); // (100 + 50) / 2
+    });
+
+    it('should handle no folders with tagging enabled', () => {
+      const groupedFolders = {
+        completed: [],
+        inProgress: [],
+        pending: [{ ...mockFolders[2], tagging_percentage: 0 }],
+      };
+
+      const result = calculateFolderStats(groupedFolders);
+
+      expect(result.total).toBe(1);
+      expect(result.overallPercentage).toBe(0);
+    });
+
+    it('should handle empty groups', () => {
+      const groupedFolders = {
+        completed: [],
+        inProgress: [],
+        pending: [],
+      };
+
+      const result = calculateFolderStats(groupedFolders);
+
+      expect(result.total).toBe(0);
+      expect(result.overallPercentage).toBe(0);
+    });
+  });
+});

--- a/frontend/src/utils/folderUtils.ts
+++ b/frontend/src/utils/folderUtils.ts
@@ -1,0 +1,126 @@
+import { FolderDetails } from '@/types/Folder';
+import { FolderTaggingInfo } from '@/types/FolderStatus';
+
+export interface FolderWithStatus extends FolderDetails {
+  tagging_percentage: number;
+}
+
+export interface GroupedFolders {
+  completed: FolderWithStatus[];
+  inProgress: FolderWithStatus[];
+  pending: FolderWithStatus[];
+}
+
+export interface FolderStats {
+  total: number;
+  completed: number;
+  inProgress: number;
+  pending: number;
+  overallPercentage: number;
+}
+
+/**
+ * Merges folder details with their tagging status
+ */
+export const mergeFoldersWithStatus = (
+  folders: FolderDetails[],
+  taggingStatus: Record<string, FolderTaggingInfo>,
+): FolderWithStatus[] => {
+  return folders.map((folder) => ({
+    ...folder,
+    tagging_percentage: taggingStatus[folder.folder_id]?.tagging_percentage ?? 0,
+  }));
+};
+
+/**
+ * Groups folders by their tagging status
+ * - Completed: AI_Tagging enabled AND 100% tagged
+ * - In Progress: AI_Tagging enabled AND < 100% tagged
+ * - Pending: AI_Tagging disabled
+ */
+export const groupFoldersByStatus = (
+  folders: FolderWithStatus[],
+): GroupedFolders => {
+  const completed: FolderWithStatus[] = [];
+  const inProgress: FolderWithStatus[] = [];
+  const pending: FolderWithStatus[] = [];
+
+  for (const folder of folders) {
+    if (!folder.AI_Tagging) {
+      pending.push(folder);
+    } else if (folder.tagging_percentage >= 100) {
+      completed.push(folder);
+    } else {
+      inProgress.push(folder);
+    }
+  }
+
+  return { completed, inProgress, pending };
+};
+
+/**
+ * Calculates folder statistics
+ */
+export const calculateFolderStats = (
+  groupedFolders: GroupedFolders,
+): FolderStats => {
+  const { completed, inProgress, pending } = groupedFolders;
+  const total = completed.length + inProgress.length + pending.length;
+
+  // Calculate overall percentage based on folders with AI tagging enabled
+  const foldersWithTagging = [...completed, ...inProgress];
+  const overallPercentage =
+    foldersWithTagging.length > 0
+      ? foldersWithTagging.reduce((sum, f) => sum + f.tagging_percentage, 0) /
+        foldersWithTagging.length
+      : 0;
+
+  return {
+    total,
+    completed: completed.length,
+    inProgress: inProgress.length,
+    pending: pending.length,
+    overallPercentage: Math.round(overallPercentage),
+  };
+};
+
+/**
+ * Storage key for persisting user preferences
+ */
+export const FOLDER_PREFS_KEY = 'pictopy_folder_preferences';
+
+export interface FolderPreferences {
+  collapsedSections: {
+    completed: boolean;
+    inProgress: boolean;
+    pending: boolean;
+  };
+}
+
+export const defaultFolderPreferences: FolderPreferences = {
+  collapsedSections: {
+    completed: false,
+    inProgress: false,
+    pending: false,
+  },
+};
+
+export const loadFolderPreferences = (): FolderPreferences => {
+  try {
+    const stored = localStorage.getItem(FOLDER_PREFS_KEY);
+    if (stored) {
+      return { ...defaultFolderPreferences, ...JSON.parse(stored) };
+    }
+  } catch (e) {
+    console.warn('Failed to load folder preferences:', e);
+  }
+  return defaultFolderPreferences;
+};
+
+export const saveFolderPreferences = (prefs: FolderPreferences): void => {
+  try {
+    localStorage.setItem(FOLDER_PREFS_KEY, JSON.stringify(prefs));
+  } catch (e) {
+    console.warn('Failed to save folder preferences:', e);
+  }
+};


### PR DESCRIPTION
Problem
The folder management interface required manual interaction with each folder's AI tagging toggle, making it tedious to manage multiple folders. Users had no overview of tagging progress across their collection.

Solution
1. Progress Summary

Visual progress bar showing overall AI tagging status
Stats breakdown: Completed | In Progress | Pending folders
2. Bulk Action Buttons

"AI Tag All" - Enable AI tagging for all pending folders at once
"Select All" - Checkbox to select multiple folders
"Tag Selected" - Apply AI tagging to selected folders only
"Disable All" / "Disable Selected" - Bulk disable options
3. Smart Sorting by Status

Folders auto-organized into collapsible sections:
In Progress (currently being tagged)
Pending (not yet enabled)
Completed (100% tagged)
Section collapse state persists across sessions
4. Multi-Select System

Individual folder checkboxes
Visual indication of selected folders
Bulk actions enabled when folders are selected
Technical Notes
No backend changes required (existing API already supports batch operations)
Added @radix-ui/react-checkbox dependency

https://github.com/AOSSIE-Org/PictoPy/issues/725

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Bulk folder selection for managing multiple folders at once
  * Batch enable/disable AI tagging operations with loading indicators
  * Folder progress summary displaying tagging completion metrics
  * Collapsible folder sections organized by status (pending, in progress, completed)
  * Enhanced checkbox controls for improved selection interface

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->