### PR TITLE
feat: replace hardcoded ports/URLs with environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,36 @@
+# =============================================================================
+# PictoPy Environment Configuration
+# =============================================================================
+# Copy this file to .env and modify values as needed.
+# All variables have sensible defaults for local development.
+
+# -----------------------------------------------------------------------------
+# Backend Server Configuration
+# -----------------------------------------------------------------------------
+# Host and port for the main PictoPy backend server
+BACKEND_HOST=localhost
+BACKEND_PORT=52123
+
+# -----------------------------------------------------------------------------
+# Sync Microservice Configuration
+# -----------------------------------------------------------------------------
+# Host and port for the sync microservice
+SYNC_MICROSERVICE_HOST=localhost
+SYNC_MICROSERVICE_PORT=52124
+
+# Optional: Override the full URLs (if not set, constructed from host:port)
+# PRIMARY_BACKEND_URL=http://localhost:52123
+# SYNC_MICROSERVICE_URL=http://localhost:52124
+
+# -----------------------------------------------------------------------------
+# Frontend Configuration (Vite)
+# -----------------------------------------------------------------------------
+# These are used by the frontend during build/development
+VITE_BACKEND_URL=http://localhost:52123
+VITE_SYNC_MICROSERVICE_URL=http://localhost:52124
+
+# -----------------------------------------------------------------------------
+# Signing Keys (for Tauri updater)
+# -----------------------------------------------------------------------------
 private = dW50cnVzdGVkIGNvbW1lbnQ6IHJzaWduIGVuY3J5cHRlZCBzZWNyZXQga2V5ClJXUlRZMEl5TjRQaUpFRXRad0dDbkNpTHlVNFBOWmZCaDRRWGNDcDdHQ3c5a0hRSUE3NEFBQkFBQUFBQUFBQUFBQUlBQUFBQVhoT1pUY2xvak01d0ZKeVVYdlVnQnlGQXlkUFhuRkdBMEY0QmdYWCtXUCtvaDMvS2tNYnJHSytXcGluQytFQWxPYm1UbVZNdU85aU53aEdJT1IveE82LzB2K2swS0MyZlFybmt5SG51aEt3YlVmMWdDSHBkN1llelU2L0JKT1puVGZFc3liNXplRlk9Cg==
 public = dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDY1MDM5OUIzNDQ5MTNEOTMKUldTVFBaRkVzNWtEWlRxWWJCeXhtMTV6ZXZ3OUs0SXhzQzBreVRoekl5bjdXS3hkZlZzQ3VvTkgK

--- a/backend/app/config/settings.py
+++ b/backend/app/config/settings.py
@@ -1,11 +1,20 @@
 from platformdirs import user_data_dir
 import os
 
+# Server Configuration
+BACKEND_HOST = os.getenv('BACKEND_HOST', 'localhost')
+BACKEND_PORT = int(os.getenv('BACKEND_PORT', '52123'))
+
+# Microservice Configuration
+SYNC_MICROSERVICE_HOST = os.getenv('SYNC_MICROSERVICE_HOST', 'localhost')
+SYNC_MICROSERVICE_PORT = int(os.getenv('SYNC_MICROSERVICE_PORT', '52124'))
+SYNC_MICROSERVICE_URL = os.getenv(
+    'SYNC_MICROSERVICE_URL',
+    f'http://{SYNC_MICROSERVICE_HOST}:{SYNC_MICROSERVICE_PORT}'
+)
+
 # Model Exports Path
 MODEL_EXPORTS_PATH = "app/models/ONNX_Exports"
-
-# Microservice URLs
-SYNC_MICROSERVICE_URL = "http://localhost:52124"
 
 CONFIDENCE_PERCENT = 0.6
 # Object Detection Models:

--- a/backend/main.py
+++ b/backend/main.py
@@ -6,7 +6,12 @@ import multiprocessing
 import os
 import json
 
-from app.config.settings import DATABASE_PATH, THUMBNAIL_IMAGES_PATH
+from app.config.settings import (
+    DATABASE_PATH,
+    THUMBNAIL_IMAGES_PATH,
+    BACKEND_HOST,
+    BACKEND_PORT,
+)
 from uvicorn import Config, Server
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -77,7 +82,7 @@ app = FastAPI(
         "url": "https://www.postman.com/aossie-pictopy/pictopy/overview",
     },
     servers=[
-        {"url": "http://localhost:52123", "description": "Local Development server"}
+        {"url": f"http://{BACKEND_HOST}:{BACKEND_PORT}", "description": "Local Development server"}
     ],
 )
 
@@ -148,8 +153,8 @@ if __name__ == "__main__":
 
     config = Config(
         app=app,
-        host="localhost",
-        port=52123,
+        host=BACKEND_HOST,
+        port=BACKEND_PORT,
         log_level="info",
         log_config=None,  # This is crucial - disable Uvicorn's default logging config
     )

--- a/frontend/src/config/Backend.ts
+++ b/frontend/src/config/Backend.ts
@@ -1,2 +1,4 @@
-export const BACKEND_URL = 'http://localhost:52123';
-export const SYNC_MICROSERVICE_URL = 'http://localhost:52124';
+export const BACKEND_URL =
+  import.meta.env.VITE_BACKEND_URL || 'http://localhost:52123';
+export const SYNC_MICROSERVICE_URL =
+  import.meta.env.VITE_SYNC_MICROSERVICE_URL || 'http://localhost:52124';

--- a/sync-microservice/app/config/settings.py
+++ b/sync-microservice/app/config/settings.py
@@ -1,10 +1,24 @@
 from platformdirs import user_data_dir
 import os
 
+# Backend Configuration
+BACKEND_HOST = os.getenv('BACKEND_HOST', 'localhost')
+BACKEND_PORT = int(os.getenv('BACKEND_PORT', '52123'))
+PRIMARY_BACKEND_URL = os.getenv(
+    'PRIMARY_BACKEND_URL',
+    f'http://{BACKEND_HOST}:{BACKEND_PORT}'
+)
+
+# Sync Microservice Configuration
+SYNC_MICROSERVICE_HOST = os.getenv('SYNC_MICROSERVICE_HOST', 'localhost')
+SYNC_MICROSERVICE_PORT = int(os.getenv('SYNC_MICROSERVICE_PORT', '52124'))
+SYNC_MICROSERVICE_URL = os.getenv(
+    'SYNC_MICROSERVICE_URL',
+    f'http://{SYNC_MICROSERVICE_HOST}:{SYNC_MICROSERVICE_PORT}'
+)
+
 # Model Exports Path
 MODEL_EXPORTS_PATH = "app/models/ONNX_Exports"
-PRIMARY_BACKEND_URL = "http://localhost:52123"
-SYNC_MICROSERVICE_URL = "http://localhost:52124"
 
 # Object Detection Models:
 SMALL_OBJ_DETECTION_MODEL = f"{MODEL_EXPORTS_PATH}/YOLOv11_Small.onnx"

--- a/sync-microservice/main.py
+++ b/sync-microservice/main.py
@@ -1,6 +1,10 @@
 import logging
 import os
-from app.config.settings import DATABASE_PATH
+from app.config.settings import (
+    DATABASE_PATH,
+    SYNC_MICROSERVICE_HOST,
+    SYNC_MICROSERVICE_PORT,
+)
 from fastapi import FastAPI
 from uvicorn import Config, Server
 from app.core.lifespan import lifespan
@@ -51,8 +55,8 @@ if __name__ == "__main__":
 
     config = Config(
         app=app,
-        host="localhost",
-        port=52124,
+        host=SYNC_MICROSERVICE_HOST,
+        port=SYNC_MICROSERVICE_PORT,
         log_level="info",
         log_config=None,  # Disable uvicorn's default logging config
     )


### PR DESCRIPTION
# Pull Request: Replace Hardcoded Ports/URLs with Environment Variables

## PR Title
```
feat: replace hardcoded ports/URLs with environment variables
```

## Summary
- Added environment variable support for backend and sync microservice server configuration
- Updated frontend to use Vite environment variables with sensible fallback defaults
- Documented all new environment variables in `.env.example`

## Motivation and Context
Ports and URLs were hardcoded throughout the codebase, making it impossible to:
- Run multiple instances on the same machine
- Deploy to cloud platforms with dynamic ports
- Easily switch between dev/staging/production environments

This PR addresses these concerns by introducing configurable environment variables while maintaining backward compatibility with existing default values.

## Changes Made

### Backend Configuration (`backend/app/config/settings.py`)
- Added `BACKEND_HOST` (default: `localhost`)
- Added `BACKEND_PORT` (default: `52123`)
- Added `SYNC_MICROSERVICE_HOST` (default: `localhost`)
- Added `SYNC_MICROSERVICE_PORT` (default: `52124`)
- Made `SYNC_MICROSERVICE_URL` configurable (auto-constructed from host:port or override)

### Backend Server (`backend/main.py`)
- Updated OpenAPI servers configuration to use dynamic URL
- Updated Uvicorn server config to use environment variables

### Sync Microservice Configuration (`sync-microservice/app/config/settings.py`)
- Added `BACKEND_HOST` and `BACKEND_PORT` configuration
- Made `PRIMARY_BACKEND_URL` configurable
- Added `SYNC_MICROSERVICE_HOST` and `SYNC_MICROSERVICE_PORT`
- Made `SYNC_MICROSERVICE_URL` configurable

### Sync Microservice Server (`sync-microservice/main.py`)
- Updated Uvicorn server config to use environment variables

### Frontend Configuration (`frontend/src/config/Backend.ts`)
- Updated to use Vite environment variables (`import.meta.env`)
- Added fallback to default values for development

### Environment Template (`.env.example`)
- Added comprehensive documentation for all new environment variables
- Organized into logical sections (Backend, Sync Microservice, Frontend)

## How to Test

### Test with default configuration (no changes needed):
```bash
# Backend
cd backend && python main.py
# Should start on localhost:52123

# Sync Microservice
cd sync-microservice && python main.py
# Should start on localhost:52124
```

### Test with custom ports:
```bash
# Backend on custom port
BACKEND_PORT=8000 python backend/main.py
# Should start on localhost:8000

# Sync Microservice on custom port
SYNC_MICROSERVICE_PORT=8001 python sync-microservice/main.py
# Should start on localhost:8001
```

### Test Frontend with custom backend URL:
```bash
cd frontend
VITE_BACKEND_URL=http://localhost:8000 npm run dev
```

## Environment Variables Reference

| Variable | Default | Description |
|----------|---------|-------------|
| `BACKEND_HOST` | `localhost` | Host for the main backend server |
| `BACKEND_PORT` | `52123` | Port for the main backend server |
| `SYNC_MICROSERVICE_HOST` | `localhost` | Host for the sync microservice |
| `SYNC_MICROSERVICE_PORT` | `52124` | Port for the sync microservice |
| `PRIMARY_BACKEND_URL` | Auto-constructed | Full URL for the main backend |
| `SYNC_MICROSERVICE_URL` | Auto-constructed | Full URL for the sync microservice |
| `VITE_BACKEND_URL` | `http://localhost:52123` | Frontend: Backend URL |
| `VITE_SYNC_MICROSERVICE_URL` | `http://localhost:52124` | Frontend: Sync microservice URL |

## Backward Compatibility
All existing deployments will continue to work without any changes, as all environment variables have sensible defaults that match the previous hardcoded values.

## Checklist
- [x] Code follows the project's coding standards
- [x] Changes are backward compatible
- [x] Environment variables documented in `.env.example`
- [x] Tested with default configuration
- [x] Tested with custom configuration

## Related Issue
Fixes #1134

---

## Files Changed
- `.env.example` - Added environment variable documentation
- `backend/app/config/settings.py` - Added env var support for server configuration
- `backend/main.py` - Updated to use config variables
- `sync-microservice/app/config/settings.py` - Added env var support
- `sync-microservice/main.py` - Updated to use config variables
- `frontend/src/config/Backend.ts` - Added Vite env var support
