### PR TITLE
Fix/toggle favourite 404

### DIFF
--- a/backend/app/database/images.py
+++ b/backend/app/database/images.py
@@ -288,7 +288,7 @@ def db_get_image_by_id(image_id: str) -> Optional[dict]:
         return {
             "id": row[0],
             "path": row[1],
-            "folder_id": str(row[2]) if row[2] else None,
+            "folder_id": str(row[2]) if row[2] is not None else None,
             "thumbnailPath": row[3],
             "metadata": image_util_parse_metadata(row[4]),
             "isTagged": bool(row[5]),

--- a/backend/app/database/images.py
+++ b/backend/app/database/images.py
@@ -484,13 +484,13 @@ def db_delete_images_by_ids(image_ids: List[ImageId]) -> bool:
         conn.close()
 
 
-def db_toggle_image_favourite_status(image_id: str) -> bool:
+def db_toggle_image_favourite_status(image_id: str) -> Optional[bool]:
     conn = sqlite3.connect(DATABASE_PATH)
     cursor = conn.cursor()
     try:
         cursor.execute("SELECT id FROM images WHERE id = ?", (image_id,))
         if not cursor.fetchone():
-            return False
+            return None
         cursor.execute(
             """
             UPDATE images
@@ -501,10 +501,10 @@ def db_toggle_image_favourite_status(image_id: str) -> bool:
         )
         conn.commit()
         return cursor.rowcount > 0
-    except Exception as e:
-        logger.error(f"Database error: {e}")
+    except Exception:
+        logger.exception("Database error while toggling favourite")
         conn.rollback()
-        return False
+        raise
     finally:
         conn.close()
 

--- a/backend/app/database/images.py
+++ b/backend/app/database/images.py
@@ -249,6 +249,59 @@ def db_get_all_images(tagged: Union[bool, None] = None) -> List[dict]:
         conn.close()
 
 
+def db_get_image_by_id(image_id: str) -> Optional[dict]:
+    """
+    Get a single image by its ID, including tags.
+    Does not catch exceptions, allowing them to propagate for proper error handling.
+    """
+    conn = _connect()
+    cursor = conn.cursor()
+
+    try:
+        query = """
+            SELECT 
+                i.id, 
+                i.path, 
+                i.folder_id, 
+                i.thumbnailPath, 
+                i.metadata, 
+                i.isTagged,
+                i.isFavourite,
+                i.latitude,
+                i.longitude,
+                i.captured_at,
+                GROUP_CONCAT(m.name, ',') as tags
+            FROM images i
+            LEFT JOIN image_classes ic ON i.id = ic.image_id
+            LEFT JOIN mappings m ON ic.class_id = m.class_id
+            WHERE i.id = ?
+            GROUP BY i.id
+        """
+        cursor.execute(query, (image_id,))
+        row = cursor.fetchone()
+
+        if not row:
+            return None
+
+        from app.utils.images import image_util_parse_metadata
+
+        return {
+            "id": row[0],
+            "path": row[1],
+            "folder_id": str(row[2]) if row[2] else None,
+            "thumbnailPath": row[3],
+            "metadata": image_util_parse_metadata(row[4]),
+            "isTagged": bool(row[5]),
+            "isFavourite": bool(row[6]),
+            "latitude": row[7],
+            "longitude": row[8],
+            "captured_at": row[9] if row[9] else None,
+            "tags": row[10].split(",") if row[10] else None,
+        }
+    finally:
+        conn.close()
+
+
 def db_get_untagged_images() -> List[UntaggedImageRecord]:
     """
     Find all images that need AI tagging.

--- a/backend/app/routes/images.py
+++ b/backend/app/routes/images.py
@@ -102,18 +102,34 @@ def toggle_favourite(req: ToggleFavouriteRequest):
         success = db_toggle_image_favourite_status(image_id)
         if not success:
             raise HTTPException(
-                status_code=404, detail="Image not found or failed to toggle"
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=ErrorResponse(
+                    success=False,
+                    error="Image Not Found",
+                    message="Image not found or failed to toggle",
+                ).model_dump(),
             )
         # Fetch updated status to return
         image = next(
             (img for img in db_get_all_images() if img["id"] == image_id), None
         )
+        if image is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=ErrorResponse(
+                    success=False,
+                    error="Image Not Found",
+                    message="Image not found after toggling",
+                ).model_dump(),
+            )
         return {
             "success": True,
             "image_id": image_id,
             "isFavourite": image.get("isFavourite", False),
         }
 
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"error in /toggle-favourite route: {e}")
         raise HTTPException(status_code=500, detail=f"Internal server error: {e}")

--- a/backend/app/routes/images.py
+++ b/backend/app/routes/images.py
@@ -129,8 +129,15 @@ def toggle_favourite(req: ToggleFavouriteRequest):
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"error in /toggle-favourite route: {e}")
-        raise HTTPException(status_code=500, detail=f"Internal server error: {e}")
+        logger.exception("Unexpected error in /toggle-favourite route")
+        raise HTTPException(
+            status_code=500,
+            detail={
+                "success": False,
+                "error": "Internal Server Error",
+                "message": "An unexpected error occurred while toggling favourite",
+            },
+        )
 
 
 class ImageInfoResponse(BaseModel):

--- a/backend/app/routes/images.py
+++ b/backend/app/routes/images.py
@@ -99,8 +99,8 @@ class ToggleFavouriteRequest(BaseModel):
 def toggle_favourite(req: ToggleFavouriteRequest):
     image_id = req.image_id
     try:
-        success = db_toggle_image_favourite_status(image_id)
-        if not success:
+        result = db_toggle_image_favourite_status(image_id)
+        if result is None:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=ErrorResponse(

--- a/backend/app/routes/images.py
+++ b/backend/app/routes/images.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, HTTPException, Query, status
 from typing import List, Optional
-from app.database.images import db_get_all_images
+from app.database.images import db_get_all_images, db_get_image_by_id
 from app.schemas.images import ErrorResponse
 from app.utils.images import image_util_parse_metadata
 from pydantic import BaseModel
@@ -110,9 +110,7 @@ def toggle_favourite(req: ToggleFavouriteRequest):
                 ).model_dump(),
             )
         # Fetch updated status to return
-        image = next(
-            (img for img in db_get_all_images() if img["id"] == image_id), None
-        )
+        image = db_get_image_by_id(image_id)
         if image is None:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,

--- a/backend/app/utils/images.py
+++ b/backend/app/utils/images.py
@@ -550,13 +550,15 @@ def image_util_parse_metadata(db_metadata: Any) -> Mapping[str, Any]:
         return defaults
 
     parsed = {}
+
     if isinstance(db_metadata, str):
         try:
-            parsed = json.loads(db_metadata)
-        except Exception:
-            parsed = {}
+            temp = json.loads(db_metadata)
+            if isinstance(temp, dict):
+                parsed = temp
+        except (json.JSONDecodeError, TypeError):
+            pass
     elif isinstance(db_metadata, dict):
         parsed = db_metadata
-
     # Merge with defaults to ensure all fields exist
     return {**defaults, **parsed}

--- a/backend/app/utils/images.py
+++ b/backend/app/utils/images.py
@@ -534,18 +534,29 @@ def image_util_extract_metadata(image_path: str) -> dict:
 def image_util_parse_metadata(db_metadata: Any) -> Mapping[str, Any]:
     """
     Safely parses metadata from the database, which might be a JSON string or already a dict.
+    Ensures all required fields for MetadataModel are present.
     """
-    if not db_metadata:
-        return {}
+    defaults = {
+        "name": "Unknown",
+        "date_created": None,
+        "width": 0,
+        "height": 0,
+        "file_location": "Unknown",
+        "file_size": 0,
+        "item_type": "unknown",
+    }
 
+    if not db_metadata:
+        return defaults
+
+    parsed = {}
     if isinstance(db_metadata, str):
         try:
             parsed = json.loads(db_metadata)
-            return parsed if isinstance(parsed, dict) else {}
-        except (json.JSONDecodeError, TypeError):
-            return {}
+        except Exception:
+            parsed = {}
+    elif isinstance(db_metadata, dict):
+        parsed = db_metadata
 
-    if isinstance(db_metadata, dict):
-        return db_metadata
-
-    return {}
+    # Merge with defaults to ensure all fields exist
+    return {**defaults, **parsed}

--- a/backend/tests/test_toggle_favourite.py
+++ b/backend/tests/test_toggle_favourite.py
@@ -8,10 +8,10 @@ client = TestClient(app)
 
 @pytest.fixture
 def dummy_image():
-    # Insert a dummy image into the database
+    # Setup
+    image_id = "test-image-123"
     conn = sqlite3.connect(DATABASE_PATH)
     cursor = conn.cursor()
-    image_id = "test-image-123"
     # Metadata is empty string here to test the crash
     cursor.execute(
         "INSERT OR REPLACE INTO images (id, path, thumbnailPath, isFavourite, metadata) VALUES (?, ?, ?, ?, ?)",
@@ -19,15 +19,35 @@ def dummy_image():
     )
     conn.commit()
     conn.close()
-    return image_id
+    
+    yield image_id
+    
+    # Teardown: Clean up the dummy image after tests
+    conn = sqlite3.connect(DATABASE_PATH)
+    cursor = conn.cursor()
+    cursor.execute("DELETE FROM images WHERE id = ?", (image_id,))
+    conn.commit()
+    conn.close()
 
 def test_get_all_images_crash(dummy_image):
     """
-    Test that /images/ doesn't crash if metadata is empty.
+    Test that /images/ doesn't crash if metadata is empty and returns defaults.
     """
     response = client.get("/images/")
     assert response.status_code == 200
-    assert response.json()["success"] is True
+    data = response.json()
+    assert data["success"] is True
+    
+    # Verify metadata defaults are present in our dummy image
+    dummy_img_data = next((img for img in data["data"] if img["id"] == dummy_image), None)
+    assert dummy_img_data is not None
+    
+    metadata = dummy_img_data["metadata"]
+    assert metadata["name"] == "Unknown"
+    assert metadata["width"] == 0
+    assert metadata["height"] == 0
+    assert metadata["file_location"] == "Unknown"
+    assert metadata["item_type"] == "unknown"
 
 def test_toggle_favourite_non_existent_image():
     """

--- a/backend/tests/test_toggle_favourite.py
+++ b/backend/tests/test_toggle_favourite.py
@@ -1,0 +1,58 @@
+from fastapi.testclient import TestClient
+from main import app
+import pytest
+import sqlite3
+from app.config.settings import DATABASE_PATH
+
+client = TestClient(app)
+
+@pytest.fixture
+def dummy_image():
+    # Insert a dummy image into the database
+    conn = sqlite3.connect(DATABASE_PATH)
+    cursor = conn.cursor()
+    image_id = "test-image-123"
+    cursor.execute(
+        "INSERT OR REPLACE INTO images (id, path, isFavourite) VALUES (?, ?, ?)",
+        (image_id, "/tmp/test.jpg", 0)
+    )
+    conn.commit()
+    conn.close()
+    return image_id
+
+def test_toggle_favourite_non_existent_image():
+    """
+    Test that toggling a non-existent image returns 404, not 500.
+    This relates to issue #1179.
+    """
+    response = client.post(
+        "/images/toggle-favourite",
+        json={"image_id": "non-existent-id"}
+    )
+    
+    assert response.status_code == 404
+    assert response.json()["detail"]["success"] is False
+    assert response.json()["detail"]["error"] == "Image Not Found"
+    assert response.json()["detail"]["message"] == "Image not found or failed to toggle"
+
+def test_toggle_favourite_success(dummy_image):
+    """
+    Test that toggling an existing image works correctly.
+    """
+    # First toggle: 0 -> 1
+    response = client.post(
+        "/images/toggle-favourite",
+        json={"image_id": dummy_image}
+    )
+    assert response.status_code == 200
+    assert response.json()["success"] is True
+    assert response.json()["isFavourite"] is True
+    
+    # Second toggle: 1 -> 0
+    response = client.post(
+        "/images/toggle-favourite",
+        json={"image_id": dummy_image}
+    )
+    assert response.status_code == 200
+    assert response.json()["success"] is True
+    assert response.json()["isFavourite"] is False

--- a/backend/tests/test_toggle_favourite.py
+++ b/backend/tests/test_toggle_favourite.py
@@ -12,13 +12,22 @@ def dummy_image():
     conn = sqlite3.connect(DATABASE_PATH)
     cursor = conn.cursor()
     image_id = "test-image-123"
+    # Metadata is empty string here to test the crash
     cursor.execute(
-        "INSERT OR REPLACE INTO images (id, path, isFavourite) VALUES (?, ?, ?)",
-        (image_id, "/tmp/test.jpg", 0)
+        "INSERT OR REPLACE INTO images (id, path, thumbnailPath, isFavourite, metadata) VALUES (?, ?, ?, ?, ?)",
+        (image_id, "/tmp/test.jpg", "/tmp/thumb.jpg", 0, "")
     )
     conn.commit()
     conn.close()
     return image_id
+
+def test_get_all_images_crash(dummy_image):
+    """
+    Test that /images/ doesn't crash if metadata is empty.
+    """
+    response = client.get("/images/")
+    assert response.status_code == 200
+    assert response.json()["success"] is True
 
 def test_toggle_favourite_non_existent_image():
     """


### PR DESCRIPTION
###  Addressed Issues:
BUG: /images/toggle-favourite returns 500 instead of 404 for unknown image_id
Fixes #1179 


###  Screenshots/Recordings:
<img width="1920" height="1080" alt="Screenshot from 2026-03-03 21-27-25" src="https://github.com/user-attachments/assets/e52ac424-3f23-4d12-865f-b18f7a793d5c" />


###  Additional Notes:
 This PR fixes issue #1179, where the /images/toggle-favourite endpoint was incorrectly returning a 500 Internal Server Error instead of a 404 Not Found when an invalid image_id was provided now it returns a 404 when an invalid image_id is provided.


## Checklist
<!-- Mark items with [x] to indicate completion -->
- [ x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [ x] My code follows the project's code style and conventions
- [ x] If applicable, I have made corresponding changes or additions to the documentation
- [ x] If applicable, I have made corresponding changes or additions to tests
- [ x] My changes generate no new warnings or errors
- [ x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [ x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [ x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.

## AI Usage Disclosure

Check one of the checkboxes below:

- [ ] This PR does not contain AI-generated code at all.
- [ x] This PR contains AI-generated code. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools: i have used gemini cli for test generation

### ⚠️ AI Notice - Important!

We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Error responses are now structured (404/500) and HTTP errors are propagated correctly.
  * Toggle-favourite verifies image existence after toggling and returns not-found if absent.

* **Improvements**
  * Updated image retrieval to fetch the updated image directly.
  * Image metadata is always returned with required fields and sensible defaults.

* **Tests**
  * Added tests for toggle-favourite, empty metadata handling, and not-found responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->