### PR TITLE
Add version bump script and docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,6 +104,39 @@ TAURI_SIGNING_PRIVATE_KEY_PASSWORD=pass
 npm run tauri build
 ```
 
+## Release Management
+
+PictoPy maintains version strings in three manifest files that must always stay in sync:
+
+- `package.json` (root)
+- `frontend/package.json`
+- `frontend/src-tauri/Cargo.toml`
+
+> **Note:** `frontend/src-tauri/tauri.conf.json` does not hold a version field in Tauri v2 - it inherits the version directly from `Cargo.toml` automatically.
+
+A version bump script at `scripts/bump-version.mjs` acts as the single source of truth. To bump the version across all three files at once, run from the repository root:
+
+```bash
+npm run version:bump -- <version>
+```
+
+For example:
+
+```bash
+npm run version:bump -- 1.2.0
+```
+
+The version must follow the `X.Y.Z` format (digits only, no `v` prefix). The script will validate the format, read and verify all three files before writing anything, then print a summary of each file updated.
+
+After running the script, regenerate the Cargo lock file:
+
+```bash
+cd frontend/src-tauri
+cargo check
+```
+
+> **Note:** The `--` separator between `version:bump` and the version number is required by npm to forward the argument to the underlying script.
+
 ## Additional Resources
 
 - [Tauri Documentation](https://tauri.app/start/)

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "linux-dev": "bash ./scripts/linux-dev.sh",
     "win-dev": "cd scripts && win-dev.bat",
+    "version:bump": "node scripts/bump-version.mjs",
     "prepare": "husky",
     "lint:check": "cd frontend && eslint --max-warnings 0 --config .eslintrc.json .",
     "lint:fix": "cd frontend && eslint --max-warnings 0 --config .eslintrc.json . --fix",

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -1,0 +1,142 @@
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..");
+
+// Target files relative to repo root
+const rootPackageJsonPath = path.join(repoRoot, "package.json");
+const frontendPackageJsonPath = path.join(repoRoot, "frontend", "package.json");
+const cargoTomlPath = path.join(
+  repoRoot,
+  "frontend",
+  "src-tauri",
+  "Cargo.toml",
+);
+
+// Parse and validate CLI arguments
+const newVersion = process.argv[2];
+if (!newVersion) {
+  console.error("Error: Please provide a version number (e.g., X.Y.Z).");
+  process.exit(1);
+}
+
+const semverRegex = /^\d+\.\d+\.\d+$/;
+if (!semverRegex.test(newVersion)) {
+  console.error(
+    "Error: Version must be in X.Y.Z format (digits only, no v prefix).",
+  );
+  process.exit(1);
+}
+
+// 1. Read files
+let rootPackageJsonContent, frontendPackageJsonContent, cargoTomlContent;
+
+try {
+  rootPackageJsonContent = fs.readFileSync(rootPackageJsonPath, "utf8");
+} catch (err) {
+  console.error(
+    `Error: Could not read root package.json at ${rootPackageJsonPath}`,
+  );
+  process.exit(1);
+}
+
+try {
+  frontendPackageJsonContent = fs.readFileSync(frontendPackageJsonPath, "utf8");
+} catch (err) {
+  console.error(
+    `Error: Could not read frontend package.json at ${frontendPackageJsonPath}`,
+  );
+  process.exit(1);
+}
+
+try {
+  cargoTomlContent = fs.readFileSync(cargoTomlPath, "utf8");
+} catch (err) {
+  console.error(`Error: Could not read Cargo.toml at ${cargoTomlPath}`);
+  process.exit(1);
+}
+
+// 2. Validate current versions and format
+let oldRootVersion;
+const rootVersionMatch = rootPackageJsonContent.match(
+  /"version"\s*:\s*"([^"]+)"/,
+);
+if (!rootVersionMatch) {
+  console.error('Error: Could not find "version" field in root package.json.');
+  process.exit(1);
+}
+oldRootVersion = rootVersionMatch[1];
+
+let oldFrontendVersion;
+const frontendVersionMatch = frontendPackageJsonContent.match(
+  /"version"\s*:\s*"([^"]+)"/,
+);
+if (!frontendVersionMatch) {
+  console.error(
+    'Error: Could not find "version" field in frontend package.json.',
+  );
+  process.exit(1);
+}
+oldFrontendVersion = frontendVersionMatch[1];
+
+let oldCargoVersion;
+const cargoVersionMatch = cargoTomlContent.match(/^version\s*=\s*"([^"]+)"/m);
+if (!cargoVersionMatch) {
+  console.error(
+    "Error: Could not find standalone package version field in Cargo.toml.",
+  );
+  process.exit(1);
+}
+oldCargoVersion = cargoVersionMatch[1];
+
+// 3. Perform replacements
+const updatedRootJsonContent = rootPackageJsonContent.replace(
+  /("version"\s*:\s*")([^"]+)(")/,
+  `$1${newVersion}$3`,
+);
+
+const updatedFrontendJsonContent = frontendPackageJsonContent.replace(
+  /("version"\s*:\s*")([^"]+)(")/,
+  `$1${newVersion}$3`,
+);
+
+const updatedCargoTomlContent = cargoTomlContent.replace(
+  /^version\s*=\s*"([^"]+)"/m,
+  `version = "${newVersion}"`,
+);
+
+// 4. Write files
+try {
+  fs.writeFileSync(rootPackageJsonPath, updatedRootJsonContent, "utf8");
+} catch (err) {
+  console.error(`Error writing to root package.json: ${err.message}`);
+  process.exit(1);
+}
+
+try {
+  fs.writeFileSync(frontendPackageJsonPath, updatedFrontendJsonContent, "utf8");
+} catch (err) {
+  console.error(`Error writing to frontend package.json: ${err.message}`);
+  process.exit(1);
+}
+
+try {
+  fs.writeFileSync(cargoTomlPath, updatedCargoTomlContent, "utf8");
+} catch (err) {
+  console.error(`Error writing to Cargo.toml: ${err.message}`);
+  process.exit(1);
+}
+
+// 5. Print summary
+console.log("\nVersion bump successful!");
+console.log(`- root package.json: ${oldRootVersion} → ${newVersion}`);
+console.log(`- frontend/package.json: ${oldFrontendVersion} → ${newVersion}`);
+console.log(
+  `- frontend/src-tauri/Cargo.toml: ${oldCargoVersion} → ${newVersion}`,
+);
+console.log(
+  "\nRemember to run 'cargo check' inside frontend/src-tauri/ to regenerate Cargo.lock",
+);

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -108,27 +108,64 @@ const updatedCargoTomlContent = cargoTomlContent.replace(
   `version = "${newVersion}"`,
 );
 
-// 4. Write files
-try {
-  fs.writeFileSync(rootPackageJsonPath, updatedRootJsonContent, "utf8");
-} catch (err) {
-  console.error(`Error writing to root package.json: ${err.message}`);
-  process.exit(1);
+// 4. Write files with rollback capability
+const writes = [
+  {
+    path: rootPackageJsonPath,
+    content: updatedRootJsonContent,
+    original: rootPackageJsonContent,
+    label: "root package.json",
+  },
+  {
+    path: frontendPackageJsonPath,
+    content: updatedFrontendJsonContent,
+    original: frontendPackageJsonContent,
+    label: "frontend/package.json",
+  },
+  {
+    path: cargoTomlPath,
+    content: updatedCargoTomlContent,
+    original: cargoTomlContent,
+    label: "frontend/src-tauri/Cargo.toml",
+  },
+];
+
+const completed = [];
+for (const write of writes) {
+  try {
+    fs.writeFileSync(write.path, write.content, "utf8");
+    completed.push(write);
+  } catch (err) {
+    console.error(`\nError writing to ${write.label}: ${err.message}`);
+    console.error("Initiating rollback...");
+
+    const rollbackFailures = [];
+    for (const completedWrite of completed) {
+      try {
+        fs.writeFileSync(completedWrite.path, completedWrite.original, "utf8");
+        console.log(`Rolled back changes in ${completedWrite.label}`);
+      } catch (rollbackErr) {
+        console.error(
+          `Critical Error: Failed to rollback ${completedWrite.label}: ${rollbackErr.message}`,
+        );
+        rollbackFailures.push(completedWrite);
+      }
+    }
+
+    if (rollbackFailures.length > 0) {
+      console.error(
+        "\nWARNING: Manual inspection is required. Some files could not be restored to their original state:",
+      );
+      for (const failed of rollbackFailures) {
+        console.error(`- ${failed.label} (${failed.path})`);
+      }
+    } else {
+      console.log("All completed writes successfully rolled back.");
+    }
+    process.exit(1);
+  }
 }
 
-try {
-  fs.writeFileSync(frontendPackageJsonPath, updatedFrontendJsonContent, "utf8");
-} catch (err) {
-  console.error(`Error writing to frontend package.json: ${err.message}`);
-  process.exit(1);
-}
-
-try {
-  fs.writeFileSync(cargoTomlPath, updatedCargoTomlContent, "utf8");
-} catch (err) {
-  console.error(`Error writing to Cargo.toml: ${err.message}`);
-  process.exit(1);
-}
 
 // 5. Print summary
 console.log("\nVersion bump successful!");


### PR DESCRIPTION
Closes #1306 

This pull request introduces a standardized process for managing and synchronizing version numbers across the project's main manifest files. It adds a new script to automate version bumps and updates the documentation to guide maintainers through the release process.

**Release management automation:**

* Added a new script, `scripts/bump-version.mjs`, which validates a provided version number and updates the `version` field in `package.json`, `frontend/package.json`, and `frontend/src-tauri/Cargo.toml` to keep them in sync. The script checks for errors, prints a summary of changes, and reminds the user to regenerate the Cargo lock file.
* Added a new npm script `version:bump` in the root `package.json` to run the version bump script easily from the command line.

**Documentation updates:**

* Updated `CONTRIBUTING.md` with a new "Release Management" section, documenting the version synchronization requirement, how to use the version bump script, and additional steps for regenerating lock files.


###  Additional Notes:

@rahulharpal1603, now, running `npm run version:bump -- 1.2.0` in root directory will bump all the versions at once.

<img width="743" height="211" alt="image" src="https://github.com/user-attachments/assets/03753b75-d9a2-4db4-8f52-c86d5bb5de11" />


### AI Usage Disclosure:

Check one of the checkboxes below:

- [ ] This PR does not contain AI-generated code at all.
- [x] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools: Gemini


## Checklist
<!-- Mark items with [x] to indicate completion -->
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [x] If applicable, I have made corresponding changes or additions to the documentation
- [ ] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added release management guidelines describing synchronized versioning across the project, required X.Y.Z format, and how to invoke the version bump process.

* **New Features**
  * Added a command to automate validated version bumps across all relevant project manifests; it reports changes, attempts rollback on failures, and reminds maintainers to regenerate lock state afterward.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->