### PR TITLE
Feat/rename image 1192

### DIFF
--- a/backend/app/database/images.py
+++ b/backend/app/database/images.py
@@ -78,6 +78,18 @@ def db_create_images_table() -> None:
     """
     )
 
+    # Ensure Memories feature columns exist on older databases
+    cursor.execute("PRAGMA table_info(images)")
+    existing_columns = {row[1] for row in cursor.fetchall()}
+
+    for column_name, column_type in [
+        ("latitude", "REAL"),
+        ("longitude", "REAL"),
+        ("captured_at", "DATETIME"),
+    ]:
+        if column_name not in existing_columns:
+            cursor.execute(f"ALTER TABLE images ADD COLUMN {column_name} {column_type}")
+
     # Create indexes for Memories feature queries
     cursor.execute("CREATE INDEX IF NOT EXISTS ix_images_latitude ON images(latitude)")
     cursor.execute(

--- a/backend/app/database/images.py
+++ b/backend/app/database/images.py
@@ -261,6 +261,30 @@ def db_get_all_images(tagged: Union[bool, None] = None) -> List[dict]:
         conn.close()
 
 
+def db_get_image_path_by_id(image_id: ImageId) -> Optional[ImagePath]:
+    """
+    Get the filesystem path for a single image by its ID.
+
+    Args:
+        image_id: ID of the image to look up
+
+    Returns:
+        The image path as a string, or None if the image is not found or an error occurs.
+    """
+    conn = _connect()
+    cursor = conn.cursor()
+
+    try:
+        cursor.execute("SELECT path FROM images WHERE id = ?", (image_id,))
+        row = cursor.fetchone()
+        return row[0] if row else None
+    except Exception as e:
+        logger.error(f"Error getting image path for id {image_id}: {e}")
+        return None
+    finally:
+        conn.close()
+
+
 def db_get_untagged_images() -> List[UntaggedImageRecord]:
     """
     Find all images that need AI tagging.

--- a/backend/app/schemas/images.py
+++ b/backend/app/schemas/images.py
@@ -132,3 +132,17 @@ class DeleteThumbnailsResponse(BaseModel):
 class GetThumbnailPathResponse(BaseModel):
     success: bool
     thumbnailPath: str
+
+
+class RenameImageRequest(BaseModel):
+    """Request model for renaming an image."""
+
+    image_id: str
+    rename: str
+
+
+class RenameImageResponse(BaseModel):
+    """Response model for image rename operations."""
+
+    success: bool
+    message: str

--- a/backend/tests/test_images.py
+++ b/backend/tests/test_images.py
@@ -1,0 +1,139 @@
+import os
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.routes.images import router as images_router
+
+app = FastAPI()
+app.include_router(images_router, prefix="/images")
+client = TestClient(app)
+
+
+@pytest.fixture
+def sample_image_id():
+    return "image_123"
+
+
+@pytest.fixture
+def sample_image_path(tmp_path):
+    image_file = tmp_path / "old_name.jpg"
+    image_file.write_bytes(b"dummy image data")
+    return str(image_file)
+
+
+class TestRenameImageAPI:
+    """Tests for the /images/rename-image endpoint."""
+
+    @patch("app.routes.images.db_get_image_path_by_id")
+    @patch("app.routes.images.os.rename")
+    def test_rename_image_success(
+        self, mock_rename, mock_get_path, sample_image_id, sample_image_path
+    ):
+        mock_get_path.return_value = sample_image_path
+
+        response = client.put(
+            "/images/rename-image",
+            json={"image_id": sample_image_id, "rename": "new_name"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert "Successfully renamed image" in data["message"]
+
+        folder = os.path.dirname(sample_image_path)
+        ext = os.path.splitext(sample_image_path)[1]
+        expected_new_path = os.path.join(folder, "new_name" + ext)
+
+        mock_get_path.assert_called_once_with(sample_image_id)
+        mock_rename.assert_called_once_with(sample_image_path, expected_new_path)
+
+    def test_rename_image_empty_id(self):
+        response = client.put(
+            "/images/rename-image",
+            json={"image_id": "   ", "rename": "new_name"},
+        )
+
+        assert response.status_code == 400
+        data = response.json()
+        assert data["detail"]["success"] is False
+        assert data["detail"]["error"] == "Validation Error"
+        assert "Image ID cannot be empty" in data["detail"]["message"]
+
+    def test_rename_image_empty_name(self, sample_image_id):
+        response = client.put(
+            "/images/rename-image",
+            json={"image_id": sample_image_id, "rename": "   "},
+        )
+
+        assert response.status_code == 400
+        data = response.json()
+        assert data["detail"]["success"] is False
+        assert data["detail"]["error"] == "Validation Error"
+        assert "New image name cannot be empty" in data["detail"]["message"]
+
+    @pytest.mark.parametrize("invalid_char", ['*', '^', '!', '/', '\\\\', '?', '|'])
+    def test_rename_image_invalid_characters(self, sample_image_id, invalid_char):
+        response = client.put(
+            "/images/rename-image",
+            json={"image_id": sample_image_id, "rename": f"bad{invalid_char}name"},
+        )
+
+        assert response.status_code == 400
+        data = response.json()
+        assert data["detail"]["success"] is False
+        assert data["detail"]["error"] == "Validation Error"
+
+    @patch("app.routes.images.db_get_image_path_by_id")
+    def test_rename_image_not_found(self, mock_get_path, sample_image_id):
+        mock_get_path.return_value = None
+
+        response = client.put(
+            "/images/rename-image",
+            json={"image_id": sample_image_id, "rename": "new_name"},
+        )
+
+        assert response.status_code == 404
+        data = response.json()
+        assert data["detail"]["success"] is False
+        assert data["detail"]["error"] == "Image Not Found"
+
+    @patch("app.routes.images.db_get_image_path_by_id")
+    @patch("app.routes.images.os.path.exists")
+    def test_rename_image_target_exists(
+        self, mock_exists, mock_get_path, sample_image_id, sample_image_path
+    ):
+        mock_get_path.return_value = sample_image_path
+        mock_exists.return_value = True
+
+        response = client.put(
+            "/images/rename-image",
+            json={"image_id": sample_image_id, "rename": "new_name"},
+        )
+
+        assert response.status_code == 400
+        data = response.json()
+        assert data["detail"]["success"] is False
+        assert data["detail"]["error"] == "File Exists"
+
+    @patch("app.routes.images.db_get_image_path_by_id")
+    @patch("app.routes.images.os.rename")
+    def test_rename_image_unexpected_error(
+        self, mock_rename, mock_get_path, sample_image_id, sample_image_path
+    ):
+        mock_get_path.return_value = sample_image_path
+        mock_rename.side_effect = OSError("disk error")
+
+        response = client.put(
+            "/images/rename-image",
+            json={"image_id": sample_image_id, "rename": "new_name"},
+        )
+
+        assert response.status_code == 500
+        data = response.json()
+        assert data["detail"]["success"] is False
+        assert data["detail"]["error"] == "Internal server error"
+

--- a/backend/tests/test_images.py
+++ b/backend/tests/test_images.py
@@ -29,10 +29,17 @@ class TestRenameImageAPI:
 
     @patch("app.routes.images.db_get_image_path_by_id")
     @patch("app.routes.images.os.rename")
+    @patch("app.routes.images.os.open")
     def test_rename_image_success(
-        self, mock_rename, mock_get_path, sample_image_id, sample_image_path
+        self,
+        mock_open,
+        mock_rename,
+        mock_get_path,
+        sample_image_id,
+        sample_image_path,
     ):
         mock_get_path.return_value = sample_image_path
+        mock_open.return_value = 3  # dummy file descriptor
 
         response = client.put(
             "/images/rename-image",
@@ -49,6 +56,7 @@ class TestRenameImageAPI:
         expected_new_path = os.path.join(folder, "new_name" + ext)
 
         mock_get_path.assert_called_once_with(sample_image_id)
+        mock_open.assert_called_once()
         mock_rename.assert_called_once_with(sample_image_path, expected_new_path)
 
     def test_rename_image_empty_id(self):
@@ -75,7 +83,9 @@ class TestRenameImageAPI:
         assert data["detail"]["error"] == "Validation Error"
         assert "New image name cannot be empty" in data["detail"]["message"]
 
-    @pytest.mark.parametrize("invalid_char", ['*', '^', '!', '/', '\\\\', '?', '|'])
+    @pytest.mark.parametrize(
+        "invalid_char", ['*', '^', '!', '/', '\\', '?', '|', '<', '>', ':', '"']
+    )
     def test_rename_image_invalid_characters(self, sample_image_id, invalid_char):
         response = client.put(
             "/images/rename-image",
@@ -102,12 +112,12 @@ class TestRenameImageAPI:
         assert data["detail"]["error"] == "Image Not Found"
 
     @patch("app.routes.images.db_get_image_path_by_id")
-    @patch("app.routes.images.os.path.exists")
+    @patch("app.routes.images.os.open")
     def test_rename_image_target_exists(
-        self, mock_exists, mock_get_path, sample_image_id, sample_image_path
+        self, mock_open, mock_get_path, sample_image_id, sample_image_path
     ):
         mock_get_path.return_value = sample_image_path
-        mock_exists.return_value = True
+        mock_open.side_effect = FileExistsError()
 
         response = client.put(
             "/images/rename-image",
@@ -120,11 +130,20 @@ class TestRenameImageAPI:
         assert data["detail"]["error"] == "File Exists"
 
     @patch("app.routes.images.db_get_image_path_by_id")
+    @patch("app.routes.images.os.unlink")
     @patch("app.routes.images.os.rename")
+    @patch("app.routes.images.os.open")
     def test_rename_image_unexpected_error(
-        self, mock_rename, mock_get_path, sample_image_id, sample_image_path
+        self,
+        mock_open,
+        mock_rename,
+        mock_unlink,
+        mock_get_path,
+        sample_image_id,
+        sample_image_path,
     ):
         mock_get_path.return_value = sample_image_path
+        mock_open.return_value = 3
         mock_rename.side_effect = OSError("disk error")
 
         response = client.put(
@@ -136,4 +155,5 @@ class TestRenameImageAPI:
         data = response.json()
         assert data["detail"]["success"] is False
         assert data["detail"]["error"] == "Internal server error"
+        mock_unlink.assert_called_once()
 

--- a/docs/backend/backend_python/openapi.json
+++ b/docs/backend/backend_python/openapi.json
@@ -926,6 +926,78 @@
         }
       }
     },
+    "/images/rename-image": {
+      "put": {
+        "tags": [
+          "Images"
+        ],
+        "summary": "Rename Image",
+        "description": "Rename an image file on disk based on its image ID.\n\nThe database record is updated separately by the sync microservice.",
+        "operationId": "rename_image_images_rename_image_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RenameImageRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RenameImageResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/app__schemas__images__ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/app__schemas__images__ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/app__schemas__images__ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/face-clusters/{cluster_id}": {
       "put": {
         "tags": [
@@ -2675,6 +2747,44 @@
           "success"
         ],
         "title": "RenameClusterResponse"
+      },
+      "RenameImageRequest": {
+        "properties": {
+          "image_id": {
+            "type": "string",
+            "title": "Image Id"
+          },
+          "rename": {
+            "type": "string",
+            "title": "Rename"
+          }
+        },
+        "type": "object",
+        "required": [
+          "image_id",
+          "rename"
+        ],
+        "title": "RenameImageRequest",
+        "description": "Request model for renaming an image."
+      },
+      "RenameImageResponse": {
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "title": "Success"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          }
+        },
+        "type": "object",
+        "required": [
+          "success",
+          "message"
+        ],
+        "title": "RenameImageResponse",
+        "description": "Response model for image rename operations."
       },
       "ShutdownResponse": {
         "properties": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -73,6 +73,7 @@
         "@vitejs/plugin-react": "^4.2.1",
         "autoprefixer": "^10.4.20",
         "babel-jest": "^29.7.0",
+        "baseline-browser-mapping": "^2.10.0",
         "eslint": "^8.57.1",
         "eslint-config-prettier": "^9.1.0",
         "eslint-config-react-app": "^7.0.1",
@@ -6588,13 +6589,16 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.20",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.20.tgz",
-      "integrity": "sha512-JMWsdF+O8Orq3EMukbUN1QfbLK9mX2CkUmQBcW2T0s8OmdAUL5LLM/6wFwSrqXzlXB13yhyK9gTKS1rIizOduQ==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
+      "integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/brace-expansion": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -88,6 +88,7 @@
     "@vitejs/plugin-react": "^4.2.1",
     "autoprefixer": "^10.4.20",
     "babel-jest": "^29.7.0",
+    "baseline-browser-mapping": "^2.10.0",
     "eslint": "^8.57.1",
     "eslint-config-prettier": "^9.1.0",
     "eslint-config-react-app": "^7.0.1",

--- a/frontend/src-tauri/src/main.rs
+++ b/frontend/src-tauri/src/main.rs
@@ -6,6 +6,7 @@ mod services;
 use sysinfo::System;
 use tauri::path::BaseDirectory;
 use tauri::{Manager, Window, WindowEvent};
+#[cfg(feature = "ci")]
 use tauri_plugin_shell::ShellExt;
 
 const ENDPOINTS: [(&str, &str, &str); 2] = [

--- a/frontend/src/api/api-functions/images.ts
+++ b/frontend/src/api/api-functions/images.ts
@@ -12,3 +12,14 @@ export const fetchAllImages = async (
   );
   return response.data;
 };
+
+export const renameImage = async (
+  imageId: string,
+  newName: string,
+): Promise<{ success: boolean; message: string }> => {
+  const response = await apiClient.put(imagesEndpoints.renameImage, {
+    image_id: imageId,
+    rename: newName,
+  });
+  return response.data;
+};

--- a/frontend/src/api/apiEndpoints.ts
+++ b/frontend/src/api/apiEndpoints.ts
@@ -1,6 +1,7 @@
 export const imagesEndpoints = {
   getAllImages: '/images/',
   setFavourite: '/images/toggle-favourite',
+  renameImage: '/images/rename-image',
 };
 
 export const faceClustersEndpoints = {

--- a/frontend/src/components/Media/MediaInfoPanel.tsx
+++ b/frontend/src/components/Media/MediaInfoPanel.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { open } from '@tauri-apps/plugin-shell';
 import {
@@ -11,6 +11,9 @@ import {
   SquareArrowOutUpRight,
 } from 'lucide-react';
 import { Image } from '@/types/Media';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { renameImage as renameImageApi } from '@/api/api-functions';
 
 interface MediaInfoPanelProps {
   show: boolean;
@@ -27,6 +30,11 @@ export const MediaInfoPanel: React.FC<MediaInfoPanelProps> = ({
   currentIndex,
   totalImages,
 }) => {
+  const [isRenaming, setIsRenaming] = useState(false);
+  const [newName, setNewName] = useState('');
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
   const getFormattedDate = () => {
     if (currentImage?.metadata?.date_created) {
       return new Date(currentImage.metadata.date_created).toLocaleDateString(
@@ -41,11 +49,26 @@ export const MediaInfoPanel: React.FC<MediaInfoPanelProps> = ({
     return 'Date not available';
   };
 
-  const getImageName = () => {
+  const getFileName = useCallback(() => {
     if (!currentImage) return 'Image';
-    // Handle both Unix (/) and Windows (\) path separators
     return currentImage.path?.split(/[/\\]/).pop() || 'Image';
-  };
+  }, [currentImage]);
+
+  const getBaseName = useCallback(() => {
+    const fileName = getFileName();
+    const lastDotIndex = fileName.lastIndexOf('.');
+    if (lastDotIndex <= 0) return fileName;
+    return fileName.substring(0, lastDotIndex);
+  }, [getFileName]);
+
+  const getExtension = useCallback(() => {
+    const fileName = getFileName();
+    const lastDotIndex = fileName.lastIndexOf('.');
+    if (lastDotIndex === -1 || lastDotIndex === fileName.length - 1) return '';
+    return fileName.substring(lastDotIndex);
+  }, [getFileName]);
+
+  const displayName = useMemo(() => getFileName(), [getFileName]);
 
   const handleLocationClick = async () => {
     if (currentImage?.metadata?.latitude && currentImage?.metadata?.longitude) {
@@ -55,6 +78,39 @@ export const MediaInfoPanel: React.FC<MediaInfoPanelProps> = ({
       } catch (error) {
         console.error('Failed to open map URL:', error);
       }
+    }
+  };
+
+  const startRenaming = () => {
+    setError(null);
+    setNewName(getBaseName());
+    setIsRenaming(true);
+  };
+
+  const cancelRenaming = () => {
+    setIsRenaming(false);
+    setError(null);
+  };
+
+  const handleRenameSubmit = async () => {
+    if (!currentImage || !newName.trim()) {
+      setError('Name cannot be empty.');
+      return;
+    }
+
+    try {
+      setIsSaving(true);
+      setError(null);
+      await renameImageApi(currentImage.id, newName.trim());
+      setIsRenaming(false);
+    } catch (e: any) {
+      const message =
+        e?.response?.data?.detail?.message ||
+        e?.response?.data?.message ||
+        'Failed to rename image.';
+      setError(message);
+    } finally {
+      setIsSaving(false);
     }
   };
 
@@ -85,13 +141,75 @@ export const MediaInfoPanel: React.FC<MediaInfoPanelProps> = ({
                 <ImageLucide className="h-5 w-5 text-blue-400" />
               </div>
               <div className="min-w-0 flex-1">
-                <p className="text-xs text-white/50">Name</p>
-                <p
-                  className="truncate font-medium text-white"
-                  title={getImageName()}
-                >
-                  {getImageName()}
-                </p>
+                <div className="flex items-center justify-between gap-2">
+                  <p className="text-xs text-white/50">Name</p>
+                  {!isRenaming && (
+                    <button
+                      type="button"
+                      onClick={startRenaming}
+                      className="text-xs text-blue-300 hover:text-blue-200"
+                    >
+                      Rename
+                    </button>
+                  )}
+                </div>
+                {isRenaming ? (
+                  <div className="mt-1 flex items-center gap-2">
+                    <div className="flex-1">
+                      <div className="flex items-center gap-1">
+                        <Input
+                          autoFocus
+                          value={newName}
+                          onChange={(e) => setNewName(e.target.value)}
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter') {
+                              e.preventDefault();
+                              handleRenameSubmit();
+                            } else if (e.key === 'Escape') {
+                              e.preventDefault();
+                              cancelRenaming();
+                            }
+                          }}
+                          className="h-8 text-sm"
+                          placeholder="Enter new name"
+                        />
+                        <span className="text-sm text-white/70">
+                          {getExtension()}
+                        </span>
+                      </div>
+                      {error && (
+                        <p className="mt-1 text-xs text-red-400">{error}</p>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-1">
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="h-8 cursor-pointer px-2 text-xs"
+                        onClick={handleRenameSubmit}
+                        disabled={isSaving}
+                      >
+                        Save
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        className="h-8 cursor-pointer px-2 text-xs text-white/70 hover:text-white"
+                        onClick={cancelRenaming}
+                        disabled={isSaving}
+                      >
+                        Cancel
+                      </Button>
+                    </div>
+                  </div>
+                ) : (
+                  <p
+                    className="truncate font-medium text-white"
+                    title={displayName}
+                  >
+                    {displayName}
+                  </p>
+                )}
               </div>
             </div>
 

--- a/frontend/src/hooks/useKeyboardNavigation.ts
+++ b/frontend/src/hooks/useKeyboardNavigation.ts
@@ -13,6 +13,16 @@ interface KeyboardHandlers {
 export const useKeyboardNavigation = (handlers: KeyboardHandlers) => {
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement | null;
+      if (
+        target &&
+        (target.tagName === 'INPUT' ||
+          target.tagName === 'TEXTAREA' ||
+          target.isContentEditable)
+      ) {
+        return;
+      }
+
       switch (e.key) {
         case 'Escape':
           handlers.onClose();


### PR DESCRIPTION
Fixes #1192


### Screenshots/Recordings:

https://github.com/user-attachments/assets/6e0d1279-366b-4d16-a9c9-bfe213f8b512

- Rename option visible in the Media Info panel for an image.
- Inline rename input showing the current file name (without extension) and the static extension label.
- Error message shown when attempting to use an invalid name (e.g. containing `*` or `!`), and successful rename reflected after saving.


### Additional Notes:
- Backend: Added `PUT /images/rename-image` which looks up an image by ID, validates the new name (disallowing characters like `<`, `>`, `:`, `"`, `/`, `\`, `|`, `?`, `*`, `!`, `^`), checks for existing files, and renames the file on disk without touching the database (which is updated by the sync microservice).
- Backend: Introduced `db_get_image_path_by_id` helper and request/response Pydantic models for the rename operation, plus unit tests in `backend/tests/test_images.py` covering success, validation errors, not-found, existing-target, and unexpected filesystem errors.
- Frontend: Exposed a `renameImage(imageId, newName)` API helper and wired it into `MediaInfoPanel` so users can rename the current image directly from the info panel via an inline text field.
- Frontend: Updated `useKeyboardNavigation` to ignore key events when typing in inputs/textareas/contenteditable elements so shortcuts like rotation (`r`) or toggling the info panel (`i`) do not fire while the rename field is focused.


## Checklist
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [x] If applicable, I have made corresponding changes or additions to the documentation (OpenAPI spec updated for the new endpoint)
- [x] If applicable, I have made corresponding changes or additions to tests (added tests for `/images/rename-image`)
- [x] My changes generate no new warnings or errors (lint checks pass locally)
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.


## AI Usage Disclosure
- [x] I used AI-assisted tools (such as Cursor / ChatGPT) to help design and/or implement this PR.
- [ ] I did not use AI-assisted tools for this PR.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added image rename endpoint with validation, collision protection, and structured error responses
  * Added inline rename UI in media panel with Save/Cancel and user feedback
  * Frontend API integration for renaming and keyboard behavior change to avoid triggering shortcuts while typing

* **Tests**
  * Added comprehensive tests for the image rename flow, validations, and error cases

* **Chores**
  * Added browser mapping library
  * Added backward-compatible database migration for Memories columns
<!-- end of auto-generated comment: release notes by coderabbit.ai -->