### PR TITLE
docs: Add note about Jest warning after frontend tests #1137

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ npm test
 
 > **Note:** After running the frontend tests, you may see a warning:
 > `Jest did not exit one second after the test run has completed.`
-> This is a known behavior and **does not indicate a problem** when all tests pass. It occurs due to async handles that Jest detects but doesn't affect test results or application functionality.
+> This is a known behavior and **does not indicate a problem** when all tests pass. It occurs due to open handles (unclosed servers, DB connections, timers, etc.) that prevent the Node process from exiting cleanly. To identify the root cause, run `npx jest --detectOpenHandles` and ensure resources are properly closed in test teardown (`afterEach`/`afterAll`).
 
 ### Backend
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,10 @@ cd frontend
 npm test
 ```
 
+> **Note:** After running the frontend tests, you may see a warning:
+> `Jest did not exit one second after the test run has completed.`
+> This is a known behavior and **does not indicate a problem** when all tests pass. It occurs due to async handles that Jest detects but doesn't affect test results or application functionality.
+
 ### Backend
 
 - FastAPI


### PR DESCRIPTION
## Description
Added documentation explaining that the "Jest did not exit one second after the test run" warning is harmless when all tests pass.

This helps new contributors understand the warning is expected behavior and not an indication of a problem.

## Changes Made
- Added a note in the Testing > Frontend section of CONTRIBUTING.md

## Files Affected
- `CONTRIBUTING.md`

Fixes #1137

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified contributor guidelines (Frontend Testing): notes that the “Jest did not exit…” warning can be expected when tests pass and added troubleshooting guidance to detect open handles and ensure proper test teardown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->