### PR TITLE
feat: auto-close inactive merge-conflicted PRs

### DIFF
--- a/.github/workflows/stale-merge-conflicts.yml
+++ b/.github/workflows/stale-merge-conflicts.yml
@@ -1,0 +1,58 @@
+name: Close stale merge-conflicted PRs
+
+on:
+  schedule:
+    - cron: "17 2 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale-merge-conflicts:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Warn and close inactive merge-conflicted PRs
+        uses: actions/stale@v10
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+          # Do not process issues.
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+
+          # Only process PRs that still have unresolved merge conflicts.
+          only-pr-labels: "PR has merge conflicts"
+
+          # Warn after 30 inactive days, then close after 5 more inactive days.
+          days-before-pr-stale: 30
+          days-before-pr-close: 5
+
+          # Use a separate stale label so the original merge-conflict label keeps its meaning.
+          stale-pr-label: "stale merge conflict"
+          close-pr-label: "closed stale merge conflict"
+
+          # If the contributor comments or updates the PR, remove stale state and restart the timer.
+          remove-pr-stale-when-updated: true
+
+          # Help process larger backlogs across daily runs.
+          operations-per-run: 100
+
+          stale-pr-message: |
+            ⚠️ **This PR still has merge conflicts and has been inactive for 30 days.**
+
+            This PR still has the `PR has merge conflicts` label and there has been no recent activity.
+
+            Please resolve the merge conflicts or leave a comment if you are still working on this PR.
+
+            If there is no activity for 5 more days, this PR may be automatically closed to help maintainers keep the pull request backlog manageable.
+
+          close-pr-message: |
+            🔒 **Closing this PR due to unresolved merge conflicts and inactivity.**
+
+            This PR still had merge conflicts and there was no activity for 5 days after the stale warning.
+
+            You can reopen this PR or create a new one after resolving the merge conflicts.

--- a/.github/workflows/stale-merge-conflicts.yml
+++ b/.github/workflows/stale-merge-conflicts.yml
@@ -42,17 +42,17 @@ jobs:
           operations-per-run: 100
 
           stale-pr-message: |
-            ⚠️ **This PR still has merge conflicts and has been inactive for 30 days.**
+            ⚠️ **This PR still has unresolved merge conflicts and has been inactive for the past 30 days.**
 
-            This PR still has the `PR has merge conflicts` label and there has been no recent activity.
+            The `PR has merge conflicts` label is still applied, and there has been no recent activity on this PR.
 
-            Please resolve the merge conflicts or leave a comment if you are still working on this PR.
+            Please resolve the merge conflicts or leave a comment if you are still actively working on it.
 
-            If there is no activity for 5 more days, this PR may be automatically closed to help maintainers keep the pull request backlog manageable.
+            If there is no further activity within the next 5 days, this PR may be automatically closed to help keep the PR backlog manageable.
 
           close-pr-message: |
-            🔒 **Closing this PR due to unresolved merge conflicts and inactivity.**
+            🔒 **Closing this PR due to unresolved merge conflicts and prolonged inactivity.**
 
-            This PR still had merge conflicts and there was no activity for 5 days after the stale warning.
+            This PR still had unresolved merge conflicts, and there was no activity within 5 days of the stale warning being posted.
 
-            You can reopen this PR or create a new one after resolving the merge conflicts.
+            You may reopen this PR or submit a new one after resolving the merge conflicts.


### PR DESCRIPTION
### Addressed Issues:

Fixes #1279


### Screenshots/Recordings:

N/A — this PR only adds a GitHub Actions workflow and does not include UI changes.


### Additional Notes:

This PR adds a separate scheduled workflow for stale merge-conflicted PR cleanup. The existing merge conflict labeling workflow is left unchanged.

The new workflow only targets PRs with the `PR has merge conflicts` label, warns them after 30 days of inactivity, and closes them after 5 additional inactive days if there is still no activity.


### AI Usage Disclosure:

- [ ] This PR does not contain AI-generated code at all.
- [x] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools: ChatGPT and Codex


## Checklist

- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [x] If applicable, I have made corresponding changes or additions to the documentation
- [x] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow to manage pull requests labeled "PR has merge conflicts": runs daily (and can be triggered manually), warns after 30 days of inactivity, closes after 5 additional days, preserves the original label meaning, does not process issues, clears stale status when a PR is updated, limits items processed per run, and includes guidance for resolving conflicts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AOSSIE-Org/PictoPy/pull/1289?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->