### PR TITLE
perf: avoid full table scan in toggle-favourite endpoint. Fixes #1223

### DIFF
--- a/backend/app/database/images.py
+++ b/backend/app/database/images.py
@@ -249,6 +249,81 @@ def db_get_all_images(tagged: Union[bool, None] = None) -> List[dict]:
         conn.close()
 
 
+def db_get_image_by_id(image_id: ImageId) -> Optional[dict]:
+    """
+    Get a single image by ID with its tags.
+
+    Args:
+        image_id: ID of the image to fetch
+
+    Returns:
+        Dictionary containing image data including tags, or None if not found
+    """
+    conn = _connect()
+    cursor = conn.cursor()
+
+    try:
+        cursor.execute(
+            """
+            SELECT
+                i.id,
+                i.path,
+                i.folder_id,
+                i.thumbnailPath,
+                i.metadata,
+                i.isTagged,
+                i.isFavourite,
+                i.latitude,
+                i.longitude,
+                i.captured_at,
+                m.name as tag_name
+            FROM images i
+            LEFT JOIN image_classes ic ON i.id = ic.image_id
+            LEFT JOIN mappings m ON ic.class_id = m.class_id
+            WHERE i.id = ?
+            ORDER BY m.name
+            """,
+            (image_id,),
+        )
+
+        results = cursor.fetchall()
+        if not results:
+            return None
+
+        from app.utils.images import image_util_parse_metadata
+
+        first_row = results[0]
+        image = {
+            "id": first_row[0],
+            "path": first_row[1],
+            "folder_id": str(first_row[2]),
+            "thumbnailPath": first_row[3],
+            "metadata": image_util_parse_metadata(first_row[4]),
+            "isTagged": bool(first_row[5]),
+            "isFavourite": bool(first_row[6]),
+            "latitude": first_row[7],
+            "longitude": first_row[8],
+            "captured_at": first_row[9] if first_row[9] else None,
+            "tags": [],
+        }
+
+        for row in results:
+            tag_name = row[10]
+            if tag_name and tag_name not in image["tags"]:
+                image["tags"].append(tag_name)
+
+        if not image["tags"]:
+            image["tags"] = None
+
+        return image
+
+    except Exception as e:
+        logger.error(f"Error getting image by ID: {e}")
+        return None
+    finally:
+        conn.close()
+
+
 def db_get_untagged_images() -> List[UntaggedImageRecord]:
     """
     Find all images that need AI tagging.

--- a/backend/app/database/images.py
+++ b/backend/app/database/images.py
@@ -296,7 +296,7 @@ def db_get_image_by_id(image_id: ImageId) -> Optional[dict]:
         image = {
             "id": first_row[0],
             "path": first_row[1],
-            "folder_id": str(first_row[2]),
+            "folder_id": str(first_row[2]) if first_row[2] is not None else None,
             "thumbnailPath": first_row[3],
             "metadata": image_util_parse_metadata(first_row[4]),
             "isTagged": bool(first_row[5]),

--- a/backend/app/routes/images.py
+++ b/backend/app/routes/images.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, HTTPException, Query, status
 from typing import List, Optional
 from app.database.images import db_get_all_images
+from app.database.images import db_get_image_by_id
 from app.schemas.images import ErrorResponse
 from app.utils.images import image_util_parse_metadata
 from pydantic import BaseModel
@@ -105,9 +106,7 @@ def toggle_favourite(req: ToggleFavouriteRequest):
                 status_code=404, detail="Image not found or failed to toggle"
             )
         # Fetch updated status to return
-        image = next(
-            (img for img in db_get_all_images() if img["id"] == image_id), None
-        )
+        image = db_get_image_by_id(image_id)
         return {
             "success": True,
             "image_id": image_id,

--- a/backend/app/routes/images.py
+++ b/backend/app/routes/images.py
@@ -107,12 +107,18 @@ def toggle_favourite(req: ToggleFavouriteRequest):
             )
         # Fetch updated status to return
         image = db_get_image_by_id(image_id)
+        if image is None:
+            raise HTTPException(
+                status_code=404, detail="Updated image could not be retrieved"
+            )
         return {
             "success": True,
             "image_id": image_id,
             "isFavourite": image.get("isFavourite", False),
         }
 
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"error in /toggle-favourite route: {e}")
         raise HTTPException(status_code=500, detail=f"Internal server error: {e}")

--- a/backend/tests/test_images.py
+++ b/backend/tests/test_images.py
@@ -34,3 +34,20 @@ class TestImagesAPI:
 
         mock_toggle_favourite.assert_called_once_with(image_id)
         mock_get_image_by_id.assert_called_once_with(image_id)
+
+    @patch("app.routes.images.db_get_image_by_id")
+    @patch("app.routes.images.db_toggle_image_favourite_status")
+    def test_toggle_favourite_returns_404_when_updated_image_lookup_fails(
+        self, mock_toggle_favourite, mock_get_image_by_id
+    ):
+        image_id = "img_123"
+        mock_toggle_favourite.return_value = True
+        mock_get_image_by_id.return_value = None
+
+        response = client.post("/images/toggle-favourite", json={"image_id": image_id})
+
+        assert response.status_code == 404
+        assert response.json() == {"detail": "Updated image could not be retrieved"}
+
+        mock_toggle_favourite.assert_called_once_with(image_id)
+        mock_get_image_by_id.assert_called_once_with(image_id)

--- a/backend/tests/test_images.py
+++ b/backend/tests/test_images.py
@@ -1,0 +1,36 @@
+from unittest.mock import patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.routes.images import router as images_router
+
+app = FastAPI()
+app.include_router(images_router, prefix="/images")
+client = TestClient(app)
+
+
+class TestImagesAPI:
+    @patch("app.routes.images.db_get_image_by_id")
+    @patch("app.routes.images.db_toggle_image_favourite_status")
+    def test_toggle_favourite_uses_single_image_lookup(
+        self, mock_toggle_favourite, mock_get_image_by_id
+    ):
+        image_id = "img_123"
+        mock_toggle_favourite.return_value = True
+        mock_get_image_by_id.return_value = {
+            "id": image_id,
+            "isFavourite": True,
+        }
+
+        response = client.post("/images/toggle-favourite", json={"image_id": image_id})
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "success": True,
+            "image_id": image_id,
+            "isFavourite": True,
+        }
+
+        mock_toggle_favourite.assert_called_once_with(image_id)
+        mock_get_image_by_id.assert_called_once_with(image_id)


### PR DESCRIPTION
### Addressed Issues:

Fixes #1223

### Screenshots/Recordings:

Not applicable.

### Additional Notes:

This PR avoids a full table scan in the `/toggle-favourite` endpoint by replacing the `db_get_all_images()` scan with a targeted `db_get_image_by_id(image_id)` lookup.

Changes made:
- added `db_get_image_by_id(image_id)` in `backend/app/database/images.py`
- updated `/toggle-favourite` in `backend/app/routes/images.py` to fetch only the toggled image
- added a focused test to verify the endpoint uses the single-image lookup

Verified locally with:
- `$env:GITHUB_ACTIONS='true'; python -m pytest backend\tests\test_images.py`
- `python -m py_compile backend\app\database\images.py backend\app\routes\images.py`

### AI Usage Disclosure:

- [x] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools: OpenAI Codex (GPT-5)

## Checklist

- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions.
- [x] I have tested my changes locally.
- [x] I have reviewed my code before submitting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced image data retrieval with complete metadata and associated tag information.
  * Improved favorite toggle functionality with optimized database operations.

* **Tests**
  * Added test coverage for the Images API, validating favorite toggle behavior and database operation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->