### PR TITLE
Fix #658: extend image viewer navigation hover and click area

### DIFF
--- a/docs/backend/backend_python/openapi.json
+++ b/docs/backend/backend_python/openapi.json
@@ -1117,9 +1117,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "$ref": "#/components/schemas/InputType",
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/InputType"
+                }
+              ],
               "description": "Choose input type: 'path' or 'base64'",
-              "default": "path"
+              "default": "path",
+              "title": "Input Type"
             },
             "description": "Choose input type: 'path' or 'base64'"
           }
@@ -2199,7 +2204,6 @@
           "metadata": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {

--- a/frontend/src/components/Media/NavigationButtons.tsx
+++ b/frontend/src/components/Media/NavigationButtons.tsx
@@ -12,20 +12,26 @@ export const NavigationButtons: React.FC<NavigationButtonsProps> = ({
 }) => {
   return (
     <>
+      {/* Previous */}
       <button
         onClick={onPrevious}
-        className="absolute top-1/2 left-4 z-30 flex -translate-y-1/2 transform cursor-pointer items-center rounded-full bg-black/30 p-3 text-white backdrop-blur-md transition-all duration-200 hover:bg-black/50 hover:shadow-lg"
         aria-label="Previous image"
+        className="group absolute top-1/2 left-0 z-30 flex h-40 w-40 -translate-y-1/2 items-center justify-center bg-transparent"
       >
-        <ChevronLeft className="h-6 w-6" />
+        <div className="pointer-events-none rounded-full bg-black/30 p-3 text-white backdrop-blur-md transition-all duration-200 group-hover:scale-110 group-hover:bg-black/50 group-hover:shadow-lg">
+          <ChevronLeft className="h-6 w-6" />
+        </div>
       </button>
 
+      {/* Next */}
       <button
         onClick={onNext}
-        className="absolute top-1/2 right-4 z-30 flex -translate-y-1/2 transform cursor-pointer items-center rounded-full bg-black/30 p-3 text-white backdrop-blur-md transition-all duration-200 hover:bg-black/50 hover:shadow-lg"
         aria-label="Next image"
+        className="group absolute top-1/2 right-0 z-30 flex h-40 w-40 -translate-y-1/2 items-center justify-center bg-transparent"
       >
-        <ChevronRight className="h-6 w-6" />
+        <div className="pointer-events-none rounded-full bg-black/30 p-3 text-white backdrop-blur-md transition-all duration-200 group-hover:scale-110 group-hover:bg-black/50 group-hover:shadow-lg">
+          <ChevronRight className="h-6 w-6" />
+        </div>
       </button>
     </>
   );


### PR DESCRIPTION
### Issue 

Closes #658

### Problem

Currently, the navigation arrows in the image preview / fullscreen mode only respond when the cursor is placed precisely on the icon. This requires pixel-perfect mouse positioning, which can feel unintuitive and cumbersome—especially when viewing large images or navigating quickly.

### Solution
This change introduces a larger, invisible interaction zone around each navigation arrow:

- Hovering anywhere within this zone highlights and slightly scales the arrow
- Clicking anywhere inside the zone triggers navigation
- The arrow’s visual size and layout remain unchanged

This behavior mirrors that of native photo viewers (e.g., Windows Photos, macOS Preview) and significantly improves overall UX.

**This change is purely UI/UX-focused and does not modify business logic or application state. No additional tests were added as the behavior is visual and interaction-based.**

https://github.com/user-attachments/assets/1dfbfcbd-0282-4caa-9b43-ab7b0fd2cbdf

This change makes image navigation feel more natural and forgiving, aligning PictoPy’s behavior with standard photo viewing experiences.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Redesigned Previous and Next navigation buttons with enhanced hover effects and improved visual feedback for better user interactions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->