### PR TITLE
Docs: document supported Python version for backend

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,9 @@ PictoPy documentation uses MkDocs with the Material theme and the Swagger UI plu
 
 To set up and run the docs website on your local machine:
 
-1. Ensure you have **Python 3** and **pip** installed. Navigate to the `/docs` folder.
+1. Ensure you have **Python 3.11** and **pip** installed. Navigate to the `/docs` folder.
+> ⚠️ Using other Python versions may lead to dependency installation or runtime issues, especially on Windows.
+
 2. Create a virtual environment:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ PictoPy is an advanced desktop gallery application that combines the power of Ta
 - **ONNX Runtime**: Runs the models efficiently
 - **DBSCAN**: Performs clustering for face embeddings
 
+#### ⚠️ Supported Python Version
+
+The PictoPy backend is currently tested and validated with **Python 3.11**.
+
+Using other Python versions may lead to dependency installation or runtime issues, especially on Windows.
+
+Known compatibility notes:
+- **Python ≤ 3.9**: incompatible dependency versions  
+- **Python ≥ 3.13**: some dependencies (e.g. `onnxruntime`, `numpy`) may not yet provide Windows wheels
+
 ### Backend (Rust via Tauri)
 
 Handles file system operations and provides a secure bridge between the frontend and local system.


### PR DESCRIPTION
Fixes #1055

###What this PR does

- Adds a “Supported Python Versions” section to README.md
- Adds a reference in CONTRIBUTING.md to clarify backend Python compatibility
- Focuses on helping new contributors avoid installation errors, especially on Windows
- Makes Python version requirements explicit (3.11 supported, others may fail)

###Context

New contributors may use unsupported Python versions (e.g., 3.9 or 3.13+) when setting up the backend.
CI currently runs backend and sync-microservice builds using Python 3.11, but this was not documented.
On Windows, using unsupported Python versions often leads to dependency installation failures or confusing errors.

###Solution

This PR updates documentation:

- README.md – Adds a clear section “Supported Python Versions” with compatibility notes
- CONTRIBUTING.md – Adds a note pointing to the supported backend Python versions

###Tested

- Verified README.md displays the supported Python version section correctly
- Verified CONTRIBUTING.md references the backend Python version
- Checked formatting and links in MkDocs docs website setup