### PR TITLE
Scroll to top using Navbar  Aossie logo

### DIFF
--- a/landing-page/src/Pages/Landing page/Navbar.tsx
+++ b/landing-page/src/Pages/Landing page/Navbar.tsx
@@ -110,11 +110,14 @@ const Navbar: React.FC = () => {
           <div className="flex justify-between items-center h-16">
             <div className="flex-shrink-0 flex items-center">
               <div className="mr-4">
-                <Link to="/">
+                <Link to="/" onClick={(e) => {
+                  e.preventDefault();
+                  window.scrollTo({ top: 0, behavior: 'smooth' });
+                }}>
                   <img
                     src={YourLogo}
                     alt="PictoPy Logo"
-                    className="w-10 h-10 object-contain"
+                    className="w-10 h-10 object-contain cursor-pointer"
                   />
                 </Link>
               </div>
@@ -123,6 +126,10 @@ const Navbar: React.FC = () => {
               <div className="relative group">
                 <Link
                   to="/"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    window.scrollTo({ top: 0, behavior: 'smooth' });
+                  }}
                   className="text-2xl font-bold 
                   bg-gradient-to-r from-yellow-500 to-green-500 
                   bg-clip-text text-transparent


### PR DESCRIPTION

Fixes #1139

### Description

Clicking the AOSSIE / PictoPy logo in the navbar should smoothly scroll the page back to the top instead of only acting as a route link.

This improves navigation UX, especially on long landing pages.

### Expected Behavior

- Clicking the navbar logo scrolls smoothly to the top of the page
- Works consistently on desktop and mobile
- Does not reload the page


### Proposed Implementation

Handle logo click in Navbar.tsx using window.scrollTo with smooth behavior.

```
window.scrollTo({ top: 0, behavior: "smooth" });

```

### Files Affected
```
Navbar.tsx

```

### video demo :
https://github.com/user-attachments/assets/578ad9b9-7e21-422a-a054-0091e1ebcb02

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Clicking the logo or navigation title now smoothly scrolls you to the top of the page.

* **Style**
  * Added cursor pointer feedback to the logo to indicate it's interactive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->