### PR TITLE
Fix: Connection leak in db_update_cluster() to prevent crashes in transactions

### DIFF
--- a/backend/app/database/face_clusters.py
+++ b/backend/app/database/face_clusters.py
@@ -226,7 +226,8 @@ def db_update_cluster(
         )
 
         updated = cursor.rowcount > 0
-        conn.commit()
+        if own_connection:
+            conn.commit()
         return updated
     finally:
         if own_connection:


### PR DESCRIPTION
Fixes #824 
Changes:
- Modified db_update_cluster() to only close connections it created (own_connection flag)
- Prevents premature closure of externally-managed connections
- Follows the same pattern used throughout the codebase

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database connection lifecycle: the system now only commits and closes connections it creates itself, avoiding unintended closure of externally provided connections and reducing integration errors with shared database resources.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->