### PR TITLE
fix(frontend): align memories page wrapper with route

### DIFF
--- a/frontend/src/pages/Memories/Memories.tsx
+++ b/frontend/src/pages/Memories/Memories.tsx
@@ -1,5 +1,7 @@
+import { MemoriesPage } from '@/components/Memories';
+
 const Memories = () => {
-  return <></>;
+  return <MemoriesPage />;
 };
 
 export default Memories;

--- a/frontend/src/routes/AppRoutes.tsx
+++ b/frontend/src/routes/AppRoutes.tsx
@@ -9,7 +9,7 @@ import { MyFav } from '@/pages/Home/MyFav';
 import { AITagging } from '@/pages/AITagging/AITagging';
 import { PersonImages } from '@/pages/PersonImages/PersonImages';
 import { ComingSoon } from '@/pages/ComingSoon/ComingSoon';
-import { MemoriesPage } from '@/components/Memories';
+import Memories from '@/pages/Memories/Memories';
 import { MemoryDetail } from '@/components/Memories/MemoryDetail';
 
 export const AppRoutes: React.FC = () => {
@@ -23,7 +23,7 @@ export const AppRoutes: React.FC = () => {
         <Route path={ROUTES.SETTINGS} element={<Settings />} />
         <Route path={ROUTES.AI} element={<AITagging />} />
         <Route path={ROUTES.ALBUMS} element={<ComingSoon />} />
-        <Route path={ROUTES.MEMORIES} element={<MemoriesPage />} />
+        <Route path={ROUTES.MEMORIES} element={<Memories />} />
         <Route path={ROUTES.MEMORY_DETAIL} element={<MemoryDetail />} />
         <Route path={ROUTES.PERSON} element={<PersonImages />} />
       </Route>


### PR DESCRIPTION
### Addressed Issues:
Fixes #1236 

### Screenshots/Recordings:
N/A (no visual behavior change intended)

### Additional Notes:
This is a small frontend consistency fix:
- `pages/Memories/Memories.tsx` now renders `MemoriesPage`
- `AppRoutes.tsx` imports the Memories route from the page module

Why:
The page wrapper was a placeholder, which could let page-level tests pass without exercising the real Memories UI.

### AI Usage Disclosure:
- [ ] This PR does not contain AI-generated code at all.
- [x] This PR contains AI-generated code. I have read the AI Usage Policy and this PR complies with this policy. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools:
- OpenAI Codex (GPT-5.4)

## Checklist
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [ ] If applicable, I have made corresponding changes or additions to the documentation
- [ ] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [x] I have joined the Discord server and I will share a link to this PR with the project maintainers there
- [x] I have read the Contribution Guidelines
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Memories page is now fully functional and displays content to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->