### PR TITLE
Fix/console logger leakage

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -27,6 +27,7 @@
         "@tauri-apps/api": ">=2.0.0-beta.0",
         "@tauri-apps/plugin-dialog": "^2.2.0",
         "@tauri-apps/plugin-fs": "^2.2.0",
+        "@tauri-apps/plugin-log": "^2.8.0",
         "@tauri-apps/plugin-opener": "^2.5.2",
         "@tauri-apps/plugin-process": "^2.3.0",
         "@tauri-apps/plugin-shell": "^2.2.0",
@@ -5175,6 +5176,15 @@
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-fs/-/plugin-fs-2.4.4.tgz",
       "integrity": "sha512-MTorXxIRmOnOPT1jZ3w96vjSuScER38ryXY88vl5F0uiKdnvTKKTtaEjTEo8uPbl4e3gnUtfsDVwC7h77GQLvQ==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-log": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-log/-/plugin-log-2.8.0.tgz",
+      "integrity": "sha512-a+7rOq3MJwpTOLLKbL8d0qGZ85hgHw5pNOWusA9o3cf7cEgtYHiGY/+O8fj8MvywQIGqFv0da2bYQDlrqLE7rw==",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.8.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,6 +42,7 @@
     "@tauri-apps/api": ">=2.0.0-beta.0",
     "@tauri-apps/plugin-dialog": "^2.2.0",
     "@tauri-apps/plugin-fs": "^2.2.0",
+    "@tauri-apps/plugin-log": "^2.8.0",
     "@tauri-apps/plugin-opener": "^2.5.2",
     "@tauri-apps/plugin-process": "^2.3.0",
     "@tauri-apps/plugin-shell": "^2.2.0",

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -3127,6 +3127,7 @@ dependencies = [
  "data-encoding",
  "directories",
  "image",
+ "log",
  "rand 0.8.5",
  "reqwest",
  "ring 0.16.20",

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.16",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -30,6 +41,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
 dependencies = [
  "alloc-no-stdlib",
+]
+
+[[package]]
+name = "android_log-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84521a3cf562bc62942e294181d9eef17eb38ceb8c68677bc49f144e4c3d4f8d"
+
+[[package]]
+name = "android_logger"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb4e440d04be07da1f1bf44fb4495ebd58669372fe0cffa6e48595ac5bd88a3"
+dependencies = [
+ "android_log-sys",
+ "env_filter",
+ "log",
 ]
 
 [[package]]
@@ -61,6 +89,12 @@ name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "ashpd"
@@ -283,6 +317,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -314,6 +360,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1da5ab77c1437701eeff7c88d968729e7766172279eab0676857b3d63af7a6f"
+dependencies = [
+ "borsh-derive",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0686c856aa6aac0c4498f936d7d6a02df690f614c03e4d906d1018062b5c5e2c"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate 3.4.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -339,6 +408,40 @@ name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+
+[[package]]
+name = "byte-unit"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c6d47a4e2961fb8721bcfc54feae6455f2f64e7054f9bc67e875f0e77f4c58d"
+dependencies = [
+ "rust_decimal",
+ "schemars 1.2.0",
+ "serde",
+ "utf8-width",
+]
+
+[[package]]
+name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "bytemuck"
@@ -979,6 +1082,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1054,6 +1167,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "fern"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4316185f709b23713e41e3195f90edef7fb00c3ed4adc79769cf09cc762a3b29"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -1150,6 +1272,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futf"
@@ -1596,6 +1724,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -2206,6 +2337,9 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "lru-slab"
@@ -2435,6 +2569,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -2994,6 +3137,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
+ "tauri-plugin-log",
  "tauri-plugin-opener",
  "tauri-plugin-process",
  "tauri-plugin-shell",
@@ -3173,6 +3317,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "qoi"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3259,6 +3423,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -3486,6 +3656,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
+name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3585,6 +3764,51 @@ dependencies = [
  "libc",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61f703d19852dbf87cbc513643fa81428361eb6940f1ac14fd58155d295a3eb0"
+dependencies = [
+ "arrayvec",
+ "borsh",
+ "bytes",
+ "num-traits",
+ "rand 0.8.5",
+ "rkyv",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -3742,6 +3966,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "security-framework"
@@ -4028,6 +4258,12 @@ name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
@@ -4319,6 +4555,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "tar"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4505,6 +4747,28 @@ dependencies = [
  "thiserror 2.0.17",
  "toml 0.9.10+spec-1.1.0",
  "url",
+]
+
+[[package]]
+name = "tauri-plugin-log"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7545bd67f070a4500432c826e2e0682146a1d6712aee22a2786490156b574d93"
+dependencies = [
+ "android_logger",
+ "byte-unit",
+ "fern",
+ "log",
+ "objc2",
+ "objc2-foundation",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "swift-rs",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.17",
+ "time",
 ]
 
 [[package]]
@@ -4792,7 +5056,9 @@ checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde",
  "time-core",
@@ -5221,6 +5487,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
+name = "utf8-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1292c0d970b54115d14f2492fe0170adf21d68a1de108eebc51c1df4f346a091"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5237,6 +5509,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "value-bag"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
 
 [[package]]
 name = "vcpkg"
@@ -6090,6 +6368,15 @@ dependencies = [
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
 ]
 
 [[package]]

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -37,6 +37,7 @@ tauri-plugin-process = "2.3.1"
 tauri-plugin-store = "2.4.1"
 tauri-plugin-updater = "2.9.0"
 tauri-plugin-opener = "2.5.2"
+tauri-plugin-log = "2"
 
 [features]
 # This feature is used for production builds or when a dev server is not specified, DO NOT REMOVE!!

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -38,6 +38,7 @@ tauri-plugin-store = "2.4.1"
 tauri-plugin-updater = "2.9.0"
 tauri-plugin-opener = "2.5.2"
 tauri-plugin-log = "2"
+log = "0.4"
 
 [features]
 # This feature is used for production builds or when a dev server is not specified, DO NOT REMOVE!!

--- a/frontend/src-tauri/capabilities/desktop.json
+++ b/frontend/src-tauri/capabilities/desktop.json
@@ -2,5 +2,5 @@
   "identifier": "desktop-capability",
   "platforms": ["macOS", "windows", "linux"],
   "windows": ["main"],
-  "permissions": ["updater:default"]
+  "permissions": ["updater:default", "log:default"]
 }

--- a/frontend/src-tauri/src/main.rs
+++ b/frontend/src-tauri/src/main.rs
@@ -190,6 +190,7 @@ fn prod(_app: &tauri::AppHandle, _resource_path: &std::path::Path) -> Result<(),
 
 fn main() {
     tauri::Builder::default()
+        .plugin(tauri_plugin_log::Builder::new().build())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_store::Builder::new().build())

--- a/frontend/src-tauri/src/main.rs
+++ b/frontend/src-tauri/src/main.rs
@@ -190,7 +190,13 @@ fn prod(_app: &tauri::AppHandle, _resource_path: &std::path::Path) -> Result<(),
 
 fn main() {
     tauri::Builder::default()
-        .plugin(tauri_plugin_log::Builder::new().build())
+        .plugin(
+            tauri_plugin_log::Builder::new()
+                .level(log::LevelFilter::Info)
+                .max_file_size(5_000_000) // 5 MB per log file
+                .rotation_strategy(tauri_plugin_log::RotationStrategy::KeepAll)
+                .build(),
+        )
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_store::Builder::new().build())

--- a/frontend/src/components/FolderPicker/AITaggingFolderPicker.tsx
+++ b/frontend/src/components/FolderPicker/AITaggingFolderPicker.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Button } from '@/components/ui/button';
 import { open } from '@tauri-apps/plugin-dialog';
 import { FolderPlus } from 'lucide-react';
+import logger from '@/utils/logger';
 interface FolderPickerProps {
   setFolderPath: (path: string[]) => void;
   className?: string;
@@ -22,13 +23,13 @@ const AITaggingFolderPicker: React.FC<FolderPickerProps> = ({
       });
       if (selected && Array.isArray(selected) && selected.length > 0) {
         setFolderPath(selected);
-        console.log('Selected folder:', selected);
+        logger.debug('Selected folder:', selected);
         if (handleDeleteCache) {
           handleDeleteCache();
         }
       }
     } catch (error) {
-      console.error('Error picking folder:', error);
+      logger.error('Error picking folder:', error);
     }
   };
   return (

--- a/frontend/src/components/Media/ImageCard.tsx
+++ b/frontend/src/components/Media/ImageCard.tsx
@@ -7,6 +7,7 @@ import { Image } from '@/types/Media';
 import { ImageTags } from './ImageTags';
 import { convertFileSrc } from '@tauri-apps/api/core';
 import { useToggleFav } from '@/hooks/useToggleFav';
+import logger from '@/utils/logger';
 
 interface ImageCardViewProps {
   image: Image;
@@ -78,7 +79,7 @@ export function ImageCard({
                   : 'bg-white/10 hover:bg-white/20 hover:shadow-lg'
               }`}
               onClick={(e) => {
-                console.log(image);
+                logger.debug('Toggling favourite for image:', image.id);
                 e.stopPropagation();
                 handleToggleFavourite();
               }}

--- a/frontend/src/components/Media/ImageCard.tsx
+++ b/frontend/src/components/Media/ImageCard.tsx
@@ -32,6 +32,7 @@ export function ImageCard({
 
   const handleToggleFavourite = useCallback(() => {
     if (image?.id) {
+      logger.debug('Toggling favourite for image:', image.id);
       toggleFavourite(image.id);
     }
   }, [image, toggleFavourite]);
@@ -79,7 +80,6 @@ export function ImageCard({
                   : 'bg-white/10 hover:bg-white/20 hover:shadow-lg'
               }`}
               onClick={(e) => {
-                logger.debug('Toggling favourite for image:', image.id);
                 e.stopPropagation();
                 handleToggleFavourite();
               }}

--- a/frontend/src/components/Media/MediaInfoPanel.tsx
+++ b/frontend/src/components/Media/MediaInfoPanel.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { open } from '@tauri-apps/plugin-shell';
+import logger from '@/utils/logger';
 import {
   X,
   ImageIcon as ImageLucide,
@@ -53,7 +54,7 @@ export const MediaInfoPanel: React.FC<MediaInfoPanelProps> = ({
       try {
         await open(`https://maps.google.com/?q=${latitude},${longitude}`);
       } catch (error) {
-        console.error('Failed to open map URL:', error);
+        logger.error('Failed to open map URL:', error);
       }
     }
   };

--- a/frontend/src/components/Media/MediaView.tsx
+++ b/frontend/src/components/Media/MediaView.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useMemo, useRef } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { revealItemInDir } from '@tauri-apps/plugin-opener';
+import logger from '@/utils/logger';
 import { MediaViewProps } from '@/types/Media';
 import { selectCurrentViewIndex } from '@/features/imageSelectors';
 import { setCurrentViewIndex, closeImageView } from '@/features/imageSlice';
@@ -102,7 +103,7 @@ export function MediaView({
     try {
       await revealItemInDir(currentImage.path);
     } catch (err) {
-      console.error('Failed to open folder:', err);
+      logger.error('Failed to open folder:', err);
     }
   };
 
@@ -164,7 +165,7 @@ export function MediaView({
 
   // Safe variables
   const currentImagePath = currentImage.path;
-  // console.log(currentImage);
+
   const currentImageAlt = `image-${currentViewIndex}`;
   return (
     <div className="fixed inset-0 z-50 mt-0 flex flex-col bg-gradient-to-b from-black/95 to-black/98 backdrop-blur-lg">

--- a/frontend/src/components/Memories/MemoryDetail.tsx
+++ b/frontend/src/components/Memories/MemoryDetail.tsx
@@ -13,6 +13,7 @@ import { useNavigate, useParams } from 'react-router';
 import { Button } from '@/components/ui/button';
 import { ArrowLeft } from 'lucide-react';
 import { ROUTES } from '@/constants/routes';
+import logger from '@/utils/logger';
 import { ImageCard } from '@/components/Media/ImageCard';
 import { MediaView } from '@/components/Media/MediaView';
 import {
@@ -146,7 +147,7 @@ export const MemoryDetail = () => {
         // Invalidate Tanstack Query cache to refetch memories
         queryClient.invalidateQueries({ queryKey: ['memories'] });
       } catch (error) {
-        console.error('Failed to toggle favorite:', error);
+        logger.error('Failed to toggle favorite:', error);
         dispatch(
           showInfoDialog({
             title: 'Error',

--- a/frontend/src/components/Memories/MemoryViewer.tsx
+++ b/frontend/src/components/Memories/MemoryViewer.tsx
@@ -13,6 +13,7 @@ import {
   clearSelectedMemory,
 } from '@/features/memoriesSlice';
 import { setCurrentViewIndex, setImages } from '@/features/imageSlice';
+import logger from '@/utils/logger';
 import { showInfoDialog } from '@/features/infoDialogSlice';
 import { MediaView } from '@/components/Media/MediaView';
 import {
@@ -58,7 +59,7 @@ export const MemoryViewer: React.FC = () => {
             variant: 'error',
           }),
         );
-        console.error('Failed to toggle favorite:', error);
+        logger.error('Failed to toggle favorite:', error);
       }
     },
     [dispatch, queryClient],

--- a/frontend/src/components/Timeline/TimelineScrollbar.tsx
+++ b/frontend/src/components/Timeline/TimelineScrollbar.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState, RefObject } from 'react';
+import logger from '@/utils/logger';
 import {
   useScroll,
   useWheel,
@@ -246,7 +247,7 @@ export default function TimelineScrollbar({
         handleScroll(e.clientY);
         updateDragTooltip(e.clientY);
       } catch (error) {
-        console.error('Error during drag:', error);
+        logger.error('Error during drag:', error);
         handleMouseUp();
       }
     };

--- a/frontend/src/features/imageSlice.ts
+++ b/frontend/src/features/imageSlice.ts
@@ -1,5 +1,6 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { Image } from '@/types/Media';
+import logger from '@/utils/logger';
 
 interface ImageState {
   images: Image[];
@@ -25,7 +26,7 @@ const imageSlice = createSlice({
       if (index >= -1 && index < imageList.length) {
         state.currentViewIndex = index;
       } else {
-        console.warn(
+        logger.warn(
           `Invalid image index: ${index}. Valid range: -1 to ${
             imageList.length - 1
           }`,

--- a/frontend/src/features/onboardingSlice.ts
+++ b/frontend/src/features/onboardingSlice.ts
@@ -1,5 +1,6 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { STEPS } from '@/constants/steps';
+import logger from '@/utils/logger';
 
 const STEP_NAMES = Object.values(STEPS);
 
@@ -38,7 +39,7 @@ const onboardingSlice = createSlice({
       if (stepIndex >= 0 && stepIndex < state.stepStatus.length) {
         state.stepStatus[stepIndex] = true;
       } else {
-        console.warn(
+        logger.warn(
           `Invalid step index: ${stepIndex}. Valid range: 0-${state.stepStatus.length - 1}`,
         );
       }

--- a/frontend/src/hooks/UseVideos.ts
+++ b/frontend/src/hooks/UseVideos.ts
@@ -2,6 +2,7 @@
 
 import { convertFileSrc, invoke } from '@tauri-apps/api/core';
 import { useState, useEffect } from 'react';
+import logger from '@/utils/logger';
 
 interface VideoData {
   original: string;
@@ -35,7 +36,7 @@ export const useVideos = (folderPaths: string[]) => {
 
         // Ensure response is in the expected format
         if (!response || typeof response !== 'object') {
-          console.error('Invalid response format:', response);
+          logger.error('Invalid response format:', response);
           setLoading(false);
           return;
         }
@@ -92,7 +93,7 @@ export const useVideos = (folderPaths: string[]) => {
         }
         setVideos(videoUrls);
       } catch (error) {
-        console.error('Error fetching videos:', error);
+        logger.error('Error fetching videos:', error);
       } finally {
         setLoading(false);
       }

--- a/frontend/src/hooks/folderService.ts
+++ b/frontend/src/hooks/folderService.ts
@@ -1,3 +1,5 @@
+import logger from '@/utils/logger';
+
 const FOLDER_PATHS_KEY = 'folderPaths';
 
 export const FolderService = {
@@ -14,7 +16,7 @@ export const FolderService = {
       localStorage.setItem(FOLDER_PATHS_KEY, JSON.stringify([]));
       return [];
     } catch (error) {
-      console.error(
+      logger.error(
         'Error reading or parsing folder paths from localStorage:',
         error,
       );
@@ -27,7 +29,7 @@ export const FolderService = {
     try {
       localStorage.setItem(FOLDER_PATHS_KEY, JSON.stringify(paths));
     } catch (error) {
-      console.error('Error saving folder paths to localStorage:', error);
+      logger.error('Error saving folder paths to localStorage:', error);
     }
   },
 };

--- a/frontend/src/hooks/selectFile.ts
+++ b/frontend/src/hooks/selectFile.ts
@@ -1,5 +1,6 @@
 import { open } from '@tauri-apps/plugin-dialog';
 import { useCallback } from 'react';
+import logger from '@/utils/logger';
 interface UseFolderPickerOptions {
   title?: string;
 }
@@ -30,7 +31,7 @@ export const useFile = (
       }
       return null;
     } catch (error) {
-      console.error('Error picking File:', error);
+      logger.error('Error picking File:', error);
       return null;
     }
   }, [title]);

--- a/frontend/src/hooks/useFolder.ts
+++ b/frontend/src/hooks/useFolder.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect } from 'react';
 import { open } from '@tauri-apps/plugin-dialog';
 import { usePictoMutation } from './useQueryExtension';
 import { addFolder } from '@/api/api-functions';
+import logger from '@/utils/logger';
 interface UseFolderPickerOptions {
   title?: string;
 }
@@ -27,11 +28,11 @@ export const useFolder = (
 
   useEffect(() => {
     if (addFolderPending) {
-      console.log('Adding folder...');
+      logger.info('Adding folder...');
     } else if (addFolderSuccess) {
-      console.log('Folder added successfully');
+      logger.info('Folder added successfully');
     } else if (addFolderError) {
-      console.error('Error adding folder');
+      logger.error('Error adding folder');
     }
   }, [addFolderSuccess, addFolderError, addFolderPending]);
 
@@ -48,7 +49,7 @@ export const useFolder = (
       }
       return null;
     } catch (error) {
-      console.error('Error picking folder:', error);
+      logger.error('Error picking folder:', error);
       return null;
     }
   }, [title]);

--- a/frontend/src/hooks/useFolderOperations.tsx
+++ b/frontend/src/hooks/useFolderOperations.tsx
@@ -77,10 +77,8 @@ export const useFolderOperations = () => {
 
   useEffect(() => {
     if (taggingStatusQuery.isError) {
-      logger.error('Failed to fetch tagging status:', taggingStatusQuery.error);
-
       const errorMessage = taggingStatusQuery.errorMessage || 'Unknown error';
-      logger.warn(`Tagging status query failed: ${errorMessage}`);
+      logger.error('Failed to fetch tagging status:', errorMessage, taggingStatusQuery.error);
     }
   }, [
     taggingStatusQuery.isError,

--- a/frontend/src/hooks/useFolderOperations.tsx
+++ b/frontend/src/hooks/useFolderOperations.tsx
@@ -77,10 +77,7 @@ export const useFolderOperations = () => {
 
   useEffect(() => {
     if (taggingStatusQuery.isError) {
-      logger.error(
-        'Failed to fetch tagging status:',
-        taggingStatusQuery.error,
-      );
+      logger.error('Failed to fetch tagging status:', taggingStatusQuery.error);
 
       const errorMessage = taggingStatusQuery.errorMessage || 'Unknown error';
       logger.warn(`Tagging status query failed: ${errorMessage}`);

--- a/frontend/src/hooks/useFolderOperations.tsx
+++ b/frontend/src/hooks/useFolderOperations.tsx
@@ -78,7 +78,11 @@ export const useFolderOperations = () => {
   useEffect(() => {
     if (taggingStatusQuery.isError) {
       const errorMessage = taggingStatusQuery.errorMessage || 'Unknown error';
-      logger.error('Failed to fetch tagging status:', errorMessage, taggingStatusQuery.error);
+      logger.error(
+        'Failed to fetch tagging status:',
+        errorMessage,
+        taggingStatusQuery.error,
+      );
     }
   }, [
     taggingStatusQuery.isError,

--- a/frontend/src/hooks/useFolderOperations.tsx
+++ b/frontend/src/hooks/useFolderOperations.tsx
@@ -12,6 +12,7 @@ import { setFolders, setTaggingStatus } from '@/features/folderSlice';
 import { FolderDetails } from '@/types/Folder';
 import { useMutationFeedback } from './useMutationFeedback';
 import { getFoldersTaggingStatus } from '@/api/api-functions/folders';
+import logger from '@/utils/logger';
 
 /**
  * Custom hook for folder operations
@@ -76,13 +77,13 @@ export const useFolderOperations = () => {
 
   useEffect(() => {
     if (taggingStatusQuery.isError) {
-      console.error(
+      logger.error(
         'Failed to fetch tagging status:',
         taggingStatusQuery.error,
       );
 
       const errorMessage = taggingStatusQuery.errorMessage || 'Unknown error';
-      console.warn(`Tagging status query failed: ${errorMessage}`);
+      logger.warn(`Tagging status query failed: ${errorMessage}`);
     }
   }, [
     taggingStatusQuery.isError,

--- a/frontend/src/utils/logger.ts
+++ b/frontend/src/utils/logger.ts
@@ -1,0 +1,75 @@
+import {
+  debug as tauriDebug,
+  info as tauriInfo,
+  warn as tauriWarn,
+  error as tauriError,
+  trace as tauriTrace,
+} from '@tauri-apps/plugin-log';
+import { isTauriEnvironment } from '@/utils/tauriUtils';
+
+/**
+ * Logger utility that routes logs through Tauri's native logging plugin.
+ *
+ * In Tauri: logs are written to the app's log file and are NOT exposed
+ * in the browser console (solving the privacy concern).
+ *
+ * In browser (dev without Tauri): falls back to console methods so
+ * developers can still see output during web-only development.
+ */
+
+function stringify(...args: unknown[]): string {
+  return args
+    .map((arg) =>
+      typeof arg === 'object' ? JSON.stringify(arg, null, 2) : String(arg),
+    )
+    .join(' ');
+}
+
+const logger = {
+  trace(...args: unknown[]) {
+    if (isTauriEnvironment()) {
+      tauriTrace(stringify(...args));
+    } else {
+      console.debug('[TRACE]', ...args);
+    }
+  },
+
+  debug(...args: unknown[]) {
+    if (isTauriEnvironment()) {
+      tauriDebug(stringify(...args));
+    } else {
+      console.debug(...args);
+    }
+  },
+
+  info(...args: unknown[]) {
+    if (isTauriEnvironment()) {
+      tauriInfo(stringify(...args));
+    } else {
+      console.info(...args);
+    }
+  },
+
+  warn(...args: unknown[]) {
+    if (isTauriEnvironment()) {
+      tauriWarn(stringify(...args));
+    } else {
+      console.warn(...args);
+    }
+  },
+
+  error(...args: unknown[]) {
+    if (isTauriEnvironment()) {
+      tauriError(stringify(...args));
+    } else {
+      console.error(...args);
+    }
+  },
+
+  /** Alias for info — drop-in replacement for console.log */
+  log(...args: unknown[]) {
+    this.info(...args);
+  },
+};
+
+export default logger;


### PR DESCRIPTION
Fixes: #1091 
@rahulharpal1603 
Issue - The core issue was dumping the full image object (file paths, metadata, favourite status) into the browser devtools in production. 

Steps to reproduce:
1 Open PictoPy and navigate to Home page
2 Open browser developer console (F12)
3 Hover over any image and click the heart icon (favorite)
4 Result: Image data is logged to console (privacy concern)

Solution Implemented:
- Integrated [tauri-plugin-log] - logs now route through Tauri's native logging system (written to log files on disk, not exposed in the browser console).

To view the logs live in the terminal use the below command:
- `Get-Content "C:\Users\<username>\AppData\Local\org.aossie.pictopy\logs\PictoPy.log" -Wait -Tail 50`

@aurthitaacharya-afk I also tried contacting you, look into this pr and if you have a better approach do let me know!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Native desktop logging enabled to capture app diagnostics.

* **Chores**
  * Centralized logger added and used across the app, replacing console logs.
  * Native logging plugin and desktop capability permissions integrated.
  * Update/download flow initializes download state more robustly (progress/reset handling).
  * Minor UI prop added to folder picker to support cache deletion handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->