### PR TITLE
docs: align frontend setup docs with working video setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,9 @@ PictoPy documentation uses MkDocs with the Material theme and the Swagger UI plu
 
 To set up and run the docs website on your local machine:
 
-1. Ensure you have **Python 3** and **pip** installed. Navigate to the `/docs` folder.
+1. Ensure you are using a supported Python version and have **pip** installed.  
+   The supported Python version for the backend is documented in the README.  
+   Navigate to the `/docs` folder.
 2. Create a virtual environment:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ PictoPy is an advanced desktop gallery application that combines the power of Ta
 
 Handles file system operations and provides a secure bridge between the frontend and local system.
 
+## Supported Python Versions (Backend)
+
+The PictoPy backend is tested and known to work with:
+
+- **Python 3.11**
+
+Using older or newer Python versions (for example, Python 3.9 or Python 3.13+) may lead to dependency installation or build issues, especially on Windows.
+
+
 ## Features
 
 - Smart tagging of photos based on detected objects, faces, and their recognition


### PR DESCRIPTION
Problem:
The written frontend setup guides require running both the backend and the sync-microservice, but this does not match the working setup shown in the official video. Following the docs causes frontend confusion and onboarding friction.

Solution:
- Documented a minimum working frontend development setup using `fastapi dev`
- Clearly marked the sync-microservice as optional and advanced
- Added warnings explaining potential issues when running both services together
- Aligned Manual Setup, Script Setup, and README guidance

This makes frontend onboarding clearer, especially for new and Windows contributors.

Closes #963


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup instructions to clarify Python version requirements.
  * Added documentation of supported Python versions for the backend (Python 3.11), including notes on potential compatibility issues with other versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->