### PR TITLE
fix: update default fix: update default Vite title PictoPy brandingVite title

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <!-- <title>Tauri + React + Typescript</title> -->
+    
      <title>PictoPy</title>
   </head>
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,8 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Tauri + React + Typescript</title>
+    <!-- <title>Tauri + React + Typescript</title> -->
+     <title>PictoPy</title>
   </head>
 
   <body>


### PR DESCRIPTION
**Fixes #1126**

- Updated default page title from "Vite + React" to "PictoPy"


This improves branding consistency across the application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Updated the application title displayed in the browser tab to "PictoPy".
  * This change updates the page metadata so the new title appears in browser tabs, window titles, and when bookmarking or listing open pages. No public APIs or exported interfaces were altered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->