### PR TITLE
Fix: Maintain Center Alignment During Zoom & Reset (Issue #656)

### DIFF
--- a/docs/backend/backend_python/openapi.json
+++ b/docs/backend/backend_python/openapi.json
@@ -1117,9 +1117,14 @@
             "in": "query",
             "required": false,
             "schema": {
-              "$ref": "#/components/schemas/InputType",
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/InputType"
+                }
+              ],
               "description": "Choose input type: 'path' or 'base64'",
-              "default": "path"
+              "default": "path",
+              "title": "Input Type"
             },
             "description": "Choose input type: 'path' or 'base64'"
           }
@@ -2199,7 +2204,6 @@
           "metadata": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {

--- a/frontend/src/components/Media/ImageViewer.tsx
+++ b/frontend/src/components/Media/ImageViewer.tsx
@@ -32,48 +32,53 @@ export const ImageViewer = forwardRef<ImageViewerRef, ImageViewerProps>(
     }, [resetSignal]);
 
     return (
-      <TransformWrapper
-        ref={transformRef}
-        initialScale={1}
-        minScale={0.1}
-        maxScale={8}
-        centerOnInit
-        limitToBounds={false}
-      >
-        <TransformComponent
-          wrapperStyle={{
-            width: '100%',
-            height: '100%',
-            overflow: 'visible',
+      <div style={{ width: '100%', height: '100%' }}>
+        <TransformWrapper
+          ref={transformRef}
+          key={imagePath}
+          initialScale={1}
+          maxScale={10}
+          wheel={{
+            step: 0.15,
           }}
-          contentStyle={{
-            width: '100%',
-            height: '100%',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-          }}
+          centerOnInit
+          limitToBounds={false}
         >
-          <img
-            src={convertFileSrc(imagePath) || '/placeholder.svg'}
-            alt={alt}
-            draggable={false}
-            className="select-none"
-            onError={(e) => {
-              const img = e.target as HTMLImageElement;
-              img.onerror = null;
-              img.src = '/placeholder.svg';
+          <TransformComponent
+            wrapperStyle={{
+              width: '100%',
+              height: '100%',
+              overflow: 'visible',
             }}
-            style={{
-              maxWidth: '100%',
-              maxHeight: '100%',
-              objectFit: 'contain',
-              zIndex: 50,
-              transform: `rotate(${rotation}deg)`,
+            contentStyle={{
+              width: '100%',
+              height: '100%',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
             }}
-          />
-        </TransformComponent>
-      </TransformWrapper>
+          >
+            <img
+              src={convertFileSrc(imagePath) || '/placeholder.svg'}
+              alt={alt}
+              draggable={false}
+              className="select-none"
+              onError={(e) => {
+                const img = e.target as HTMLImageElement;
+                img.onerror = null;
+                img.src = '/placeholder.svg';
+              }}
+              style={{
+                maxWidth: '100%',
+                maxHeight: '100%',
+                objectFit: 'cover',
+                zIndex: 50,
+                transform: `rotate(${rotation}deg)`,
+              }}
+            />
+          </TransformComponent>
+        </TransformWrapper>
+      </div>
     );
   },
 );


### PR DESCRIPTION
## Fix: Maintain Center Alignment During Zoom & Reset (Issue #656)

This PR fixes the behavior where images would drift off-center after zooming or switching images.

### What was happening
- Zoom + pan state was being reused across images  
- When zooming back out, transforms were not being fully reset  
- Navigating to another image opened it already shifted/zoomed

### What this PR changes
- Always initialize images with a clean transform (center + default zoom)
- Reset transform when `resetSignal` or `imagePath` changes
- Prevent lingering pan values from affecting subsequent images

### Result
- Images always open centered  
- Zooming back out snaps cleanly back to center  
- Navigation between images feels natural and consistent

This brings the viewer behavior closer to typical image viewers and significantly improves UX.

Closes #656.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API schema documentation with refined parameter definitions and improved metadata validation constraints.

* **Enhancements**
  * Improved image viewer with enhanced zoom controls, expanded scaling capabilities, and optimized image rendering for better visual quality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->