### PR TITLE
fix typo PictoCopy's

### DIFF
--- a/landing-page/src/Pages/FaqPage/FAQ.tsx
+++ b/landing-page/src/Pages/FaqPage/FAQ.tsx
@@ -59,7 +59,7 @@ export default function FAQ() {
             Frequently Asked Questions
           </h2>
           <p className="max-w-2xl mx-auto text-lg text-gray-600 dark:text-gray-300">
-            Everything you need to know about PictoCopy's smart photo organization 
+            Everything you need to know about PictoPy's smart photo organization 
             and AI-powered tagging features.
           </p>
         </motion.div>


### PR DESCRIPTION
Fixes #1118 
Typo mistakes at FAQ section 

PictoCopy's should be PictoPy's 

### Solution 
```
PictoCopy's -> PictoPy's
```

### Screenshots : 

#### before :
<img width="700" height="298" alt="Image" src="https://github.com/user-attachments/assets/ff79ad34-c4e3-464a-94bb-446b0c78e560" />

#### After :
<img width="884" height="392" alt="image" src="https://github.com/user-attachments/assets/5e247fea-c467-4f3b-94ee-528334df79da" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected references in FAQ content to accurately reflect product naming and information about smart photo organization and AI-powered tagging capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->