### PR TITLE
fix: remove duplicate logger initialization in images.py

### DIFF
--- a/backend/app/utils/images.py
+++ b/backend/app/utils/images.py
@@ -2,7 +2,6 @@ import os
 import uuid
 import datetime
 import json
-import logging
 from typing import List, Tuple, Dict, Any, Mapping
 from PIL import Image, ExifTags
 from pathlib import Path
@@ -25,8 +24,6 @@ logger = get_logger(__name__)
 
 # GPS EXIF tag constant
 GPS_INFO_TAG = 34853
-
-logger = logging.getLogger(__name__)
 
 
 def image_util_process_folder_images(folder_data: List[Tuple[str, int, bool]]) -> bool:


### PR DESCRIPTION
## Summary

Fixes #815 

Removes duplicate logger initialization in `backend/app/utils/images.py` that was causing the custom configured logger to be overwritten by a standard Python logger.

## Changes Made
- Removed duplicate `logger = logging.getLogger(__name__)` on line 29
- Removed unused `import logging` statement
- Kept the correct initialization: `logger = get_logger(__name__)`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization to enhance maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->