### PR TITLE
fix: highlight missing folders in settings

### DIFF
--- a/backend/app/routes/folders.py
+++ b/backend/app/routes/folders.py
@@ -450,6 +450,8 @@ def get_all_folders():
                 ai_tagging,
                 tagging_completed,
             ) = folder_data
+            # Check if folder path still exists on filesystem
+            folder_exists = os.path.isdir(folder_path)
             folders.append(
                 FolderDetails(
                     folder_id=folder_id,
@@ -458,6 +460,7 @@ def get_all_folders():
                     last_modified_time=last_modified_time,
                     AI_Tagging=ai_tagging,
                     taggingCompleted=tagging_completed,
+                    exists=folder_exists,
                 )
             )
 

--- a/backend/app/schemas/folders.py
+++ b/backend/app/schemas/folders.py
@@ -30,6 +30,7 @@ class FolderDetails(BaseModel):
     last_modified_time: int
     AI_Tagging: bool
     taggingCompleted: Optional[bool] = None
+    exists: bool = True
 
 
 class GetAllFoldersData(BaseModel):

--- a/backend/tests/test_folders.py
+++ b/backend/tests/test_folders.py
@@ -586,11 +586,13 @@ class TestFoldersAPI:
     # ============================================================================
 
     @patch("app.routes.folders.db_get_all_folder_details")
+    @patch("app.routes.folders.os.path.isdir")
     def test_get_all_folders_success(
-        self, mock_get_all_folders, client, sample_folder_details
+        self, mock_isdir, mock_get_all_folders, client, sample_folder_details
     ):
         """Test successfully retrieving all folders."""
         mock_get_all_folders.return_value = sample_folder_details
+        mock_isdir.return_value = True
 
         response = client.get("/folders/all-folders")
 
@@ -608,8 +610,10 @@ class TestFoldersAPI:
         assert first_folder["parent_folder_id"] is None
         assert first_folder["AI_Tagging"] is True
         assert first_folder["taggingCompleted"] is False
+        assert first_folder["exists"] is True
 
         mock_get_all_folders.assert_called_once()
+        assert mock_isdir.call_count == 2
 
     @patch("app.routes.folders.db_get_all_folder_details")
     def test_get_all_folders_empty(self, mock_get_all_folders, client):

--- a/docs/backend/backend_python/openapi.json
+++ b/docs/backend/backend_python/openapi.json
@@ -1686,6 +1686,11 @@
               }
             ],
             "title": "Taggingcompleted"
+          },
+          "exists": {
+            "type": "boolean",
+            "title": "Exists",
+            "default": true
           }
         },
         "type": "object",

--- a/frontend/src/hooks/useFolderOperations.tsx
+++ b/frontend/src/hooks/useFolderOperations.tsx
@@ -25,6 +25,8 @@ export const useFolderOperations = () => {
   const foldersQuery = usePictoQuery({
     queryKey: ['folders'],
     queryFn: getAllFolders,
+    // Ensure we re-check filesystem existence when navigating back to Settings
+    refetchOnMount: 'always',
   });
 
   const taggingStatusQuery = usePictoQuery({

--- a/frontend/src/pages/SettingsPage/components/FolderManagementCard.tsx
+++ b/frontend/src/pages/SettingsPage/components/FolderManagementCard.tsx
@@ -37,11 +37,14 @@ const FolderManagementCard: React.FC = () => {
     >
       {folders.length > 0 ? (
         <div className="space-y-3">
-          {folders.map((folder: FolderDetails, index: number) => (
-            <div
-              key={index}
-              className="group border-border bg-background/50 relative rounded-lg border p-4 transition-all hover:border-gray-300 hover:shadow-sm dark:hover:border-gray-600"
-            >
+          {folders.map((folder: FolderDetails, index: number) => {
+            const isMissing = folder.exists === false;
+
+            return (
+              <div
+                key={index}
+                className="group border-border bg-background/50 relative rounded-lg border p-4 transition-all hover:border-gray-300 hover:shadow-sm dark:hover:border-gray-600"
+              >
               <div className="flex items-center justify-between">
                 <div className="min-w-0 flex-1">
                   <div className="flex items-center gap-3">
@@ -49,6 +52,11 @@ const FolderManagementCard: React.FC = () => {
                     <span className="text-foreground truncate">
                       {folder.folder_path}
                     </span>
+                    {folder.exists === false && (
+                      <span className="rounded bg-red-100 px-2 py-0.5 text-xs font-medium text-red-700 dark:bg-red-900/30 dark:text-red-300">
+                        Missing
+                      </span>
+                    )}
                   </div>
                 </div>
 
@@ -62,7 +70,9 @@ const FolderManagementCard: React.FC = () => {
                       checked={folder.AI_Tagging}
                       onCheckedChange={() => toggleAITagging(folder)}
                       disabled={
-                        enableAITaggingPending || disableAITaggingPending
+                        enableAITaggingPending ||
+                        disableAITaggingPending ||
+                        folder.exists === false
                       }
                     />
                   </div>
@@ -71,7 +81,11 @@ const FolderManagementCard: React.FC = () => {
                     onClick={() => deleteFolder(folder.folder_id)}
                     variant="outline"
                     size="sm"
-                    className="h-8 w-8 cursor-pointer text-gray-500 hover:border-red-300 hover:text-red-600 dark:text-gray-400 dark:hover:text-red-400"
+                    className={
+                      isMissing
+                        ? 'h-8 w-8 cursor-pointer border-red-300 bg-red-50 text-red-700 hover:border-red-400 hover:bg-red-100 hover:text-red-800 dark:border-red-900/50 dark:bg-red-900/20 dark:text-red-300 dark:hover:bg-red-900/30'
+                        : 'h-8 w-8 cursor-pointer text-gray-500 hover:border-red-300 hover:text-red-600 dark:text-gray-400 dark:hover:text-red-400'
+                    }
                     disabled={deleteFolderPending}
                   >
                     <Trash2 className="h-4 w-4" />
@@ -113,8 +127,9 @@ const FolderManagementCard: React.FC = () => {
                   />
                 </div>
               )}
-            </div>
-          ))}
+              </div>
+            );
+          })}
         </div>
       ) : (
         <div className="py-8 text-center">

--- a/frontend/src/types/Folder.ts
+++ b/frontend/src/types/Folder.ts
@@ -5,6 +5,7 @@ export interface FolderDetails {
   last_modified_time: number;
   AI_Tagging: boolean;
   taggingCompleted?: boolean;
+  exists?: boolean;
 }
 
 export interface GetAllFoldersData {


### PR DESCRIPTION
## Summary
Adds filesystem existence detection for saved folders and improves Settings → Folder Management UI to clearly indicate missing folders.

## Changes
- Backend: `GET /folders/all-folders` now returns `exists` for each folder (checked via filesystem).
- Frontend: shows a red **Missing** badge for folders that no longer exist.
- Frontend: disables AI tagging toggle for missing folders.
- Frontend: highlights the delete button for missing folders to encourage cleanup.
- Frontend: folder list refetches when opening Settings (so existence is re-checked).

## How to test
1. Add Folder A and Folder B in Settings.
2. Delete Folder A from your file manager.
3. Open Settings → Folder A shows **Missing**, AI toggle disabled, delete button highlighted.
4. Click delete → Folder A is removed from PictoPy.

<img width="1225" height="474" alt="Screenshot 2026-01-26 183612" src="https://github.com/user-attachments/assets/5c3bb2a5-56cd-4520-8f0f-07e3e8f7ca7a" />


Closes #1081 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * System now detects and displays when folders no longer exist on the filesystem with a "Missing" badge indicator
  * AI Tagging toggle is disabled for missing folders to prevent operations on unavailable paths
  * Delete button is visually highlighted (red styling) when a folder is missing

* **Improvements**
  * Settings page refreshes folder status validation when revisited to ensure real-time accuracy

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->