### PR TITLE
fix: move image_util_parse_metadata import to global scope

### DIFF
--- a/backend/app/database/images.py
+++ b/backend/app/database/images.py
@@ -7,6 +7,7 @@ from app.config.settings import (
     DATABASE_PATH,
 )
 from app.logging.setup_logging import get_logger
+from app.utils.images import image_util_parse_metadata
 
 # Initialize logger
 logger = get_logger(__name__)
@@ -176,8 +177,6 @@ def db_get_all_images(tagged: Union[bool, None] = None) -> List[dict]:
         ) in results:
             if image_id not in images_dict:
                 # Safely parse metadata JSON -> dict
-                from app.utils.images import image_util_parse_metadata
-
                 metadata_dict = image_util_parse_metadata(metadata)
 
                 images_dict[image_id] = {
@@ -242,8 +241,6 @@ def db_get_untagged_images() -> List[UntaggedImageRecord]:
 
         untagged_images = []
         for image_id, path, folder_id, thumbnail_path, metadata in results:
-            from app.utils.images import image_util_parse_metadata
-
             md = image_util_parse_metadata(metadata)
             untagged_images.append(
                 {


### PR DESCRIPTION
Fixes #1108

Moved the image_util_parse_metadata import from inside loops to the top of the file (global scope). While Python caches module imports, importing inside tight loops is considered bad practice and adds unnecessary overhead when iterating over thousands of images.

Changes:
- Added import at line 10 with other app-specific imports
- Removed redundant import inside db_get_all_images() loop (was line 179)
- Removed redundant import inside db_get_untagged_images() loop (was line 245)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code organization improvements for better maintainability with no end-user impact.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->