### PR TITLE
docs: mention recommended Python version for local setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ PictoPy is an advanced desktop gallery application that combines the power of Ta
 1. First, join the **[Discord Server](https://discord.gg/hjUhu33uAn) (Go to Projects->PictoPy)** to chat with everyone.
 2. For detailed setup instructions, coding guidelines, and the contribution process, please check out our [CONTRIBUTING.md](./CONTRIBUTING.md) file.
 
+## Recommended Python Version
+
+For local development, it is recommended to use **Python 3.10 or 3.11**.
+Some dependencies may not yet be fully compatible with newer Python versions.
+
 # Architecture
 
 ### Frontend


### PR DESCRIPTION
While setting up PictoPy locally, I noticed some confusion around Python versions.
This came up in the AOSSIE Discord discussion as well.

This PR documents a recommended Python version in the README to help new contributors avoid setup issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added recommended Python version guidance for local development, specifying Python 3.10 or 3.11 as optimal versions.
  * Included notes about potential compatibility issues with newer Python versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->