### PR TITLE
Docs/jest warning frontend tests

### DIFF
--- a/docs/Manual_Setup_Guide.md
+++ b/docs/Manual_Setup_Guide.md
@@ -180,7 +180,7 @@ Before setting up the Python backend and sync-microservice, you need to have **M
 
     For other systems, consult your distribution's documentation.
 
-  ### ONNX Runtime warning on Windows 11 (safe to ignore)
+ ### ONNX Runtime warning on Windows 11 (safe to ignore)
 
 While running backend tests or starting the PictoPy backend on Windows 11, you may see a warning similar to:
 

--- a/docs/Manual_Setup_Guide.md
+++ b/docs/Manual_Setup_Guide.md
@@ -200,7 +200,8 @@ Jest did not exit one second after the test run has completed.
 
 This warning does **not** indicate a test failure. All tests may still pass successfully.
 
-It is usually caused by open async handles such as timers, watchers, or dev-server related processes.  
+It is usually caused by open async handles such as timers, watchers, or dev-server-related processes.
+  
 If tests pass and no processes are hanging, the warning can be safely ignored.
 
 For debugging purposes, contributors can optionally run:

--- a/docs/Manual_Setup_Guide.md
+++ b/docs/Manual_Setup_Guide.md
@@ -180,15 +180,15 @@ Before setting up the Python backend and sync-microservice, you need to have **M
 
     For other systems, consult your distribution's documentation.
 
-   3. ### ONNX Runtime warning on Windows 11 (safe to ignore)
+  ### ONNX Runtime warning on Windows 11 (safe to ignore)
 
-      While running backend tests or starting the PictoPy backend on Windows 11, you may see a warning similar to:
+While running backend tests or starting the PictoPy backend on Windows 11, you may see a warning similar to:
 
-      UserWarning: Unsupported Windows version (11).
-      ONNX Runtime supports Windows 10 and above.
+UserWarning: Unsupported Windows version (11).
+ONNX Runtime supports Windows 10 and above.
 
+This warning is **harmless**. If backend tests pass successfully and the application runs as expected, the setup is working correctly.
 
-    This warning is **harmless**. If backend tests pass successfully and the application runs as expected, the setup is working correctly.
+The warning originates from ONNX Runtime's internal OS version check and does **not** indicate a compatibility issue with PictoPy on Windows 11.
 
-    The warning originates from ONNX Runtime's internal OS version check and does s **not** indicate a compatibility issue with PictoPy on Windows 11.
 

--- a/docs/Manual_Setup_Guide.md
+++ b/docs/Manual_Setup_Guide.md
@@ -179,3 +179,16 @@ Before setting up the Python backend and sync-microservice, you need to have **M
     ```
 
     For other systems, consult your distribution's documentation.
+
+   3. ### ONNX Runtime warning on Windows 11 (safe to ignore)
+
+      While running backend tests or starting the PictoPy backend on Windows 11, you may see a warning similar to:
+
+      UserWarning: Unsupported Windows version (11).
+      ONNX Runtime supports Windows 10 and above.
+
+
+    This warning is **harmless**. If backend tests pass successfully and the application runs as expected, the setup is working correctly.
+
+    The warning originates from ONNX Runtime's internal OS version check and does s **not** indicate a compatibility issue with PictoPy on Windows 11.
+

--- a/docs/Manual_Setup_Guide.md
+++ b/docs/Manual_Setup_Guide.md
@@ -191,4 +191,17 @@ This warning is **harmless**. If backend tests pass successfully and the applica
 
 The warning originates from ONNX Runtime's internal OS version check and does **not** indicate a compatibility issue with PictoPy on Windows 11.
 
+### Jest warning after successful frontend tests
 
+While running frontend tests, you may see the following warning:
+
+Jest did not exit one second after the test run has completed.
+
+
+This warning does **not** indicate a test failure. All tests may still pass successfully.
+
+It is usually caused by open async handles such as timers, watchers, or dev-server related processes.  
+If tests pass and no processes are hanging, the warning can be safely ignored.
+
+For debugging purposes, contributors can optionally run:
+npm test -- --detectOpenHandles


### PR DESCRIPTION
### Summary
Adds documentation clarifying a common Jest warning that appears after successful frontend test runs.

### Details
When running frontend tests, Jest may print the warning:

> “Jest did not exit one second after the test run has completed.”

All tests still pass successfully, and the application functions as expected. This warning is typically caused by open async handles such as timers, watchers, or dev-server related processes and does **not** indicate a test failure.

Without clarification, this message can confuse new contributors into thinking the test suite or setup is broken.

This PR adds a short troubleshooting note explaining:
- Why the warning appears
- When it is safe to ignore
- How contributors can optionally debug it using `--detectOpenHandles`

### Scope
- 📄 Documentation only  
- ❌ No code changes

### Testing
- Frontend tests executed successfully on Windows 11

### Related Issue
Closes #1137


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that ONNX Runtime warnings on Windows 11 are harmless and do not indicate compatibility issues; guidance added to safely ignore the message.
  * Documented Jest’s non-fatal “did not exit” warning after frontend tests, described possible causes, and added debugging guidance (e.g., running tests with --detectOpenHandles).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->