### PR TITLE
require 1s hoverintent for feature cards, remove emoji cursor , preserve tap toggle 

### DIFF
--- a/landing-page/public/assets/gallery-screenshot.svg
+++ b/landing-page/public/assets/gallery-screenshot.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="700" viewBox="0 0 1200 700">
+  <defs>
+    <linearGradient id="g" x1="0" x2="1">
+      <stop offset="0" stop-color="#06b6d4"/>
+      <stop offset="1" stop-color="#34d399"/>
+    </linearGradient>
+  </defs>
+  <rect width="100%" height="100%" fill="#0f172a" rx="16"/>
+  <rect x="40" y="40" width="520" height="320" rx="8" fill="#ffffff10"/>
+  <rect x="680" y="40" width="480" height="320" rx="8" fill="#ffffff10"/>
+  <rect x="40" y="400" width="360" height="240" rx="8" fill="#ffffff10"/>
+  <rect x="440" y="400" width="360" height="240" rx="8" fill="#ffffff10"/>
+  <rect x="840" y="400" width="320" height="240" rx="8" fill="#ffffff10"/>
+  <g transform="translate(80,90)">
+    <rect width="140" height="90" rx="6" fill="url(#g)"/>
+    <rect x="160" y="0" width="120" height="90" rx="6" fill="#ffffff20"/>
+    <rect x="300" y="0" width="180" height="90" rx="6" fill="#ffffff20"/>
+  </g>
+  <text x="72" y="36" fill="#fff" font-family="Inter, Arial, sans-serif" font-size="20">Gallery screenshot (placeholder)</text>
+</svg>


### PR DESCRIPTION
Fixes the gallery feature cards accidentally expanding on short hover and removes the emoji cursor which produced unexpected pointer behavior across devices.
Desktop: cards now expand only after an intentional ~1 second hover (applies only to devices that support hover and have a fine pointer).
Touch / mobile: tap/click behavior preserved — immediate toggle on click/tap.
Replaced inline emoji cursor in source (and added a placeholder screenshot asset). Note: built production files in 
[dist](vscode-file://vscode-app/private/var/folders/57/xkrbhh5x4sd2nd524g0l77tc0000gn/T/AppTranslocation/1334B98B-69DA-4592-B371-52E1A4E370BB/d/Visual%20Studio%20Code-11.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
 may still include the old inline cursor until the project is rebuilt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced the "How It Works" section with hover-based step activation on desktop, automatically adjusted based on device type.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->