### PR TITLE
fix: enable WebP image support in backend validation

### DIFF
--- a/backend/app/utils/images.py
+++ b/backend/app/utils/images.py
@@ -310,10 +310,11 @@ def image_util_find_folder_id_for_image(
 def image_util_is_valid_image(file_path: str) -> bool:
     """Check if the file is a valid image with allowed extensions."""
     # Check file extension first
-    allowed_extensions = {".jpg", ".jpeg", ".png"}
+    allowed_extensions = {".jpg", ".jpeg", ".png",".webp"}
     file_extension = Path(file_path).suffix.lower()
 
     if file_extension not in allowed_extensions:
+        # Unsupported image format
         return False
 
     # Then verify it's a valid image

--- a/frontend/src/components/EmptyStates/EmptyAITaggingState.tsx
+++ b/frontend/src/components/EmptyStates/EmptyAITaggingState.tsx
@@ -20,7 +20,7 @@ export const EmptyAITaggingState = () => {
         </div>
         <div className="flex items-center gap-2">
           <ImageIcon className="h-4 w-4" />
-          <span>Supports PNG, JPG, JPEG image formats.</span>
+          <span>Supports PNG, JPG, JPEG, WebP image formats.</span>
         </div>
       </div>
     </div>

--- a/frontend/src/components/EmptyStates/EmptyGalleryState.tsx
+++ b/frontend/src/components/EmptyStates/EmptyGalleryState.tsx
@@ -20,7 +20,7 @@ export const EmptyGalleryState = () => {
         </div>
         <div className="flex items-center gap-2">
           <ImageIcon className="h-4 w-4" />
-          <span>Supports PNG, JPG, JPEG image formats.</span>
+          <span>Supports PNG, JPG, JPEG, WebP image formats.</span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Closes #973 

## Summary
This PR adds official WebP image support to PictoPy by extending backend image validation.
Pillow already supports WebP decoding, so no changes were required to the image processing,
tagging, or face clustering pipelines.

## Changes
- Allow `.webp` images in backend image validation
- Update UI empty-state text to reflect WebP support

## Notes
- Folder-based imports rely on backend validation only, so no frontend upload changes were required
- Existing PNG/JPG/JPEG functionality remains unaffected

## Testing
- Imported folders containing WebP images
- Verified WebP images are visible and processed correctly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended image format support to include WebP, allowing users to upload WebP images in addition to PNG, JPG, and JPEG formats.

* **UI Improvements**
  * Updated help text and empty state messages to inform users that WebP format is now supported for image uploads and processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->