### PR TITLE
   fix: Remove duplicate logger initialization in images.py

### DIFF
--- a/backend/app/utils/images.py
+++ b/backend/app/utils/images.py
@@ -2,7 +2,6 @@ import os
 import uuid
 import datetime
 import json
-import logging
 from typing import List, Tuple, Dict, Any, Mapping
 from PIL import Image, ExifTags
 from pathlib import Path
@@ -25,8 +24,6 @@ logger = get_logger(__name__)
 
 # GPS EXIF tag constant
 GPS_INFO_TAG = 34853
-
-logger = logging.getLogger(__name__)
 
 
 def image_util_process_folder_images(folder_data: List[Tuple[str, int, bool]]) -> bool:


### PR DESCRIPTION
 Fix: Remove Duplicate Logger Initialization in `images.py`

Description
Fixes duplicate logger initialization in `backend/app/utils/images.py` that was causing the custom configured logger to be overwritten by a standard Python logger.

Changes Made
- Removed duplicate logger initialization on line 29 (`logger = logging.getLogger(__name__)`)
- Removed unused `import logging` statement
- Kept only the correct logger initialization using `get_logger(__name__)`

 Problem
The logger was initialized twice:
1. Line 23: `logger = get_logger(__name__)` (Correct - uses custom logger)
2. Line 29: `logger = logging.getLogger(__name__)` (Duplicate - overwrites custom logger)

This caused:
- Loss of custom logging configuration (color coding, component prefixes)
- Inconsistent logging behavior
- Unused import
- 
 Solution
- Single logger initialization using the project's custom `get_logger()` function
- Removed unused import
- Ensures consistent logging with proper formatting

Testing
- Verified logger works correctly with custom formatting
-  All linting checks passed (Ruff, Black)
-  Application tested: Add folder, enable AI tagging, face clusters all working
-  No breaking changes

Impact
- **Before**: Custom logger was overwritten, losing formatting and configuration
- **After**: Single, properly configured logger with consistent behavior


Closes #815 issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal logging infrastructure for better maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->