### PR TITLE
Fix Home navbar button to scroll to top on landing page

### DIFF
--- a/landing-page/src/Pages/Landing page/Home1.tsx
+++ b/landing-page/src/Pages/Landing page/Home1.tsx
@@ -15,6 +15,7 @@ const ShuffleHero = () => {
 
   return (
     <section className="w-full px-8 py-12 grid grid-cols-1 md:grid-cols-2 items-center gap-8 max-w-6xl mx-auto bg-white dark:bg-black transition-colors duration-300">
+      <div id="home"></div>
       <div className="font-['Inter',_sans-serif]">
         <motion.span 
           initial={{ opacity: 0, y: 10 }}

--- a/landing-page/src/Pages/Landing page/Navbar.tsx
+++ b/landing-page/src/Pages/Landing page/Navbar.tsx
@@ -144,7 +144,7 @@ const Navbar: React.FC = () => {
 
             {/* Desktop Navigation */}
             <div className="hidden md:flex items-center space-x-8">
-              <NavLink to="/">Home</NavLink>
+              <NavLink to="#home" isScrollLink={true}>Home</NavLink>
 
               {/* Dark Mode Toggle Button */}
               <button


### PR DESCRIPTION
### What was fixed
The Home button in the landing page navbar did not scroll the page back to the top when clicked.

### Why it happened
The Home link routed to `/`, and when users were already on the landing page, React Router did not trigger navigation or reset the scroll position.

### How it was fixed
- Added a `home` anchor at the top of the landing page.
- Updated the Home navbar item to reuse the existing scroll-link behavior for smooth scrolling.

This keeps navigation consistent with other section links and avoids unnecessary routing logic.

Fixes #856

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Updated Home navigation link to use smooth in-page scrolling instead of page navigation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->