### PR TITLE
fix: guard addFolderMutate call when no folder is selected in onboarding

### DIFF
--- a/frontend/src/components/OnboardingSteps/FolderSetupStep.tsx
+++ b/frontend/src/components/OnboardingSteps/FolderSetupStep.tsx
@@ -58,7 +58,9 @@ export function FolderSetupStep({
 
   const handleNext = () => {
     localStorage.setItem('folderChosen', 'true');
-    addFolderMutate(folder);
+    if (folder) {
+      addFolderMutate(folder);
+    }
     dispatch(markCompleted(stepIndex));
   };
 


### PR DESCRIPTION
###  Addressed Issues:

Fixes #994 


###  Screenshots/Recordings:
Before : 
<img width="1351" height="936" alt="Screenshot 2026-05-25 at 03 27 44" src="https://github.com/user-attachments/assets/6ae40684-f872-45cb-b747-483c28a8569e" />

Change :
Could not test locally as the full backend setup was required to reach the onboarding screen. The fix is just a one line obvious change :  addFolderMutate(folder) is only called when folder is a non-empty string, which is verifiably correct by code inspection.


### AI Usage Disclosure:

- [x] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have reviewed the code and I am responsible for it.

I have used the following AI models and tools: Claude


## Checklist
<!-- Mark items with [x] to indicate completion -->
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [ ] If applicable, I have made corresponding changes or additions to the documentation
- [ ] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced folder setup validation during onboarding. The system now ensures a folder is properly selected before processing, preventing empty submissions and improving the overall setup experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AOSSIE-Org/PictoPy/pull/1287?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->