### PR TITLE
feat: implement database schema and migration for video support #1066

### DIFF
--- a/backend/app/database/images.py
+++ b/backend/app/database/images.py
@@ -34,7 +34,7 @@ class ImageRecord(TypedDict, total=False):
     longitude: Optional[float]
     captured_at: Optional[datetime]
     # New fields for video support
-    is_video: bool
+    is_video: Optional[bool]
     duration: Optional[float]
     codec: Optional[str]
 
@@ -74,6 +74,9 @@ def db_create_images_table() -> None:
             metadata TEXT,
             isTagged BOOLEAN DEFAULT 0,
             isFavourite BOOLEAN DEFAULT 0,
+            is_video BOOLEAN DEFAULT 0,
+            duration REAL,
+            codec TEXT,
             latitude REAL,
             longitude REAL,
             captured_at DATETIME,

--- a/backend/app/database/images.py
+++ b/backend/app/database/images.py
@@ -33,6 +33,10 @@ class ImageRecord(TypedDict, total=False):
     latitude: Optional[float]
     longitude: Optional[float]
     captured_at: Optional[datetime]
+    # New fields for video support
+    is_video: bool
+    duration: Optional[float]
+    codec: Optional[str]
 
 
 class UntaggedImageRecord(TypedDict):
@@ -103,6 +107,17 @@ def db_create_images_table() -> None:
     """
     )
 
+    # Ensure new video-related columns exist for pre-existing databases
+    cursor.execute("PRAGMA table_info(images)")
+    existing_columns = {row[1] for row in cursor.fetchall()}
+
+    if "is_video" not in existing_columns:
+        cursor.execute("ALTER TABLE images ADD COLUMN is_video BOOLEAN DEFAULT 0")
+    if "duration" not in existing_columns:
+        cursor.execute("ALTER TABLE images ADD COLUMN duration REAL")
+    if "codec" not in existing_columns:
+        cursor.execute("ALTER TABLE images ADD COLUMN codec TEXT")
+
     conn.commit()
     conn.close()
 
@@ -118,8 +133,36 @@ def db_bulk_insert_images(image_records: List[ImageRecord]) -> bool:
     try:
         cursor.executemany(
             """
-            INSERT INTO images (id, path, folder_id, thumbnailPath, metadata, isTagged, latitude, longitude, captured_at)
-            VALUES (:id, :path, :folder_id, :thumbnailPath, :metadata, :isTagged, :latitude, :longitude, :captured_at)
+            INSERT INTO images (
+                id,
+                path,
+                folder_id,
+                thumbnailPath,
+                metadata,
+                isTagged,
+                isFavourite,
+                is_video,
+                duration,
+                codec,
+                latitude,
+                longitude,
+                captured_at
+            )
+            VALUES (
+                :id,
+                :path,
+                :folder_id,
+                :thumbnailPath,
+                :metadata,
+                :isTagged,
+                COALESCE(:isFavourite, 0),
+                COALESCE(:is_video, 0),
+                :duration,
+                :codec,
+                :latitude,
+                :longitude,
+                :captured_at
+            )
             ON CONFLICT(path) DO UPDATE SET
                 folder_id=excluded.folder_id,
                 thumbnailPath=excluded.thumbnailPath,
@@ -128,6 +171,10 @@ def db_bulk_insert_images(image_records: List[ImageRecord]) -> bool:
                     WHEN excluded.isTagged THEN 1
                     ELSE images.isTagged
                 END,
+                isFavourite=COALESCE(excluded.isFavourite, images.isFavourite),
+                is_video=COALESCE(excluded.is_video, images.is_video),
+                duration=COALESCE(excluded.duration, images.duration),
+                codec=COALESCE(excluded.codec, images.codec),
                 latitude=COALESCE(excluded.latitude, images.latitude),
                 longitude=COALESCE(excluded.longitude, images.longitude),
                 captured_at=COALESCE(excluded.captured_at, images.captured_at)
@@ -169,6 +216,9 @@ def db_get_all_images(tagged: Union[bool, None] = None) -> List[dict]:
                 i.metadata, 
                 i.isTagged,
                 i.isFavourite,
+                i.is_video,
+                i.duration,
+                i.codec,
                 i.latitude,
                 i.longitude,
                 i.captured_at,
@@ -199,6 +249,9 @@ def db_get_all_images(tagged: Union[bool, None] = None) -> List[dict]:
             metadata,
             is_tagged,
             is_favourite,
+            is_video,
+            duration,
+            codec,
             latitude,
             longitude,
             captured_at,
@@ -218,6 +271,9 @@ def db_get_all_images(tagged: Union[bool, None] = None) -> List[dict]:
                     "metadata": metadata_dict,
                     "isTagged": bool(is_tagged),
                     "isFavourite": bool(is_favourite),
+                    "is_video": bool(is_video),
+                    "duration": duration,
+                    "codec": codec,
                     "latitude": latitude,
                     "longitude": longitude,
                     "captured_at": (

--- a/backend/app/routes/images.py
+++ b/backend/app/routes/images.py
@@ -34,6 +34,9 @@ class ImageData(BaseModel):
     metadata: MetadataModel
     isTagged: bool
     isFavourite: bool
+    isVideo: bool = False
+    duration: Optional[float] = None
+    codec: Optional[str] = None
     tags: Optional[List[str]] = None
 
 
@@ -66,6 +69,9 @@ def get_all_images(
                 metadata=image_util_parse_metadata(image["metadata"]),
                 isTagged=image["isTagged"],
                 isFavourite=image.get("isFavourite", False),
+                isVideo=bool(image.get("is_video", False)),
+                duration=image.get("duration"),
+                codec=image.get("codec"),
                 tags=image["tags"],
             )
             for image in images

--- a/backend/app/utils/images.py
+++ b/backend/app/utils/images.py
@@ -204,6 +204,11 @@ def image_util_prepare_image_records(
                 "thumbnailPath": thumbnail_path,
                 "metadata": metadata_json,
                 "isTagged": False,
+                 # Default video-related fields for image ingestion
+                "isFavourite": False,
+                "is_video": False,
+                "duration": None,
+                "codec": None,
                 "latitude": latitude,  # Can be None
                 "longitude": longitude,  # Can be None
                 "captured_at": (

--- a/backend/app/utils/images.py
+++ b/backend/app/utils/images.py
@@ -204,7 +204,7 @@ def image_util_prepare_image_records(
                 "thumbnailPath": thumbnail_path,
                 "metadata": metadata_json,
                 "isTagged": False,
-                 # Default video-related fields for image ingestion
+                # Default video-related fields for image ingestion
                 "isFavourite": False,
                 "is_video": False,
                 "duration": None,

--- a/backend/tests/test_video_metadata_schema.py
+++ b/backend/tests/test_video_metadata_schema.py
@@ -1,4 +1,3 @@
-import os
 import sqlite3
 from pathlib import Path
 

--- a/backend/tests/test_video_metadata_schema.py
+++ b/backend/tests/test_video_metadata_schema.py
@@ -1,0 +1,57 @@
+import os
+import sqlite3
+from pathlib import Path
+
+from app.database.images import db_create_images_table
+
+
+def test_db_create_images_table_adds_video_columns(tmp_path, monkeypatch):
+    """
+    Ensure db_create_images_table adds is_video, duration, and codec columns
+    to an existing images table that was created without them.
+    """
+
+    db_path = tmp_path / "test_video_schema.sqlite3"
+
+    # Create an "old schema" images table without video columns
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            """
+            CREATE TABLE images (
+                id TEXT PRIMARY KEY,
+                path VARCHAR UNIQUE,
+                folder_id INTEGER,
+                thumbnailPath TEXT UNIQUE,
+                metadata TEXT,
+                isTagged BOOLEAN DEFAULT 0,
+                isFavourite BOOLEAN DEFAULT 0,
+                latitude REAL,
+                longitude REAL,
+                captured_at DATETIME
+            )
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    # Point the images module to this temporary database
+    monkeypatch.setattr("app.database.images.DATABASE_PATH", str(db_path))
+
+    # This should run CREATE TABLE IF NOT EXISTS (no-op on existing)
+    # and then ensure the new video-related columns exist via ALTER TABLE.
+    db_create_images_table()
+
+    # Verify that the new columns are present
+    conn = sqlite3.connect(db_path)
+    try:
+        cursor = conn.execute("PRAGMA table_info(images)")
+        columns = {row[1] for row in cursor.fetchall()}
+    finally:
+        conn.close()
+
+    assert "is_video" in columns
+    assert "duration" in columns
+    assert "codec" in columns
+


### PR DESCRIPTION
### Addressed Issues:

Part of #1066 — backend support for video metadata (schema + `/images` read).

### Screenshots/Recordings:

_Not applicable — this PR is backend-only (DB schema + API response). The change can be verified via `GET /images` in Swagger or curl._

### Additional Notes:
<!-- Add any additional information, context, or notes for reviewers -->

- This PR:
  - No breaking changes to existing APIs.
  - Adds `is_video`, `duration`, and `codec` columns to the existing `images` SQLite table.
  - Safely upgrades existing databases using `PRAGMA table_info(images)` + `ALTER TABLE` so older installs are not broken.
  - Extends `db_get_all_images()` and the `/images` response model to surface these fields as `isVideo`, `duration`, and `codec`.
  - Sets safe defaults for current image ingestion (images are stored with `is_video = 0`, `duration = NULL`, `codec = NULL`).
- No ffprobe/video ingestion logic is added yet — this is a schema + plumbing step to unblock future video work under #1066.


I have used the following AI models and tools:  
- Claude  for planning and code suggestions  
- Google Gemini for issue selection / strategy guidance

## Checklist
<!-- Mark items with [x] to indicate completion -->
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [ ] If applicable, I have made corresponding changes or additions to the documentation
- [x] If applicable, I have made corresponding changes or additions to tests (`backend/tests/test_video_metadata_schema.py`)
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added video metadata to image records: video flag, duration, and codec. These fields are exposed in API responses with sensible defaults and preserved when updating records. Existing installations receive a lightweight schema update so prior data continues to work.

* **Tests**
  * Added automated test coverage verifying the video metadata columns are created and exposed correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->