### PR TITLE
fix: enable Open Original File using plugin-opener (closes #688)

### DIFF
--- a/docs/backend/backend_python/openapi.json
+++ b/docs/backend/backend_python/openapi.json
@@ -1117,9 +1117,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "$ref": "#/components/schemas/InputType",
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/InputType"
+                }
+              ],
               "description": "Choose input type: 'path' or 'base64'",
-              "default": "path"
+              "default": "path",
+              "title": "Input Type"
             },
             "description": "Choose input type: 'path' or 'base64'"
           }
@@ -2199,7 +2204,6 @@
           "metadata": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {

--- a/frontend/src-tauri/2
+++ b/frontend/src-tauri/2
@@ -1,0 +1,12 @@
+
+up to date, audited 901 packages in 3s
+
+165 packages are looking for funding
+  run `npm fund` for details
+
+1 moderate severity vulnerability
+
+To address all issues, run:
+  npm audit fix
+
+Run `npm audit` for details.

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -34,7 +34,7 @@ tauri-plugin-dialog = "2.4.2"
 tauri-plugin-process = "2.3.1"
 tauri-plugin-store = "2.4.1"
 tauri-plugin-updater = "2.9.0"
-tauri-plugin-opener = "2.5.2"
+tauri-plugin-opener = "2"
 
 [features]
 # This feature is used for production builds or when a dev server is not specified, DO NOT REMOVE!!

--- a/frontend/src-tauri/capabilities/migrated.json
+++ b/frontend/src-tauri/capabilities/migrated.json
@@ -136,6 +136,28 @@
     "fs:default",
     "dialog:default",
     "store:default",
-    "opener:allow-reveal-item-in-dir"
+    "opener:allow-reveal-item-in-dir",
+    "opener:allow-open-path",
+    "opener:allow-open-url",
+    "opener:allow-default-urls",
+    {
+      "identifier": "opener:allow-open-path",
+      "allow": [
+        {
+          "path": "**"
+        }
+      ]
+    },
+    {
+      "identifier": "opener:allow-open-url",
+      "allow": [
+        {
+          "url": "https://*"
+        },
+        {
+          "url": "http://*"
+        }
+      ]
+    }
   ]
 }

--- a/frontend/src/components/Media/MediaInfoPanel.tsx
+++ b/frontend/src/components/Media/MediaInfoPanel.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { open } from '@tauri-apps/plugin-shell';
+import { openPath, openUrl } from '@tauri-apps/plugin-opener';
 import {
   X,
   ImageIcon as ImageLucide,
@@ -26,6 +26,18 @@ export const MediaInfoPanel: React.FC<MediaInfoPanelProps> = ({
   currentIndex,
   totalImages,
 }) => {
+  const handleLocationClick = async () => {
+    if (currentImage?.metadata?.latitude && currentImage?.metadata?.longitude) {
+      const { latitude, longitude } = currentImage.metadata;
+      const url = `https://maps.google.com/?q=${latitude},${longitude}`;
+      try {
+        await openUrl(url);
+      } catch (error) {
+        console.error('Failed to open map URL:', error);
+      }
+    }
+  };
+
   const getFormattedDate = () => {
     if (currentImage?.metadata?.date_created) {
       return new Date(currentImage.metadata.date_created).toLocaleDateString(
@@ -44,18 +56,6 @@ export const MediaInfoPanel: React.FC<MediaInfoPanelProps> = ({
     if (!currentImage) return 'Image';
     // Handle both Unix (/) and Windows (\) path separators
     return currentImage.path?.split(/[/\\]/).pop() || 'Image';
-  };
-
-  const handleLocationClick = async () => {
-    if (currentImage?.metadata?.latitude && currentImage?.metadata?.longitude) {
-      const { latitude, longitude } = currentImage.metadata;
-      const url = `https://maps.google.com/?q=${latitude},${longitude}`;
-      try {
-        await open(url);
-      } catch (error) {
-        console.error('Failed to open map URL:', error);
-      }
-    }
   };
 
   if (!show) return null;
@@ -163,7 +163,7 @@ export const MediaInfoPanel: React.FC<MediaInfoPanelProps> = ({
             onClick={async () => {
               if (currentImage?.path) {
                 try {
-                  await open(currentImage.path);
+                  await openPath(currentImage.path);
                 } catch (error) {
                   console.error('Failed to open file:', error);
                 }
@@ -171,6 +171,7 @@ export const MediaInfoPanel: React.FC<MediaInfoPanelProps> = ({
             }}
           >
             Open Original File
+            <SquareArrowOutUpRight className="ml-2 inline h-4 w-4" />
           </button>
         </div>
       </div>


### PR DESCRIPTION
Fixes #688

❌ Problem

The Open Original File button was non-functional because:

@tauri-apps/plugin-shell only supports URLs, not local file paths

No backend-compatible mechanism existed for opening local files

Legacy tauri::api::shell::open API is removed in Tauri v2

✅ Solution

Migrated file and URL handling to @tauri-apps/plugin-opener, which provides native OS support in Tauri v2.

What this PR does

Introduces @tauri-apps/plugin-opener for native file and URL handling

Opens local images using the system’s default viewer

Reveals image files directly in the system file explorer

Opens location links in the default browser

Adds required Tauri capability permissions

Verification

Open Original File opens the image correctly

Open Folder reveals the file in the OS file manager

External location links open in the browser

Verified on Windows, macOS, and Linux

Impact

Restores expected functionality

Aligns file handling with current Tauri standards

Improves overall reliability and user experience

Related Issue

Closes #688

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now open location information from media files directly in Google Maps.

* **Bug Fixes**
  * Updated dependencies and refined file/URL opening mechanisms for improved stability.

* **Chores**
  * Expanded application permissions for opening files and external URLs; updated backend API documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->