### PR TITLE
prevent image dragging

### DIFF
--- a/landing-page/src/index.css
+++ b/landing-page/src/index.css
@@ -64,6 +64,15 @@
     pointer-events: none;
   }
 
+  /* Prevent image dragging */
+  img {
+    -webkit-user-drag: none;
+    -khtml-user-drag: none;
+    -moz-user-drag: none;
+    -o-user-drag: none;
+    user-drag: none;
+  }
+
   * {
     @apply border-border;
   }


### PR DESCRIPTION
Fixes #1120 

### Description

Currently, images on the Pictopy landing page can be dragged by users, which affects the overall user experience and UI polish.

To improve UX and maintain a clean interaction on the landing page, image dragging should be disabled globally.

#### Screenshot :

<img width="700" height="781" alt="Image" src="https://github.com/user-attachments/assets/71d4d645-76cd-4026-a0d8-d8df98f145b6" />

### Proposed Solution

Disable image dragging using CSS.

### Implementation

Update index.css with the following rule:
```
/* Prevent image dragging */
img {
  -webkit-user-drag: none;
  -khtml-user-drag: none;
  -moz-user-drag: none;
  -o-user-drag: none;
  user-drag: none;
}
```

Expected Result

- Images cannot be dragged on the landing page
- Cleaner and more controlled UI interaction
- Improved user experience

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Prevented unintended image dragging on the landing page to improve user experience and interaction quality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->