### PR TITLE
Fix: Prevent full page reload when clicking avatar/logo

### DIFF
--- a/frontend/src/components/Navigation/Navbar/Navbar.tsx
+++ b/frontend/src/components/Navigation/Navbar/Navbar.tsx
@@ -6,6 +6,8 @@ import { selectAvatar, selectName } from '@/features/onboardingSelectors';
 import { clearSearch } from '@/features/searchSlice';
 import { convertFileSrc } from '@tauri-apps/api/core';
 import { FaceSearchDialog } from '@/components/Dialog/FaceSearchDialog';
+import { Link } from 'react-router';
+import { ROUTES } from '@/constants/routes';
 
 export function Navbar() {
   const userName = useSelector(selectName);
@@ -20,10 +22,10 @@ export function Navbar() {
     <div className="sticky top-0 z-40 flex h-14 w-full items-center justify-between border-b pr-4 backdrop-blur">
       {/* Logo */}
       <div className="flex w-[256px] items-center justify-center">
-        <a href="/" className="flex items-center space-x-2">
+        <Link to={`/${ROUTES.HOME}`} className="flex items-center space-x-2">
           <img src="/128x128.png" width={32} height={32} alt="PictoPy Logo" />
           <span className="text-xl font-bold">PictoPy</span>
-        </a>
+        </Link>
       </div>
 
       {/* Search Bar */}
@@ -82,13 +84,13 @@ export function Navbar() {
           <span className="hidden text-sm sm:inline-block">
             Welcome <span className="text-muted-foreground">{userName}</span>
           </span>
-          <a href="/settings" className="p-2">
+          <Link to={`/${ROUTES.SETTINGS}`} className="p-2">
             <img
               src={userAvatar || '/photo1.png'}
               className="hover:ring-primary/50 h-8 w-8 cursor-pointer rounded-full transition-all hover:ring-2"
               alt="User avatar"
             />
-          </a>
+          </Link>
         </div>
       </div>
     </div>

--- a/landing-page/src/App.tsx
+++ b/landing-page/src/App.tsx
@@ -15,7 +15,7 @@ import { ScrollProgress } from "./components/ui/ScrollProgress";
 
 function HomePage() {
   return (
-    <>
+    <div id="home">
       <Home /> {/* This will now render the Home component */}
       <ScrollProgress></ScrollProgress>
       <InteractiveDemo />
@@ -24,7 +24,7 @@ function HomePage() {
       <PictopyLanding />
       <FAQ />
       <Footer />
-    </>
+    </div>
   );
 }
 

--- a/landing-page/src/Pages/Landing page/Navbar.tsx
+++ b/landing-page/src/Pages/Landing page/Navbar.tsx
@@ -27,10 +27,14 @@ const NavLink: React.FC<NavLinkProps> = ({
       const element = document.getElementById(targetId);
 
       if (element) {
-        // Scroll to the element with smooth behavior
-        element.scrollIntoView({
+        // Scroll with offset to account for sticky navbar
+        const offset = 90;
+        const elementTop = element.getBoundingClientRect().top + window.scrollY;
+        const targetScroll = elementTop - offset;
+
+        window.scrollTo({
+          top: targetScroll,
           behavior: "smooth",
-          block: "start",
         });
       }
 
@@ -144,7 +148,7 @@ const Navbar: React.FC = () => {
 
             {/* Desktop Navigation */}
             <div className="hidden md:flex items-center space-x-8">
-              <NavLink to="/">Home</NavLink>
+              <NavLink to="#home" isScrollLink={true}>Home</NavLink>
 
               {/* Dark Mode Toggle Button */}
               <button
@@ -191,7 +195,7 @@ const Navbar: React.FC = () => {
         >
           <div className="pt-16 pb-6 px-4 space-y-6">
             <div className="space-y-4 flex flex-col items-start">
-              <NavLink to="/" onClick={() => setIsOpen(false)}>
+              <NavLink to="#home" isScrollLink={true} onClick={() => setIsOpen(false)}>
                 Home
               </NavLink>
               <NavLink to="#features" isScrollLink={true} onClick={() => setIsOpen(false)}>


### PR DESCRIPTION
Problem

Clicking the avatar or logo triggered a full page reload (white flash)
because navigation used <a href> instead of React Router navigation.

Fix

Replaced <a href> with <Link> so navigation stays inside the SPA

No reload, smoother UX

Consistent with other internal routes

How to test

1️⃣ Open app
2️⃣ Click the avatar or logo
3️⃣ Navigation happens instantly — no white flash

Fixes: #864 

Before:

https://github.com/user-attachments/assets/41cfcfac-cf27-44ab-b848-5f6be2d5e0ce



After:

https://github.com/user-attachments/assets/e96dcbc7-3f88-4305-9e41-87fb624c6b22



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
* Improved navigation scroll behavior to properly account for sticky header offset, ensuring sections are fully visible when accessed via navigation links.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->