### PR TITLE
Docs: clarify ONNX Runtime warning on Windows 11

### DIFF
--- a/docs/Manual_Setup_Guide.md
+++ b/docs/Manual_Setup_Guide.md
@@ -180,15 +180,15 @@ Before setting up the Python backend and sync-microservice, you need to have **M
 
     For other systems, consult your distribution's documentation.
 
-   3. ### ONNX Runtime warning on Windows 11 (safe to ignore)
+  ### ONNX Runtime warning on Windows 11 (safe to ignore)
 
-      While running backend tests or starting the PictoPy backend on Windows 11, you may see a warning similar to:
+While running backend tests or starting the PictoPy backend on Windows 11, you may see a warning similar to:
 
-      UserWarning: Unsupported Windows version (11).
-      ONNX Runtime supports Windows 10 and above.
+UserWarning: Unsupported Windows version (11).
+ONNX Runtime supports Windows 10 and above.
 
+This warning is **harmless**. If backend tests pass successfully and the application runs as expected, the setup is working correctly.
 
-    This warning is **harmless**. If backend tests pass successfully and the application runs as expected, the setup is working correctly.
+The warning originates from ONNX Runtime's internal OS version check and does **not** indicate a compatibility issue with PictoPy on Windows 11.
 
-    The warning originates from ONNX Runtime's internal OS version check and does s **not** indicate a compatibility issue with PictoPy on Windows 11.
 

--- a/docs/Manual_Setup_Guide.md
+++ b/docs/Manual_Setup_Guide.md
@@ -179,3 +179,16 @@ Before setting up the Python backend and sync-microservice, you need to have **M
     ```
 
     For other systems, consult your distribution's documentation.
+
+   3. ### ONNX Runtime warning on Windows 11 (safe to ignore)
+
+      While running backend tests or starting the PictoPy backend on Windows 11, you may see a warning similar to:
+
+      UserWarning: Unsupported Windows version (11).
+      ONNX Runtime supports Windows 10 and above.
+
+
+    This warning is **harmless**. If backend tests pass successfully and the application runs as expected, the setup is working correctly.
+
+    The warning originates from ONNX Runtime's internal OS version check and does s **not** indicate a compatibility issue with PictoPy on Windows 11.
+


### PR DESCRIPTION
### Summary
Clarifies the ONNX Runtime warning seen on Windows 11 during backend tests and local runs.

### Details
Windows 11 users may see an ONNX Runtime warning even though the backend works correctly and tests pass. This PR documents that the warning is harmless and does not indicate a compatibility issue.

### Related Issue
Closes #1136

### Testing
- Backend tests executed successfully on Windows 11


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a troubleshooting note explaining that ONNX Runtime warnings seen on Windows 11 are harmless, originate from an OS-version check, and do not indicate a compatibility issue with the application.
  * Clarifies expected behavior for Windows 11 users; no functional or compatibility changes were made.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->