### PR TITLE
feat: Add pagination support for image gallery API

### DIFF
--- a/frontend/src/api/api-functions/images.ts
+++ b/frontend/src/api/api-functions/images.ts
@@ -1,12 +1,68 @@
 import { imagesEndpoints } from '../apiEndpoints';
 import { apiClient } from '../axiosConfig';
-import { APIResponse } from '@/types/API';
+import { APIResponse, PaginatedAPIResponse } from '@/types/API';
+import { Image } from '@/types/Media';
 
+export interface FetchImagesParams {
+  tagged?: boolean;
+  page?: number;
+  limit?: number;
+}
+
+/**
+ * Fetch images from the API with optional pagination.
+ *
+ * @param params - Optional parameters for filtering and pagination
+ * @param params.tagged - Filter by tagged status
+ * @param params.page - Page number (1-indexed)
+ * @param params.limit - Number of images per page
+ * @returns APIResponse or PaginatedAPIResponse depending on whether pagination params are provided
+ */
 export const fetchAllImages = async (
+  params?: FetchImagesParams | boolean,
+): Promise<APIResponse | PaginatedAPIResponse<Image>> => {
+  // Handle backward compatibility: if params is a boolean, treat it as tagged filter
+  const queryParams: Record<string, unknown> = {};
+
+  if (typeof params === 'boolean') {
+    queryParams.tagged = params;
+  } else if (params) {
+    if (params.tagged !== undefined) {
+      queryParams.tagged = params.tagged;
+    }
+    if (params.page !== undefined) {
+      queryParams.page = params.page;
+    }
+    if (params.limit !== undefined) {
+      queryParams.limit = params.limit;
+    }
+  }
+
+  const response = await apiClient.get<
+    APIResponse | PaginatedAPIResponse<Image>
+  >(imagesEndpoints.getAllImages, { params: queryParams });
+  return response.data;
+};
+
+/**
+ * Fetch paginated images from the API.
+ *
+ * @param page - Page number (1-indexed)
+ * @param limit - Number of images per page (default: 50)
+ * @param tagged - Optional filter by tagged status
+ * @returns PaginatedAPIResponse with images and pagination info
+ */
+export const fetchPaginatedImages = async (
+  page: number,
+  limit: number = 50,
   tagged?: boolean,
-): Promise<APIResponse> => {
-  const params = tagged !== undefined ? { tagged } : {};
-  const response = await apiClient.get<APIResponse>(
+): Promise<PaginatedAPIResponse<Image>> => {
+  const params: Record<string, unknown> = { page, limit };
+  if (tagged !== undefined) {
+    params.tagged = tagged;
+  }
+
+  const response = await apiClient.get<PaginatedAPIResponse<Image>>(
     imagesEndpoints.getAllImages,
     { params },
   );

--- a/frontend/src/features/imageSelectors.ts
+++ b/frontend/src/features/imageSelectors.ts
@@ -9,6 +9,21 @@ export const selectImages = (state: RootState) => {
 export const selectCurrentViewIndex = (state: RootState) =>
   state.images.currentViewIndex;
 
+// Pagination selectors
+export const selectPagination = (state: RootState) => state.images.pagination;
+
+export const selectCurrentPage = (state: RootState) =>
+  state.images.pagination.page;
+
+export const selectHasNextPage = (state: RootState) =>
+  state.images.pagination.hasNext;
+
+export const selectIsLoadingMore = (state: RootState) =>
+  state.images.pagination.isLoadingMore;
+
+export const selectTotalCount = (state: RootState) =>
+  state.images.pagination.totalCount;
+
 // Memoized selectors
 export const selectIsImageViewOpen = createSelector(
   [selectCurrentViewIndex],

--- a/frontend/src/features/imageSlice.ts
+++ b/frontend/src/features/imageSlice.ts
@@ -1,14 +1,37 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { Image } from '@/types/Media';
+import { PaginationInfo } from '@/types/API';
+
+interface PaginationState {
+  page: number;
+  limit: number;
+  totalCount: number;
+  totalPages: number;
+  hasNext: boolean;
+  hasPrevious: boolean;
+  isLoadingMore: boolean;
+}
 
 interface ImageState {
   images: Image[];
   currentViewIndex: number;
+  pagination: PaginationState;
 }
+
+const initialPaginationState: PaginationState = {
+  page: 1,
+  limit: 50,
+  totalCount: 0,
+  totalPages: 0,
+  hasNext: false,
+  hasPrevious: false,
+  isLoadingMore: false,
+};
 
 const initialState: ImageState = {
   images: [],
   currentViewIndex: -1,
+  pagination: initialPaginationState,
 };
 
 const imageSlice = createSlice({
@@ -17,6 +40,41 @@ const imageSlice = createSlice({
   reducers: {
     setImages(state, action: PayloadAction<Image[]>) {
       state.images = action.payload;
+    },
+
+    // Append images for infinite scroll (adds to existing images)
+    appendImages(state, action: PayloadAction<Image[]>) {
+      state.images = [...state.images, ...action.payload];
+    },
+
+    // Set pagination info from API response
+    setPagination(state, action: PayloadAction<PaginationInfo>) {
+      state.pagination = {
+        page: action.payload.page,
+        limit: action.payload.limit,
+        totalCount: action.payload.total_count,
+        totalPages: action.payload.total_pages,
+        hasNext: action.payload.has_next,
+        hasPrevious: action.payload.has_previous,
+        isLoadingMore: false,
+      };
+    },
+
+    // Set loading state for infinite scroll
+    setLoadingMore(state, action: PayloadAction<boolean>) {
+      state.pagination.isLoadingMore = action.payload;
+    },
+
+    // Increment page for next fetch
+    incrementPage(state) {
+      if (state.pagination.hasNext) {
+        state.pagination.page += 1;
+      }
+    },
+
+    // Reset pagination to initial state
+    resetPagination(state) {
+      state.pagination = initialPaginationState;
     },
 
     setCurrentViewIndex(state, action: PayloadAction<number>) {
@@ -39,11 +97,21 @@ const imageSlice = createSlice({
     clearImages(state) {
       state.images = [];
       state.currentViewIndex = -1;
+      state.pagination = initialPaginationState;
     },
   },
 });
 
-export const { setImages, setCurrentViewIndex, closeImageView, clearImages } =
-  imageSlice.actions;
+export const {
+  setImages,
+  appendImages,
+  setPagination,
+  setLoadingMore,
+  incrementPage,
+  resetPagination,
+  setCurrentViewIndex,
+  closeImageView,
+  clearImages,
+} = imageSlice.actions;
 
 export default imageSlice.reducer;

--- a/frontend/src/types/API.ts
+++ b/frontend/src/types/API.ts
@@ -6,3 +6,20 @@ export interface APIResponse {
   error?: string;
   message?: string;
 }
+
+export interface PaginationInfo {
+  page: number;
+  limit: number;
+  total_count: number;
+  total_pages: number;
+  has_next: boolean;
+  has_previous: boolean;
+}
+
+export interface PaginatedAPIResponse<T> {
+  data: T[];
+  success: boolean;
+  message?: string;
+  error?: string;
+  pagination: PaginationInfo;
+}


### PR DESCRIPTION
## Summary

Implements pagination for the image gallery API to improve performance with large photo collections.

## Changes

### Backend
- Updated `db_get_all_images()` to support `page` and `limit` parameters
- Added `PaginationInfo` response model
- Backward compatible - existing code without pagination params still works

### Frontend
- Added `PaginationInfo` and `PaginatedAPIResponse` types
- Added `fetchPaginatedImages()` function
- Updated Redux state with pagination actions
- Implemented infinite scroll using Intersection Observer
- Updated Home and AI Tagging pages

## API Usage
GET /images/?page=1&limit=50 # First 50 images
GET /images/?page=2&limit=50 # Next 50 images
GET /images/?page=1&limit=50&tagged=true # Paginated tagged images



## Testing

- [x] Tested locally
- [x] Pagination works correctly
- [x] Infinite scroll loads more images
- [x] No linter errors

Closes #1065

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added infinite scroll functionality to image galleries—images automatically load as users scroll down
  * Enabled pagination support for more efficient image browsing and loading across the platform

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->