### PR TITLE
Fix cargo:check script pointing to wrong directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint:fix": "cd frontend && eslint --max-warnings 0 --config .eslintrc.json . --fix",
     "format:fix": "cd frontend && prettier --write \"**/*.{ts,tsx,json}\"",
     "format:check": "cd frontend && prettier --check \"**/*.{ts,tsx,json}\"",
-    "cargo:check": "cd backend && cargo check",
+    "cargo:check": "cd frontend/src-tauri && cargo check",
     "setup": "cd scripts && node setup.js"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes #1088 

The `cargo:check` script was trying to run in the `backend/` directory, but that's where the Python code lives. The Rust code is actually in `frontend/src-tauri/`, so the script was failing with a "manifest not found" error.

Changed the script to point to the correct location. Tested it and it works now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build verification process to run from the frontend source directory. This change realigns the development workflow with the project structure, improving consistency and reliability across the build system while enhancing overall development efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->