### PR TITLE
Improve type safety in FaceCollections.tsx by replacing `any` with `Cluster`

### DIFF
--- a/frontend/src/components/FaceCollections.tsx
+++ b/frontend/src/components/FaceCollections.tsx
@@ -54,7 +54,7 @@ export function FaceCollections() {
           to see all their photos.
         </p>
         <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8">
-          {clusters.map((cluster: any) => (
+          {clusters.map((cluster: Cluster) => (
             <div
               key={cluster.cluster_id}
               className="hover:bg-accent flex cursor-pointer flex-col items-center gap-2 rounded-lg p-4 transition-colors dark:hover:bg-white/10"


### PR DESCRIPTION
Fixes #888

### What
This PR improves type safety in the `FaceCollections.tsx` component by replacing `(cluster: any)` with `(cluster: Cluster)`, which is already imported. This ensures stronger typing, prevents misuse of cluster properties, and aligns with React best practices.

### Why
Using `any` weakens type safety and can lead to misuse of cluster properties.  
Replacing it with `Cluster` ensures stronger typing and aligns with best practices.

### Changes Made
- Updated `.map()` function to use `(cluster: Cluster)` instead of `(cluster: any)`
- Verified that `cluster.cluster_id` remains the key prop and is unique

### Testing
- ✅ AI Tagging view renders correctly
- ✅ Face collections display as expected
- ✅ No React key warnings observed in DevTools console

<img width="784" height="792" alt="Screenshot 2026-01-03 194417" src="https://github.com/user-attachments/assets/4760617b-eb6e-4cf3-8114-e0d14b9761b7" />
--> Console view after testing — no React key warning observed. The devtools permission error is unrelated to the component logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code quality improvements to enhance type safety and maintainability.

---

**Note:** This release contains no user-visible changes or new functionality. Updates are focused on internal code improvements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->