### PR TITLE
docs: fix spelling in backend directory structure

### DIFF
--- a/docs/backend/backend_python/directory-structure.md
+++ b/docs/backend/backend_python/directory-structure.md
@@ -2,7 +2,7 @@
 
 The entry point for the backend is in `main.py`, which initializes the databases and handles the startup and shutdown for the FastAPI server.
 
-The code for the application mainly lies in the `app/` directory the heirarchy of which looks like this:
+The code for the application mainly lies in the `app/` directory the hierarchy of which looks like this:
 
 ```bash
 .
@@ -21,7 +21,7 @@ We will discuss what each of these directories do and the relevant files they co
 
 ## config
 
-Related to variables used accross the application.
+Related to variables used across the application.
 
 | Name          | Description                                                                                                         |
 | ------------- | ------------------------------------------------------------------------------------------------------------------- |
@@ -29,7 +29,7 @@ Related to variables used accross the application.
 
 ## database
 
-This directory contains files related to database operations, including table creation, query handeling and some helper functions on the tables.
+This directory contains files related to database operations, including table creation, query handling and some helper functions on the tables.
 These files are the places where most of the SQL queries are written. By default, on startup this directory is where the databases (`.db` files) is
 created.
 


### PR DESCRIPTION
Fixes #1180

Changes:
- `heirarchy` -> `hierarchy` in `docs/backend/backend_python/directory-structure.md` (1 occurrence(s))
- `accross` -> `across` in `docs/backend/backend_python/directory-structure.md` (1 occurrence(s))
- `handeling` -> `handling` in `docs/backend/backend_python/directory-structure.md` (1 occurrence(s))

Verification:
- Applied exact text replacements against the current upstream base branch.
- Confirmed the pull request diff contains only the intended documentation typo fix(es).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated backend directory structure documentation with corrected spelling and improved descriptions of the directory hierarchy and layout.
  * Enhanced configuration and database sections with rewritten text for clearer explanations of component responsibilities and shared variable handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AOSSIE-Org/PictoPy/pull/1282?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->