### PR TITLE
Fix app reload and white flash caused by navbar navigation

### DIFF
--- a/frontend/src/components/Navigation/Navbar/Navbar.tsx
+++ b/frontend/src/components/Navigation/Navbar/Navbar.tsx
@@ -6,6 +6,7 @@ import { selectAvatar, selectName } from '@/features/onboardingSelectors';
 import { clearSearch } from '@/features/searchSlice';
 import { convertFileSrc } from '@tauri-apps/api/core';
 import { FaceSearchDialog } from '@/components/Dialog/FaceSearchDialog';
+import {Link} from 'react-router';
 
 export function Navbar() {
   const userName = useSelector(selectName);
@@ -20,10 +21,10 @@ export function Navbar() {
     <div className="sticky top-0 z-40 flex h-14 w-full items-center justify-between border-b pr-4 backdrop-blur">
       {/* Logo */}
       <div className="flex w-[256px] items-center justify-center">
-        <a href="/" className="flex items-center space-x-2">
+        <Link to="/" className="flex items-center space-x-2">
           <img src="/128x128.png" width={32} height={32} alt="PictoPy Logo" />
           <span className="text-xl font-bold">PictoPy</span>
-        </a>
+        </Link>
       </div>
 
       {/* Search Bar */}
@@ -82,13 +83,13 @@ export function Navbar() {
           <span className="hidden text-sm sm:inline-block">
             Welcome <span className="text-muted-foreground">{userName}</span>
           </span>
-          <a href="/settings" className="p-2">
+          <Link to="/settings" className="p-2">
             <img
               src={userAvatar || '/photo1.png'}
               className="hover:ring-primary/50 h-8 w-8 cursor-pointer rounded-full transition-all hover:ring-2"
               alt="User avatar"
             />
-          </a>
+          </Link>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This PR fixes the white flash and full app reload that occur when navigating using the Navbar.

Previously, clicking the app logo or the profile/avatar icon triggered a full page reload, which caused the app to briefly show a white screen, render the Home / empty gallery state, and re-run startup logic such as the update check.

The root cause was internal navigation using full page links instead of router-based navigation.

What was changed
- Replaced internal Navbar links with router-based navigation
- Ensured navigation to Home (logo click) and Settings/Profile happens without reloading the app

Result
- No white flash during navigation
- No unnecessary app reloads
- Smoother and more consistent user experience

Fixes #1020 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated navigation component to enhance routing efficiency and responsiveness.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->