### PR TITLE
Fix/silent image skip on thumbnail failure

### DIFF
--- a/backend/app/utils/images.py
+++ b/backend/app/utils/images.py
@@ -176,6 +176,12 @@ def image_util_prepare_image_records(
                     "isTagged": False,
                 }
             )
+        else:
+            # Thumbnail generation failed - log warning and skip image
+            logger.warning(
+                f"Image skipped: Failed to generate thumbnail for {image_path}. "
+                f"The image will not be added to the database."
+            )
 
     return image_records
 


### PR DESCRIPTION
## Problem
In the `image_util_prepare_image_records` function, when `image_util_generate_thumbnail()` returns `False` (indicating thumbnail generation failure), the code simply skips adding the image to `image_records` without logging any warning or error message. The user has no visibility into which images were skipped or why.

## Impact
- Images missing from database without user notification
- No visibility into which images failed to process
- Difficult to debug image import issues
- Users may not realize images are missing until they search for them

## Solution
Added explicit warning logging when thumbnail generation fails, so users are informed about skipped images.


## Testing
- [x] Tested with images that fail thumbnail generation (corrupted files, unsupported formats, etc.)
- [x] Verified warning messages appear in logs
- [x] Confirmed that valid images still process correctly
- [x] Ran prettier on frontend files
- [x] Ran pre-commit hooks (ruff, black) on backend files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes
fixes issue #843 
* **Bug Fixes**
  * Enhanced image processing error reporting. When image thumbnail generation fails, the system now logs explicit warning messages instead of silently skipping the file. This provides administrators with better visibility into processing failures and helps identify problematic images during import operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->