### PR TITLE
refactor: use successData from usePictoQuery in Home

### DIFF
--- a/frontend/src/pages/Home/Home.tsx
+++ b/frontend/src/pages/Home/Home.tsx
@@ -22,7 +22,7 @@ export const Home = () => {
   const searchState = useSelector((state: RootState) => state.search);
   const isSearchActive = searchState.active;
 
-  const { data, isLoading, isSuccess, isError, error } = usePictoQuery({
+  const { successData, isLoading, isSuccess, isError, error } = usePictoQuery({
     queryKey: ['images'],
     queryFn: () => fetchAllImages(),
     enabled: !isSearchActive,
@@ -40,10 +40,9 @@ export const Home = () => {
 
   useEffect(() => {
     if (!isSearchActive && isSuccess) {
-      const images = data?.data as Image[];
-      dispatch(setImages(images));
+      dispatch(setImages(successData ?? []));
     }
-  }, [data, isSuccess, dispatch, isSearchActive]);
+  }, [successData, isSuccess, dispatch, isSearchActive]);
 
   const title =
     isSearchActive && images.length > 0


### PR DESCRIPTION
While reading through the Home page implementation, I noticed that the component was accessing `data?.data` directly even though `usePictoQuery` already exposes `successData` for this purpose.

This change updates the Home page to use `successData` instead, which better aligns with the abstraction provided by `usePictoQuery` and avoids the need for explicit casting in the component.

The behavior remains unchanged — images are still fetched, stored in Redux, and rendered in the gallery as before — but the code is now a bit cleaner and more consistent with the intended usage of the query hook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code quality and maintainability in the Home page component through updated variable naming and dependency management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->