### PR TITLE
fix: label uvicorn logs without error tag

### DIFF
--- a/backend/app/logging/setup_logging.py
+++ b/backend/app/logging/setup_logging.py
@@ -235,9 +235,14 @@ class InterceptHandler(logging.Handler):
         Args:
             record: The log record to process
         """
-        # Get the appropriate module name
+        # Get the appropriate module name. Uvicorn uses logger names such as
+        # ``uvicorn.error`` for regular server lifecycle messages, so avoid
+        # reducing those names to just ``error`` because that makes INFO logs
+        # look like failures in the formatted output.
         module_name = record.name
-        if "." in module_name:
+        if module_name.startswith("uvicorn"):
+            module_name = "uvicorn"
+        elif "." in module_name:
             module_name = module_name.split(".")[-1]
 
         # Create a message that includes the original module in the format

--- a/sync-microservice/app/logging/setup_logging.py
+++ b/sync-microservice/app/logging/setup_logging.py
@@ -243,9 +243,14 @@ class InterceptHandler(logging.Handler):
         Args:
             record: The log record to process
         """
-        # Get the appropriate module name
+        # Get the appropriate module name. Uvicorn uses logger names such as
+        # ``uvicorn.error`` for regular server lifecycle messages, so avoid
+        # reducing those names to just ``error`` because that makes INFO logs
+        # look like failures in the formatted output.
         module_name = record.name
-        if "." in module_name:
+        if module_name.startswith("uvicorn"):
+            module_name = "uvicorn"
+        elif "." in module_name:
             module_name = module_name.split(".")[-1]
 
         # Create a message that includes the original module in the format


### PR DESCRIPTION
## Summary
- Keep Uvicorn lifecycle logs tagged as `[uvicorn]` instead of deriving `[error]` from `uvicorn.error`
- Apply the same logging tag fix to both backend and sync-microservice intercept handlers

## Test Plan
- `python3 -m py_compile backend/app/logging/setup_logging.py sync-microservice/app/logging/setup_logging.py`
- Manual LogRecord verification for `uvicorn.error` confirms output contains `[uvicorn]` and not `[error]`

Closes #1172


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved logging output formatting to more accurately label Uvicorn-related logs, ensuring clearer and more consistent log identification across services.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AOSSIE-Org/PictoPy/pull/1296?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->