### PR TITLE
fix: Enable "Open Folder" button functionality

### DIFF
--- a/frontend/src/components/Media/MediaView.tsx
+++ b/frontend/src/components/Media/MediaView.tsx
@@ -87,7 +87,7 @@ export function MediaView({
     handleNextImage,
   );
 
-  // Folder Open functionality
+  /** Opens the system file explorer at the current image's location. */
   const handleOpenFolder = async () => {
     if (!currentImage?.path) return;
     try {

--- a/frontend/src/components/Media/MediaViewControls.tsx
+++ b/frontend/src/components/Media/MediaViewControls.tsx
@@ -13,6 +13,7 @@ interface MediaViewControlsProps {
   type?: string;
 }
 
+/** Control buttons for the full-screen media viewer. */
 export const MediaViewControls: React.FC<MediaViewControlsProps> = ({
   showInfo,
   onToggleInfo,


### PR DESCRIPTION
@rahulharpal1603 
Fixes #959 
- Implemented the non-functional "Open Folder" button in the full-screen image viewer.
- Used functionality from @tauri-apps/plugin-opener.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Open Folder" button to the media view toolbar that reveals the file location for the current item.
* **Bug Fixes**
  * Improved error reporting when the Open Folder action fails (now logs the underlying error).
* **Documentation**
  * Added brief component and function descriptions for media view controls.
* **Chores**
  * Other media controls (Info, Favorites, Slideshow, Close) remain available and unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->