### PR TITLE
fix: add missing useEffect dependencies to prevent stale closures (fi…

### DIFF
--- a/frontend/src/components/OnboardingSteps/FolderSetupStep.tsx
+++ b/frontend/src/components/OnboardingSteps/FolderSetupStep.tsx
@@ -34,7 +34,7 @@ export function FolderSetupStep({
     if (localStorage.getItem('folderChosen') === 'true') {
       dispatch(markCompleted(stepIndex));
     }
-  }, []);
+  }, [dispatch, stepIndex]);
 
   const { pickSingleFolder, addFolderMutate } = useFolder({
     title: 'Select folder to import photos from',

--- a/frontend/src/pages/InitialSteps/InitialSteps.tsx
+++ b/frontend/src/pages/InitialSteps/InitialSteps.tsx
@@ -13,7 +13,7 @@ export const InitialSteps: React.FC = () => {
     if (currentStepIndex === -1) {
       navigate(ROUTES.HOME);
     }
-  }, [currentStepIndex]);
+  }, [currentStepIndex, navigate]);
 
   return (
     <OnboardingStep stepIndex={currentStepIndex} stepName={currentStepName} />


### PR DESCRIPTION
Closes #799

This PR fixes missing dependencies in `useEffect` hooks that violated React's Rules of Hooks and could cause stale closures in the onboarding flow.

##  Changes Made

### File 1: [frontend/src/components/OnboardingSteps/FolderSetupStep.tsx](cci:7://file:///c:/Users/Nithi/OneDrive/Desktop/gsoc/PictoPy/frontend/src/components/OnboardingSteps/FolderSetupStep.tsx:0:0-0:0)
**Before:**
```typescript
useEffect(() => {
  if (localStorage.getItem('folderChosen') === 'true') {
    dispatch(markCompleted(stepIndex));
  }
}, []);  //  Missing: dispatch, stepIndex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved step completion tracking during onboarding to properly synchronize with state changes.
  * Enhanced navigation responsiveness in the initial setup flow for better reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->