### PR TITLE
ui(empty-state): make Settings link clickable in empty gallery

### DIFF
--- a/frontend/src/components/EmptyStates/EmptyGalleryState.tsx
+++ b/frontend/src/components/EmptyStates/EmptyGalleryState.tsx
@@ -1,6 +1,6 @@
 import { FolderOpen, Image as ImageIcon } from 'lucide-react';
-import { useNavigate } from "react-router";
-import { ROUTES } from '@/constants/routes'; 
+import { useNavigate } from 'react-router';
+import { ROUTES } from '@/constants/routes';
 
 export const EmptyGalleryState = () => {
   const navigate = useNavigate();
@@ -21,14 +21,14 @@ export const EmptyGalleryState = () => {
         <div className="flex items-center gap-2">
           <FolderOpen className="h-4 w-4" />
           <span>
-            Go to{" "}
+            Go to{' '}
             <button
               type="button"
-              onClick={() => navigate(`/${ROUTES.SETTINGS}`)} 
-              className="text-blue-500 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 rounded"
+              onClick={() => navigate(`/${ROUTES.SETTINGS}`)}
+              className="rounded text-blue-500 hover:underline focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:outline-none"
             >
               Settings
-            </button>{" "}
+            </button>{' '}
             to add folders.
           </span>
         </div>


### PR DESCRIPTION
Fixes #965

## 🧭 Make “Settings” link clickable in empty gallery

### What
Makes the **“Go to Settings to add folders”** text in the empty gallery state clickable and navigates directly to the **Settings** page.

### Why
When users land on an empty gallery, adding folders is the next obvious action.  
Making the Settings link clickable reduces friction and improves first-time user experience.

### Scope
- UI-only change
- No backend changes
- No routing logic modified
- Limited to `EmptyGalleryState`

### Implementation
- Uses existing router navigation
- Only the word **Settings** is interactive for clarity and accessibility

---

## 📸 Screenshots

### Before
Plain text, not clickable.

![Before - Empty Gallery State](https://github.com/user-attachments/assets/832057ba-f6fb-4dd8-af11-34bbaf0b80ba)

### After
**Settings** is clickable and navigates directly to the Settings page.

![After - Clickable Settings Link](https://github.com/user-attachments/assets/ee37fc4e-f4d8-4ca1-8907-234833d4fe7d)

---

### Testing
- Verified navigation to Settings from empty gallery state
- No regressions observed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Empty gallery state now shows an interactive "Settings" button replacing static guidance; tapping it opens the Settings screen to configure folders, improving discoverability.

* **Chores**
  * Navigation behavior added to enable the Settings button; no changes to public component APIs or exported interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->