### PR TITLE
docs(frontend): add getting started and dev instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,16 @@
 
 PictoPy is an advanced desktop gallery application that combines the power of Tauri, React, and Rust for the frontend with a Python backend for sophisticated image analysis and management.
 
-# Want to Contribute? 😄
+# Contributing
 
-&nbsp;&nbsp;&nbsp;<a href="https://discord.gg/hjUhu33uAn"><img src="https://github.com/user-attachments/assets/3ed93273-5055-4532-a524-87a337a4fbba" height="40"></a>
+We welcome contributions of all kinds — code, documentation, tests, bug reports, and ideas. For full contribution guidelines, please read our [`CONTRIBUTING.md`](./CONTRIBUTING.md).
 
-1. First, join the **[Discord Server](https://discord.gg/hjUhu33uAn) (Go to Projects->PictoPy)** to chat with everyone.
-2. For detailed setup instructions, coding guidelines, and the contribution process, please check out our [CONTRIBUTING.md](./CONTRIBUTING.md) file.
+- **Chat & discuss:** Join our **[Discord Server](https://discord.gg/hjUhu33uAn)** (see Projects → PictoPy) to ask questions and propose changes.
+- **Report issues:** Use GitHub Issues for bugs and feature requests.
+- **Contribute code:** Fork the repo, create a descriptive branch (e.g., `feature/add-thing`), add tests and documentation, then open a Pull Request against `main`. Follow the coding standards and testing instructions in [`CONTRIBUTING.md`](./CONTRIBUTING.md).
+
+
+
 
 # Architecture
 
@@ -63,3 +67,7 @@ Handles file system operations and provides a secure bridge between the frontend
 ---
 
 Our Code of Conduct: [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md)
+
+## License
+
+This project is licensed under the **GNU General Public License v3.0 (GPL-3.0)**. See the full license in [`LICENSE.md`](./LICENSE.md).

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -5,3 +5,49 @@ This template should help get you started developing with Tauri, React and Types
 ## Recommended IDE Setup
 
 - [VS Code](https://code.visualstudio.com/) + [Tauri](https://marketplace.visualstudio.com/items?itemName=tauri-apps.tauri-vscode) + [rust-analyzer](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer)
+## Getting Started
+
+Follow these steps to run the frontend locally.
+
+**Prerequisites**
+
+- Node.js (LTS) installed (recommended v18+)
+- npm, pnpm, or yarn
+- If you plan to run the desktop app with Tauri: Rust toolchain (install via `rustup`) and Tauri prerequisites — see https://tauri.app/
+
+**Install dependencies**
+
+```bash
+cd frontend
+npm install
+```
+
+**Run the frontend development server**
+
+```bash
+npm run dev
+```
+
+**Run the desktop app (Tauri) in development**
+
+```bash
+npm run tauri dev
+```
+
+**Build & preview**
+
+```bash
+npm run build
+npm run preview
+```
+
+**Useful scripts**
+
+- `npm run test` — run tests
+- `npm run lint:check` / `npm run lint:fix` — linting
+- `npm run format:check` / `npm run format:fix` — formatting
+- `npm run setup:linux` — run `scripts/setup_env.sh` to prepare the Linux dev environment
+
+**Troubleshooting**
+
+- If `npm run tauri dev` fails, ensure you have Rust and the required toolchain installed (see Tauri docs). If the dev server doesn't start, check for port conflicts or errors in the terminal.


### PR DESCRIPTION
## Summary
This pull request adds a **Getting Started** section to the frontend README.

The new section documents how to install dependencies and run the frontend in development and production modes, including Tauri desktop development.


Closing issue #1129 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated main README with new Contributing section and links to contribution guidelines
  * Added GPL-3.0 License section to main README
  * Expanded frontend README with comprehensive Getting Started guide including prerequisites, installation, development setup, and troubleshooting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->