### PR TITLE
Fix: use project logger to prevent duplicate logs in images utility

### DIFF
--- a/backend/app/utils/images.py
+++ b/backend/app/utils/images.py
@@ -27,7 +27,6 @@ logger = get_logger(__name__)
 # GPS EXIF tag constant
 GPS_INFO_TAG = 34853
 
-logger = logging.getLogger(__name__)
 
 
 def image_util_process_folder_images(folder_data: List[Tuple[str, int, bool]]) -> bool:


### PR DESCRIPTION
## Problem:
The images utility initialized its own logger instead of using the project's centralized logging configuration.  
This resulted in duplicate log outputs when the module was imported multiple times.

## Root Cause:
`logging.getLogger(__name__)` was used alongside the project's `get_logger`, causing multiple handlers to attach to the same module logger.

## Solution:
Removed the redundant logger initialization and used the project's logging setup consistently.

## Impact:
- Eliminates duplicate log entries
- Keeps logging behavior consistent across modules
- No functional behavior changed

## Verification:
Ran the module after modification — logs now appear only once and all features work as before.

Fixes #815