### PR TITLE
#815: fix(logging): remove duplicate logger initialization in images utils 

### DIFF
--- a/backend/app/utils/images.py
+++ b/backend/app/utils/images.py
@@ -2,7 +2,6 @@ import os
 import uuid
 import datetime
 import json
-import logging
 from typing import List, Tuple, Dict, Any, Mapping
 from PIL import Image, ExifTags
 from pathlib import Path
@@ -26,7 +25,6 @@ logger = get_logger(__name__)
 # GPS EXIF tag constant
 GPS_INFO_TAG = 34853
 
-logger = logging.getLogger(__name__)
 
 
 def image_util_process_folder_images(folder_data: List[Tuple[str, int, bool]]) -> bool:


### PR DESCRIPTION
Fix duplicate logger initialization

 Problem
The images utility initialized the logger twice, overwriting the project’s
custom logging configuration.

 Solution
- Removed duplicate `logging.getLogger()` usage
- Removed unused `logging` import
- Kept only `get_logger(__name__)`

Result
Ensures consistent logging behavior and improves code quality.

Closes #815


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed redundant logging setup to streamline internal code structure and improve maintainability without affecting user-facing functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->