### PR TITLE
docs: document supported Python version to improve Windows onboarding

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,9 @@ PictoPy documentation uses MkDocs with the Material theme and the Swagger UI plu
 
 To set up and run the docs website on your local machine:
 
-1. Ensure you have **Python 3** and **pip** installed. Navigate to the `/docs` folder.
+1. Ensure you are using a supported Python version and have **pip** installed.  
+   The supported Python version for the backend is documented in the README.  
+   Navigate to the `/docs` folder.
 2. Create a virtual environment:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ PictoPy is an advanced desktop gallery application that combines the power of Ta
 
 Handles file system operations and provides a secure bridge between the frontend and local system.
 
+## Supported Python Versions (Backend)
+
+The PictoPy backend is tested and known to work with:
+
+- **Python 3.11**
+
+Using older or newer Python versions (for example, Python 3.9 or Python 3.13+) may lead to dependency installation or build issues, especially on Windows.
+
+
 ## Features
 
 - Smart tagging of photos based on detected objects, faces, and their recognition


### PR DESCRIPTION
This PR documents the Python version that is tested and known to work with the PictoPy backend.

Motivation:
- New contributors may use unsupported Python versions (e.g. 3.9 or 3.13+)
- This leads to avoidable dependency installation failures, especially on Windows
- CI currently runs backend and sync-microservice builds using Python 3.11, but this was undocumented

Changes:
- Added a Supported Python Versions section to README
- Added a reference in CONTRIBUTING.md

Fixes #1055


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation setup instructions with improved Python environment requirements, including explicit pip references and clearer links to backend Python version information
  * Introduced new section detailing supported backend Python versions (3.11), with comprehensive compatibility notes highlighting potential issues with older versions (3.9) and newer versions (3.13+), with particular attention to Windows system considerations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->