### PR TITLE
Step count progress bar overflow fixed

### DIFF
--- a/docs/backend/backend_python/openapi.json
+++ b/docs/backend/backend_python/openapi.json
@@ -1117,9 +1117,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "$ref": "#/components/schemas/InputType",
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/InputType"
+                }
+              ],
               "description": "Choose input type: 'path' or 'base64'",
-              "default": "path"
+              "default": "path",
+              "title": "Input Type"
             },
             "description": "Choose input type: 'path' or 'base64'"
           }
@@ -2199,7 +2204,6 @@
           "metadata": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14476,20 +14476,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/yaml": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      }
-    },
     "node_modules/yargs": {
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",

--- a/frontend/src/components/OnboardingSteps/AvatarSelectionStep.tsx
+++ b/frontend/src/components/OnboardingSteps/AvatarSelectionStep.tsx
@@ -65,14 +65,14 @@ export const AvatarSelectionStep: React.FC<AvatarNameSelectionStepProps> = ({
         <CardHeader className="p-3">
           <div className="text-muted-foreground mb-1 flex justify-between text-xs">
             <span>
-              Step {stepIndex + 1} of {totalSteps}
+              Step {stepIndex} of {totalSteps}
             </span>
-            <span>{Math.round(((stepIndex + 1) / totalSteps) * 100)}%</span>
+            <span>{Math.round(((stepIndex) / totalSteps) * 100)}%</span>
           </div>
           <div className="bg-muted mb-2 h-1.5 w-full rounded-full">
             <div
               className="bg-primary h-full rounded-full transition-all duration-300"
-              style={{ width: `${((stepIndex + 1) / totalSteps) * 100}%` }}
+              style={{ width: `${((stepIndex) / totalSteps) * 100}%` }}
             />
           </div>
           <CardTitle className="mt-1 text-xl font-semibold">

--- a/frontend/src/components/OnboardingSteps/FolderSetupStep.tsx
+++ b/frontend/src/components/OnboardingSteps/FolderSetupStep.tsx
@@ -64,7 +64,7 @@ export function FolderSetupStep({
   if (localStorage.getItem('folderChosen') === 'true') {
     return null;
   }
-  const progressPercent = Math.round(((stepIndex + 1) / totalSteps) * 100);
+  const progressPercent = Math.round(((stepIndex) / totalSteps) * 100);
 
   return (
     <>
@@ -72,7 +72,7 @@ export function FolderSetupStep({
         <CardHeader className="p-3">
           <div className="text-muted-foreground mb-1 flex justify-between text-xs">
             <span>
-              Step {stepIndex + 1} of {totalSteps}
+              Step {stepIndex} of {totalSteps}
             </span>
             <span>{progressPercent}%</span>
           </div>

--- a/frontend/src/components/OnboardingSteps/OnboardingStep.tsx
+++ b/frontend/src/components/OnboardingSteps/OnboardingStep.tsx
@@ -44,7 +44,7 @@ export const OnboardingStep: React.FC<OnboardingStepProps> = ({
         return <div></div>;
     }
   };
-
+  
   return (
     <div className="bg-background text-foreground flex min-h-screen w-full items-center justify-center">
       <div className="flex h-[540px] w-full max-w-4xl gap-3">

--- a/frontend/src/components/OnboardingSteps/ThemeSelectionStep.tsx
+++ b/frontend/src/components/OnboardingSteps/ThemeSelectionStep.tsx
@@ -51,14 +51,14 @@ export const ThemeSelectionStep: React.FC<ThemeSelectionStepProps> = ({
     return null;
   }
 
-  const progressPercent = Math.round(((stepIndex + 1) / totalSteps) * 100);
+  const progressPercent = Math.round(((stepIndex ) / totalSteps) * 100);
   return (
     <>
       <Card className="flex max-h-full w-1/2 flex-col border p-4">
         <CardHeader className="p-3">
           <div className="text-muted-foreground mb-1 flex justify-between text-xs">
             <span>
-              Step {stepIndex + 1} of {totalSteps}
+              Step {stepIndex } of {totalSteps}
             </span>
             <span>{progressPercent}%</span>
           </div>


### PR DESCRIPTION
## Solves Issue
BUG: progress bar overflow in onboarding steps (#638)

## Solution Summary

The issue is fixed by using the actual step index from the current state instead of manually adding `+1`.  
This keeps the progress calculation accurate and prevents overflow.

## Why this solution is correct

- No change in existing architecture or flow  
- Minimal code change, low risk  
- Uses existing state instead of hardcoded logic  
- Easier to understand and maintain  

## Testing

- **Unit testing**: Step index value is correct  
- **Boundary testing**: Progress stays within 0–100%  
- **System testing**: Progress bar matches visible steps  

## Proof

Screenshots attached showing correct progress behavior.

<img width="1920" height="1080" alt="Screenshot (459)" src="https://github.com/user-attachments/assets/ad356612-2301-4552-95f6-abb1dfff1518" />

### Team Name - EtherX
- Ritigya Gupta
- Sirjan Singh
- Heeral Mandolia

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected onboarding step numbering and progress indicators to properly display current step position instead of next step.

* **Documentation**
  * Updated API schema for face search operation parameter handling and metadata object validation constraints.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->