### PR TITLE
fix: fixed hardcoded copyright year

### DIFF
--- a/frontend/src/components/Navigation/Sidebar/AppSidebar.tsx
+++ b/frontend/src/components/Navigation/Sidebar/AppSidebar.tsx
@@ -87,7 +87,7 @@ export function AppSidebar() {
       <SidebarFooter className="border-border/40 mt-auto border-t py-4">
         <div className="text-muted-foreground space-y-1 px-4 text-xs">
           <div className="font-medium">PictoPy v{version}</div>
-          <div>© 2025 PictoPy</div>
+          <div>© {new Date().getFullYear()} PictoPy</div>
         </div>
       </SidebarFooter>
     </Sidebar>


### PR DESCRIPTION
@raghavpuri31 
Fixes: #1092 
Fixed hardcoded copyright year in the codebase.
Change:
// Before
<div>© 2025 PictoPy</div>

// After
<div>© {new Date().getFullYear()} PictoPy</div>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated sidebar copyright notice to automatically display the current year.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->