### PR TITLE
feat: handle model initialization crash risk

### DIFF
--- a/backend/app/models/FaceNet.py
+++ b/backend/app/models/FaceNet.py
@@ -1,6 +1,5 @@
 # app/facenet/FaceNet.py
 
-import onnxruntime
 from app.utils.FaceNet import FaceNet_util_normalize_embedding
 from app.utils.ONNX import create_inference_session_with_fallback
 from app.logging.setup_logging import get_logger

--- a/backend/app/models/FaceNet.py
+++ b/backend/app/models/FaceNet.py
@@ -11,9 +11,19 @@ logger = get_logger(__name__)
 
 class FaceNet:
     def __init__(self, model_path):
-        self.session = onnxruntime.InferenceSession(
-            model_path, providers=ONNX_util_get_execution_providers()
-        )
+        try:
+            self.session = onnxruntime.InferenceSession(
+                model_path, providers=ONNX_util_get_execution_providers()
+            )
+        except Exception as e:
+            logger.warning(f"Failed to initialize InferenceSession with default providers: {e}. Falling back to CPUExecutionProvider.")
+            try:
+                self.session = onnxruntime.InferenceSession(
+                    model_path, providers=["CPUExecutionProvider"]
+                )
+            except Exception as cpu_e:
+                logger.error(f"Failed to initialize FaceNet InferenceSession with CPUExecutionProvider: {cpu_e}")
+                raise cpu_e
         self.input_tensor_name = self.session.get_inputs()[0].name
         self.output_tensor_name = self.session.get_outputs()[0].name
 

--- a/backend/app/models/FaceNet.py
+++ b/backend/app/models/FaceNet.py
@@ -2,7 +2,7 @@
 
 import onnxruntime
 from app.utils.FaceNet import FaceNet_util_normalize_embedding
-from app.utils.ONNX import ONNX_util_get_execution_providers
+from app.utils.ONNX import create_inference_session_with_fallback
 from app.logging.setup_logging import get_logger
 
 # Initialize logger
@@ -11,19 +11,9 @@ logger = get_logger(__name__)
 
 class FaceNet:
     def __init__(self, model_path):
-        try:
-            self.session = onnxruntime.InferenceSession(
-                model_path, providers=ONNX_util_get_execution_providers()
-            )
-        except Exception as e:
-            logger.warning(f"Failed to initialize InferenceSession with default providers: {e}. Falling back to CPUExecutionProvider.")
-            try:
-                self.session = onnxruntime.InferenceSession(
-                    model_path, providers=["CPUExecutionProvider"]
-                )
-            except Exception as cpu_e:
-                logger.error(f"Failed to initialize FaceNet InferenceSession with CPUExecutionProvider: {cpu_e}")
-                raise cpu_e
+        self.session = create_inference_session_with_fallback(
+            model_path, logger=logger, model_name="FaceNet"
+        )
         self.input_tensor_name = self.session.get_inputs()[0].name
         self.output_tensor_name = self.session.get_outputs()[0].name
 

--- a/backend/app/models/YOLO.py
+++ b/backend/app/models/YOLO.py
@@ -1,4 +1,3 @@
-import onnxruntime
 import time
 import cv2
 import numpy as np

--- a/backend/app/models/YOLO.py
+++ b/backend/app/models/YOLO.py
@@ -20,9 +20,19 @@ class YOLO:
         self.conf_threshold = conf_threshold
         self.iou_threshold = iou_threshold
         # Create ONNX session once and reuse it
-        self.session = onnxruntime.InferenceSession(
-            self.model_path, providers=ONNX_util_get_execution_providers()
-        )
+        try:
+            self.session = onnxruntime.InferenceSession(
+                self.model_path, providers=ONNX_util_get_execution_providers()
+            )
+        except Exception as e:
+            logger.warning(f"Failed to initialize InferenceSession with default providers: {e}. Falling back to CPUExecutionProvider.")
+            try:
+                self.session = onnxruntime.InferenceSession(
+                    self.model_path, providers=["CPUExecutionProvider"]
+                )
+            except Exception as cpu_e:
+                logger.error(f"Failed to initialize YOLO InferenceSession with CPUExecutionProvider: {cpu_e}")
+                raise cpu_e
 
         # Initialize model info
         self.get_input_details()

--- a/backend/app/models/YOLO.py
+++ b/backend/app/models/YOLO.py
@@ -8,7 +8,7 @@ from app.utils.YOLO import (
     YOLO_util_multiclass_nms,
 )
 from app.utils.memory_monitor import log_memory_usage
-from app.utils.ONNX import ONNX_util_get_execution_providers
+from app.utils.ONNX import create_inference_session_with_fallback
 from app.logging.setup_logging import get_logger
 
 logger = get_logger(__name__)
@@ -20,19 +20,9 @@ class YOLO:
         self.conf_threshold = conf_threshold
         self.iou_threshold = iou_threshold
         # Create ONNX session once and reuse it
-        try:
-            self.session = onnxruntime.InferenceSession(
-                self.model_path, providers=ONNX_util_get_execution_providers()
-            )
-        except Exception as e:
-            logger.warning(f"Failed to initialize InferenceSession with default providers: {e}. Falling back to CPUExecutionProvider.")
-            try:
-                self.session = onnxruntime.InferenceSession(
-                    self.model_path, providers=["CPUExecutionProvider"]
-                )
-            except Exception as cpu_e:
-                logger.error(f"Failed to initialize YOLO InferenceSession with CPUExecutionProvider: {cpu_e}")
-                raise cpu_e
+        self.session = create_inference_session_with_fallback(
+            self.model_path, logger=logger, model_name="YOLO"
+        )
 
         # Initialize model info
         self.get_input_details()

--- a/backend/app/utils/ONNX.py
+++ b/backend/app/utils/ONNX.py
@@ -1,4 +1,6 @@
 import onnxruntime
+import logging
+from typing import Optional
 
 
 def ONNX_util_get_execution_providers() -> list:
@@ -30,7 +32,11 @@ def ONNX_util_get_execution_providers() -> list:
         return ["CPUExecutionProvider"]
 
 
-def create_inference_session_with_fallback(model_path, logger, model_name=""):
+def create_inference_session_with_fallback(
+    model_path: str,
+    logger: logging.Logger,
+    model_name: str = ""
+) -> onnxruntime.InferenceSession:
     """
     Create an ONNX InferenceSession with fallback to CPUExecutionProvider on failure.
 

--- a/backend/app/utils/ONNX.py
+++ b/backend/app/utils/ONNX.py
@@ -28,3 +28,38 @@ def ONNX_util_get_execution_providers() -> list:
         return onnxruntime.get_available_providers()
     else:
         return ["CPUExecutionProvider"]
+
+
+def create_inference_session_with_fallback(model_path, logger, model_name=""):
+    """
+    Create an ONNX InferenceSession with fallback to CPUExecutionProvider on failure.
+
+    Args:
+        model_path (str): Path to the ONNX model file.
+        logger (logging.Logger): Logger instance.
+        model_name (str): Optional name of the model for logging purposes.
+
+    Returns:
+        onnxruntime.InferenceSession: The initialized inference session.
+
+    Raises:
+        Exception: If initialization fails even with the fallback.
+    """
+    try:
+        return onnxruntime.InferenceSession(
+            model_path, providers=ONNX_util_get_execution_providers()
+        )
+    except Exception as e:
+        logger.warning(
+            f"Failed to initialize InferenceSession with default providers: {e}. Falling back to CPUExecutionProvider."
+        )
+        try:
+            return onnxruntime.InferenceSession(
+                model_path, providers=["CPUExecutionProvider"]
+            )
+        except Exception as cpu_e:
+            model_str = f"{model_name} " if model_name else ""
+            logger.error(
+                f"Failed to initialize {model_str}InferenceSession with CPUExecutionProvider: {cpu_e}"
+            )
+            raise

--- a/backend/tests/test_onnx_utils.py
+++ b/backend/tests/test_onnx_utils.py
@@ -2,56 +2,53 @@ import pytest
 from unittest.mock import patch, MagicMock
 from app.utils.ONNX import create_inference_session_with_fallback
 
-def test_create_inference_session_success():
+@pytest.fixture
+def onnx_mocks():
     with patch('app.utils.ONNX.onnxruntime.InferenceSession') as mock_session, \
          patch('app.utils.ONNX.ONNX_util_get_execution_providers', return_value=['CUDAExecutionProvider']):
-        
-        mock_logger = MagicMock()
-        session = create_inference_session_with_fallback('dummy_path', mock_logger)
-        
-        mock_session.assert_called_once_with('dummy_path', providers=['CUDAExecutionProvider'])
-        mock_logger.warning.assert_not_called()
-        mock_logger.error.assert_not_called()
-        assert session == mock_session.return_value
+        yield mock_session, MagicMock()
 
-def test_create_inference_session_fallback_success():
-    with patch('app.utils.ONNX.onnxruntime.InferenceSession') as mock_session, \
-         patch('app.utils.ONNX.ONNX_util_get_execution_providers', return_value=['CUDAExecutionProvider']):
-        
-        # Make the first call raise an exception, and the second call succeed
-        cpu_success_mock = MagicMock()
-        mock_session.side_effect = [Exception("CUDA failed"), cpu_success_mock]
-        
-        mock_logger = MagicMock()
-        session = create_inference_session_with_fallback('dummy_path', mock_logger)
-        
-        assert mock_session.call_count == 2
-        mock_session.assert_any_call('dummy_path', providers=['CUDAExecutionProvider'])
-        mock_session.assert_any_call('dummy_path', providers=['CPUExecutionProvider'])
-        
-        mock_logger.warning.assert_called_once()
-        assert "CUDA failed" in mock_logger.warning.call_args[0][0]
-        mock_logger.error.assert_not_called()
-        
-        # Second value in side_effect is the success mock
-        # Verify the returned session is the successful CPU fallback mock
-        assert session == cpu_success_mock
+def test_create_inference_session_success(onnx_mocks):
+    mock_session, mock_logger = onnx_mocks
+    session = create_inference_session_with_fallback('dummy_path', mock_logger)
+    
+    mock_session.assert_called_once_with('dummy_path', providers=['CUDAExecutionProvider'])
+    mock_logger.warning.assert_not_called()
+    mock_logger.error.assert_not_called()
+    assert session == mock_session.return_value
 
-def test_create_inference_session_fallback_failure():
-    with patch('app.utils.ONNX.onnxruntime.InferenceSession') as mock_session, \
-         patch('app.utils.ONNX.ONNX_util_get_execution_providers', return_value=['CUDAExecutionProvider']):
-        
-        # Make both calls raise an exception
-        mock_session.side_effect = [Exception("CUDA failed"), Exception("CPU failed")]
-        
-        mock_logger = MagicMock()
-        
-        with pytest.raises(Exception, match="CPU failed"):
-            create_inference_session_with_fallback('dummy_path', mock_logger, model_name="TestModel")
-            
-        assert mock_session.call_count == 2
-        mock_logger.warning.assert_called_once()
-        mock_logger.error.assert_called_once()
-        assert "TestModel" in mock_logger.error.call_args[0][0]
-        assert "CPU failed" in mock_logger.error.call_args[0][0]
+def test_create_inference_session_fallback_success(onnx_mocks):
+    mock_session, mock_logger = onnx_mocks
+    
+    # Make the first call raise an exception, and the second call succeed
+    cpu_success_mock = MagicMock()
+    mock_session.side_effect = [Exception("CUDA failed"), cpu_success_mock]
+    
+    session = create_inference_session_with_fallback('dummy_path', mock_logger)
+    
+    assert mock_session.call_count == 2
+    mock_session.assert_any_call('dummy_path', providers=['CUDAExecutionProvider'])
+    mock_session.assert_any_call('dummy_path', providers=['CPUExecutionProvider'])
+    
+    mock_logger.warning.assert_called_once()
+    assert "CUDA failed" in mock_logger.warning.call_args[0][0]
+    mock_logger.error.assert_not_called()
+    
+    # Second value in side_effect is the success mock
+    # Verify the returned session is the successful CPU fallback mock
+    assert session == cpu_success_mock
 
+def test_create_inference_session_fallback_failure(onnx_mocks):
+    mock_session, mock_logger = onnx_mocks
+    
+    # Make both calls raise an exception
+    mock_session.side_effect = [Exception("CUDA failed"), Exception("CPU failed")]
+    
+    with pytest.raises(Exception, match="CPU failed"):
+        create_inference_session_with_fallback('dummy_path', mock_logger, model_name="TestModel")
+        
+    assert mock_session.call_count == 2
+    mock_logger.warning.assert_called_once()
+    mock_logger.error.assert_called_once()
+    assert "TestModel" in mock_logger.error.call_args[0][0]
+    assert "CPU failed" in mock_logger.error.call_args[0][0]

--- a/backend/tests/test_onnx_utils.py
+++ b/backend/tests/test_onnx_utils.py
@@ -33,7 +33,8 @@ def test_create_inference_session_fallback_success():
         mock_logger.error.assert_not_called()
         
         # Second value in side_effect is the success mock
-        assert session is not None
+        # Verify the returned session is the successful CPU fallback mock
+        assert session == mock_session.side_effect[1]
 
 def test_create_inference_session_fallback_failure():
     with patch('app.utils.ONNX.onnxruntime.InferenceSession') as mock_session, \
@@ -52,3 +53,4 @@ def test_create_inference_session_fallback_failure():
         mock_logger.error.assert_called_once()
         assert "TestModel" in mock_logger.error.call_args[0][0]
         assert "CPU failed" in mock_logger.error.call_args[0][0]
+

--- a/backend/tests/test_onnx_utils.py
+++ b/backend/tests/test_onnx_utils.py
@@ -19,7 +19,8 @@ def test_create_inference_session_fallback_success():
          patch('app.utils.ONNX.ONNX_util_get_execution_providers', return_value=['CUDAExecutionProvider']):
         
         # Make the first call raise an exception, and the second call succeed
-        mock_session.side_effect = [Exception("CUDA failed"), MagicMock()]
+        cpu_success_mock = MagicMock()
+        mock_session.side_effect = [Exception("CUDA failed"), cpu_success_mock]
         
         mock_logger = MagicMock()
         session = create_inference_session_with_fallback('dummy_path', mock_logger)
@@ -34,7 +35,7 @@ def test_create_inference_session_fallback_success():
         
         # Second value in side_effect is the success mock
         # Verify the returned session is the successful CPU fallback mock
-        assert session == mock_session.side_effect[1]
+        assert session == cpu_success_mock
 
 def test_create_inference_session_fallback_failure():
     with patch('app.utils.ONNX.onnxruntime.InferenceSession') as mock_session, \

--- a/backend/tests/test_onnx_utils.py
+++ b/backend/tests/test_onnx_utils.py
@@ -52,3 +52,4 @@ def test_create_inference_session_fallback_failure(onnx_mocks):
     mock_logger.error.assert_called_once()
     assert "TestModel" in mock_logger.error.call_args[0][0]
     assert "CPU failed" in mock_logger.error.call_args[0][0]
+

--- a/backend/tests/test_onnx_utils.py
+++ b/backend/tests/test_onnx_utils.py
@@ -1,0 +1,54 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from app.utils.ONNX import create_inference_session_with_fallback
+
+def test_create_inference_session_success():
+    with patch('app.utils.ONNX.onnxruntime.InferenceSession') as mock_session, \
+         patch('app.utils.ONNX.ONNX_util_get_execution_providers', return_value=['CUDAExecutionProvider']):
+        
+        mock_logger = MagicMock()
+        session = create_inference_session_with_fallback('dummy_path', mock_logger)
+        
+        mock_session.assert_called_once_with('dummy_path', providers=['CUDAExecutionProvider'])
+        mock_logger.warning.assert_not_called()
+        mock_logger.error.assert_not_called()
+        assert session == mock_session.return_value
+
+def test_create_inference_session_fallback_success():
+    with patch('app.utils.ONNX.onnxruntime.InferenceSession') as mock_session, \
+         patch('app.utils.ONNX.ONNX_util_get_execution_providers', return_value=['CUDAExecutionProvider']):
+        
+        # Make the first call raise an exception, and the second call succeed
+        mock_session.side_effect = [Exception("CUDA failed"), MagicMock()]
+        
+        mock_logger = MagicMock()
+        session = create_inference_session_with_fallback('dummy_path', mock_logger)
+        
+        assert mock_session.call_count == 2
+        mock_session.assert_any_call('dummy_path', providers=['CUDAExecutionProvider'])
+        mock_session.assert_any_call('dummy_path', providers=['CPUExecutionProvider'])
+        
+        mock_logger.warning.assert_called_once()
+        assert "CUDA failed" in mock_logger.warning.call_args[0][0]
+        mock_logger.error.assert_not_called()
+        
+        # Second value in side_effect is the success mock
+        assert session is not None
+
+def test_create_inference_session_fallback_failure():
+    with patch('app.utils.ONNX.onnxruntime.InferenceSession') as mock_session, \
+         patch('app.utils.ONNX.ONNX_util_get_execution_providers', return_value=['CUDAExecutionProvider']):
+        
+        # Make both calls raise an exception
+        mock_session.side_effect = [Exception("CUDA failed"), Exception("CPU failed")]
+        
+        mock_logger = MagicMock()
+        
+        with pytest.raises(Exception, match="CPU failed"):
+            create_inference_session_with_fallback('dummy_path', mock_logger, model_name="TestModel")
+            
+        assert mock_session.call_count == 2
+        mock_logger.warning.assert_called_once()
+        mock_logger.error.assert_called_once()
+        assert "TestModel" in mock_logger.error.call_args[0][0]
+        assert "CPU failed" in mock_logger.error.call_args[0][0]


### PR DESCRIPTION
## Summary
Added error handling and a fallback mechanism to CPUExecutionProvider for ONNX InferenceSession initialization in both YOLO and FaceNet models.

## Problem
Closes #1212
The `onnxruntime.InferenceSession` constructor is a blocking operation and if anything failed (like missing file, or hardware acceleration failing), it crashed the entire backend.

## Solution
Wrapped the initialization in a `try...except` block with error logging. It now tries `ONNX_util_get_execution_providers()`, and if it fails, falls back gracefully to `CPUExecutionProvider` before giving up and crashing.

## Testing
- Verified syntax
- Tested logging structure

## Checklist
- [x] Tested fallback logic
- [x] Included try-except block
- [x] Avoids unnecessary crashes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AI model startup robustness: sessions now automatically fall back to alternative execution providers (including CPU) when preferred providers fail, reducing startup errors.
  * Enhanced logging around model initialization and clearer error reporting when fallback attempts fail.

* **Tests**
  * Added unit tests validating session creation, fallback behavior, and related logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->