### PR TITLE
Fixed double scroll-bar issue

### DIFF
--- a/frontend/src/layout/layout.tsx
+++ b/frontend/src/layout/layout.tsx
@@ -20,7 +20,7 @@ const Layout: React.FC = () => {
         <Navbar />
         <div className="flex" style={{ height: 'calc(100vh - 56px)' }}>
           <AppSidebar />
-          <div className="m-4 w-full overflow-y-auto">
+          <div className="m-4 w-full">
             <Outlet />
           </div>
         </div>


### PR DESCRIPTION
Fixes #941

Problem: 
When the window was maximized, two vertical scrollbars appeared, causing confusing UX and layout overflow.

Cause: 
The issue was caused by nested containers applying "overflow-y-auto" simultaneously, resulting in multiple scroll contexts.

Solution: 
Removed redundant overflow handling and ensured a single scroll container at the layout level. 

Result:
Scroll behavior is now consistent across window sizes with a single scrollbar.

Before:
https://github.com/user-attachments/assets/44a31e0d-a618-48b0-a634-9f798818b9cc

After:
https://github.com/user-attachments/assets/328601f9-d69a-438e-ae3a-035d3047ea4e

I've included before and after recordings to clearly demonstrate the issue and the fix. Please let me know if you'd like the solution
handled differently or split further.


