### PR TITLE
Fix: Resolve watcher service deadlock during self-restart on folder deletion

### DIFF
--- a/docs/backend/backend_python/openapi.json
+++ b/docs/backend/backend_python/openapi.json
@@ -2073,119 +2073,6 @@
         ],
         "title": "DeleteFoldersResponse"
       },
-      "app__schemas__folders__ErrorResponse": {
-        "properties": {
-          "success": {
-            "type": "boolean",
-            "title": "Success",
-            "default": false
-          },
-          "message": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Message"
-          },
-          "error": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Error"
-          }
-        },
-        "type": "object",
-        "title": "ErrorResponse"
-      },
-      "app__schemas__face_clusters__ErrorResponse": {
-        "properties": {
-          "success": {
-            "type": "boolean",
-            "title": "Success",
-            "default": false
-          },
-          "message": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Message"
-          },
-          "error": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Error"
-          }
-        },
-        "type": "object",
-        "title": "ErrorResponse"
-      },
-      "app__schemas__images__ErrorResponse": {
-        "properties": {
-          "success": {
-            "type": "boolean",
-            "title": "Success",
-            "default": false
-          },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          },
-          "error": {
-            "type": "string",
-            "title": "Error"
-          }
-        },
-        "type": "object",
-        "required": [
-          "message",
-          "error"
-        ],
-        "title": "ErrorResponse"
-      },
-      "app__schemas__user_preferences__ErrorResponse": {
-        "properties": {
-          "success": {
-            "type": "boolean",
-            "title": "Success"
-          },
-          "error": {
-            "type": "string",
-            "title": "Error"
-          },
-          "message": {
-            "type": "string",
-            "title": "Message"
-          }
-        },
-        "type": "object",
-        "required": [
-          "success",
-          "error",
-          "message"
-        ],
-        "title": "ErrorResponse",
-        "description": "Error response model"
-      },
       "FaceSearchRequest": {
         "properties": {
           "path": {
@@ -3407,6 +3294,119 @@
           "type"
         ],
         "title": "ValidationError"
+      },
+      "app__schemas__face_clusters__ErrorResponse": {
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "title": "Success",
+            "default": false
+          },
+          "message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Message"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          }
+        },
+        "type": "object",
+        "title": "ErrorResponse"
+      },
+      "app__schemas__folders__ErrorResponse": {
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "title": "Success",
+            "default": false
+          },
+          "message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Message"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          }
+        },
+        "type": "object",
+        "title": "ErrorResponse"
+      },
+      "app__schemas__images__ErrorResponse": {
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "title": "Success",
+            "default": false
+          },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
+          "error": {
+            "type": "string",
+            "title": "Error"
+          }
+        },
+        "type": "object",
+        "required": [
+          "message",
+          "error"
+        ],
+        "title": "ErrorResponse"
+      },
+      "app__schemas__user_preferences__ErrorResponse": {
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "title": "Success"
+          },
+          "error": {
+            "type": "string",
+            "title": "Error"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          }
+        },
+        "type": "object",
+        "required": [
+          "success",
+          "error",
+          "message"
+        ],
+        "title": "ErrorResponse",
+        "description": "Error response model"
       }
     }
   }

--- a/sync-microservice/app/utils/watcher.py
+++ b/sync-microservice/app/utils/watcher.py
@@ -311,13 +311,16 @@ def watcher_util_stop_folder_watcher() -> None:
         # Signal the watcher to stop
         stop_event.set()
 
-        # Wait for thread to finish
-        watcher_thread.join(timeout=5.0)
+        # Wait for thread to finish if not called from the thread itself
+        if threading.current_thread() != watcher_thread:
+            watcher_thread.join(timeout=5.0)
 
-        if watcher_thread.is_alive():
-            logger.warning("Warning: Watcher thread did not stop gracefully")
+            if watcher_thread.is_alive():
+                logger.warning("Warning: Watcher thread did not stop gracefully")
+            else:
+                logger.info("Watcher stopped successfully")
         else:
-            logger.info("Watcher stopped successfully")
+            logger.info("Watcher stopped successfully (called from within watcher thread)")
 
     except Exception as e:
         logger.error(f"Error stopping watcher: {e}")
@@ -336,6 +339,17 @@ def watcher_util_restart_folder_watcher() -> bool:
         True if restart was successful, False otherwise
     """
     logger.info("Restarting folder watcher...")
+    
+    if watcher_thread and threading.current_thread() == watcher_thread:
+        # We are inside the watcher thread, so we can't join ourselves.
+        # Launch a background thread to do the restart.
+        def restart_worker():
+            watcher_util_stop_folder_watcher()
+            watcher_util_start_folder_watcher()
+
+        threading.Thread(target=restart_worker, daemon=True).start()
+        return True
+
     watcher_util_stop_folder_watcher()
     return watcher_util_start_folder_watcher()
 


### PR DESCRIPTION
###  Addressed Issues:

Fixes #1031 


###  Screenshots/Recordings:

<img width="668" height="284" alt="image" src="https://github.com/user-attachments/assets/cc21be46-11ec-481e-8100-5220460a6da8" />


###  Additional Notes:

Description
This PR fixes a bug where the sync-microservice watcher service would freeze and eventually fail when attempting to restart itself after detecting a deleted folder.

Previously, when a folder was deleted, the background thread (watcher_thread) triggered a restart sequence that called watcher_util_stop_folder_watcher(). Inside that stop function, the thread attempted to execute watcher_thread.join(). Since it was joining itself, this caused a deadlock that hung for the 5-second timeout, preventing a clean restart and throwing a runtime error.

Changes made
- watcher.py
    - Prevent Self-Joining: Added a thread-safety check in watcher_util_stop_folder_watcher() so that .join() is only called if threading.current_thread() != watcher_thread.
    - Spawn Restart Worker: Updated watcher_util_restart_folder_watcher() to check if it's being executed by the watcher_thread. If so, it spawns a temporary background daemon thread to handle the stop/start sequence, allowing the original watcher thread to return and terminate gracefully.
    
How to test
1. Start the sync-microservice.
2. Add a folder to the watchlist (this automatically starts the watcher).
3. Manually delete that folder from the filesystem while the service is running.
4. Observe the logs: The watcher should now log "Processing 1 deleted folders", followed immediately by successfully stopping the watcher thread and restarting it, without the 5-second hang or the thread-stopping warning.

### AI Usage Disclosure:

We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact. AI slop is strongly discouraged and may lead to banning and blocking. Do not spam our repos with AI slop.

Check one of the checkboxes below:

- [x ] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools: TODO


## Checklist
<!-- Mark items with [x] to indicate completion -->
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [x] If applicable, I have made corresponding changes or additions to the documentation
- [x] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated OpenAPI schema organization in backend documentation

* **Bug Fixes**
  * Fixed folder watcher thread management issues during stop operations
  * Enhanced folder watcher restart functionality to correctly handle internal thread operations
  * Improved overall stability of folder watching processes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AOSSIE-Org/PictoPy/pull/1269?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->