### PR TITLE
Fix: Home button now scrolls to top smoothly on landing page (#856)

### DIFF
--- a/landing-page/src/App.tsx
+++ b/landing-page/src/App.tsx
@@ -15,7 +15,7 @@ import { ScrollProgress } from "./components/ui/ScrollProgress";
 
 function HomePage() {
   return (
-    <>
+    <div id="home">
       <Home /> {/* This will now render the Home component */}
       <ScrollProgress></ScrollProgress>
       <InteractiveDemo />
@@ -24,7 +24,7 @@ function HomePage() {
       <PictopyLanding />
       <FAQ />
       <Footer />
-    </>
+    </div>
   );
 }
 

--- a/landing-page/src/Pages/Landing page/Navbar.tsx
+++ b/landing-page/src/Pages/Landing page/Navbar.tsx
@@ -27,10 +27,14 @@ const NavLink: React.FC<NavLinkProps> = ({
       const element = document.getElementById(targetId);
 
       if (element) {
-        // Scroll to the element with smooth behavior
-        element.scrollIntoView({
+        // Scroll with offset to account for sticky navbar
+        const offset = 90;
+        const elementTop = element.getBoundingClientRect().top + window.scrollY;
+        const targetScroll = elementTop - offset;
+
+        window.scrollTo({
+          top: targetScroll,
           behavior: "smooth",
-          block: "start",
         });
       }
 
@@ -144,7 +148,7 @@ const Navbar: React.FC = () => {
 
             {/* Desktop Navigation */}
             <div className="hidden md:flex items-center space-x-8">
-              <NavLink to="/">Home</NavLink>
+              <NavLink to="#home" isScrollLink={true}>Home</NavLink>
 
               {/* Dark Mode Toggle Button */}
               <button
@@ -191,7 +195,7 @@ const Navbar: React.FC = () => {
         >
           <div className="pt-16 pb-6 px-4 space-y-6">
             <div className="space-y-4 flex flex-col items-start">
-              <NavLink to="/" onClick={() => setIsOpen(false)}>
+              <NavLink to="#home" isScrollLink={true} onClick={() => setIsOpen(false)}>
                 Home
               </NavLink>
               <NavLink to="#features" isScrollLink={true} onClick={() => setIsOpen(false)}>


### PR DESCRIPTION
### Summary
This PR fixes the issue where clicking **Home** on the landing page
did nothing when the user was already on `/`.

React Router does not trigger navigation if you are already on the
same route, so the scroll position was not reset.

### Changes
- Added `id="home"` at the top of the landing layout
- Updated the **Home** navbar item to use `#home` with `isScrollLink`
- Ensures smooth scrolling consistent with other section links

### Why this works
The navbar already implements smooth scrolling for section anchors.
By using `#home`, we reuse that logic and avoid router no-ops.

### Manual Testing
1. Open landing page
2. Scroll down
3. Click **Home**
4. Page scrolls smoothly back to the top (desktop + mobile)

Fixes #856

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced in-page navigation to smoothly scroll between sections while automatically accounting for the sticky navbar position, ensuring content remains fully visible when navigating.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->