### PR TITLE
Hover Background Color to Faq Containes in landing-page.

### DIFF
--- a/landing-page/src/Pages/FaqPage/FAQ.tsx
+++ b/landing-page/src/Pages/FaqPage/FAQ.tsx
@@ -100,8 +100,8 @@ function FAQItem({ question, answer, isOpen, onClick, index, icon }: FAQItemProp
   bg-white dark:bg-black
   border
   ${isOpen 
-    ? 'border- 6 border-pink-500 dark:border-grey-500' 
-    : 'border- 6 - dark:border-grey-500'}
+    ? 'border-6 border-pink-500 dark:border-gray-500' 
+    : 'border-6 border-gray-300 dark:border-gray-500'}
 `}
       initial={{ opacity: 0, y: 30 }}
       whileInView={{ opacity: 1, y: 0 }}


### PR DESCRIPTION
Adds a subtle pink border to the FAQ section container on click,
aligning its interaction feedback with Gallery feature hover behavior.

Supports both light and dark themes. 

<img width="1294" height="471" alt="Screenshot 2025-12-23 213118" src="https://github.com/user-attachments/assets/899e3876-d082-42c3-816f-680166a3bf90" />

<img width="1502" height="442" alt="Screenshot 2025-12-23 213129" src="https://github.com/user-attachments/assets/925d1613-aedd-41f2-a3ee-59a8870705c7" /> 

Open to feedback or further UI refinements if needed. 
closes #855 





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * FAQ items now use dynamic border styling that changes color and thickness when expanded or collapsed, replacing the previous hover-only border effect. This improves visual feedback for open/closed states, makes item state clearer at a glance, and provides a more consistent, responsive appearance during interaction.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->