### PR TITLE
fix(person-images): prevent flash of previous page's images (#1315)

### DIFF
--- a/frontend/src/pages/PersonImages/PersonImages.tsx
+++ b/frontend/src/pages/PersonImages/PersonImages.tsx
@@ -56,9 +56,9 @@ export const PersonImages = () => {
   // page's images (issue #1315). Fall back to the cluster-scoped query data for
   // that window; read the slice once synced so favourite toggles still work.
   const personImages =
-    loadedClusterId === clusterId
+    clusterId !== undefined && loadedClusterId === clusterId
       ? images
-      : (((data?.data as any)?.images as Image[]) ?? []);
+      : ((data?.data as { images?: Image[] })?.images ?? []);
 
   const handleEditName = () => {
     setClusterName(clusterName);

--- a/frontend/src/pages/PersonImages/PersonImages.tsx
+++ b/frontend/src/pages/PersonImages/PersonImages.tsx
@@ -22,6 +22,11 @@ export const PersonImages = () => {
   const images = useSelector(selectImages);
   const [clusterName, setClusterName] = useState<string>('random_name');
   const [isEditing, setIsEditing] = useState<boolean>(false);
+  // Which cluster the shared `images` slice currently holds. Keyed on clusterId
+  // (not `isLoading`) so it also covers person A -> person B when B is cached.
+  const [loadedClusterId, setLoadedClusterId] = useState<string | undefined>(
+    undefined,
+  );
   const { data, isLoading, isSuccess, isError } = usePictoQuery({
     queryKey: ['person-images', clusterId],
     queryFn: async () => fetchClusterImages({ clusterId: clusterId || '' }),
@@ -42,9 +47,18 @@ export const PersonImages = () => {
       const images = (res?.images || []) as Image[];
       dispatch(setImages(images));
       setClusterName(res?.cluster_name || 'random_name');
+      setLoadedClusterId(clusterId);
       dispatch(hideLoader());
     }
-  }, [data, isSuccess, isError, isLoading, dispatch]);
+  }, [data, isSuccess, isError, isLoading, dispatch, clusterId]);
+
+  // Until the slice is synced for this cluster it still holds the previous
+  // page's images (issue #1315). Fall back to the cluster-scoped query data for
+  // that window; read the slice once synced so favourite toggles still work.
+  const personImages =
+    loadedClusterId === clusterId
+      ? images
+      : (((data?.data as any)?.images as Image[]) ?? []);
 
   const handleEditName = () => {
     setClusterName(clusterName);
@@ -109,7 +123,7 @@ export const PersonImages = () => {
       </div>
       <h1 className="mb-6 text-2xl font-bold">{clusterName}</h1>
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
-        {images.map((image, index) => (
+        {personImages.map((image, index) => (
           <ImageCard
             key={image.id}
             image={image}
@@ -121,7 +135,7 @@ export const PersonImages = () => {
       </div>
 
       {/* Media Viewer Modal */}
-      {isImageViewOpen && <MediaView images={images} />}
+      {isImageViewOpen && <MediaView images={personImages} />}
     </div>
   );
 };

--- a/frontend/src/pages/PersonImages/PersonImages.tsx
+++ b/frontend/src/pages/PersonImages/PersonImages.tsx
@@ -22,8 +22,7 @@ export const PersonImages = () => {
   const images = useSelector(selectImages);
   const [clusterName, setClusterName] = useState<string>('random_name');
   const [isEditing, setIsEditing] = useState<boolean>(false);
-  // Which cluster the shared `images` slice currently holds. Keyed on clusterId
-  // (not `isLoading`) so it also covers person A -> person B when B is cached.
+  
   const [loadedClusterId, setLoadedClusterId] = useState<string | undefined>(
     undefined,
   );
@@ -52,9 +51,7 @@ export const PersonImages = () => {
     }
   }, [data, isSuccess, isError, isLoading, dispatch, clusterId]);
 
-  // Until the slice is synced for this cluster it still holds the previous
-  // page's images (issue #1315). Fall back to the cluster-scoped query data for
-  // that window; read the slice once synced so favourite toggles still work.
+  // Fallback to query data until Redux slice syncs for this cluster (#1315)
   const personImages =
     clusterId !== undefined && loadedClusterId === clusterId
       ? images

--- a/frontend/src/pages/PersonImages/PersonImages.tsx
+++ b/frontend/src/pages/PersonImages/PersonImages.tsx
@@ -22,7 +22,7 @@ export const PersonImages = () => {
   const images = useSelector(selectImages);
   const [clusterName, setClusterName] = useState<string>('random_name');
   const [isEditing, setIsEditing] = useState<boolean>(false);
-  
+
   const [loadedClusterId, setLoadedClusterId] = useState<string | undefined>(
     undefined,
   );
@@ -56,6 +56,11 @@ export const PersonImages = () => {
     clusterId !== undefined && loadedClusterId === clusterId
       ? images
       : ((data?.data as { images?: Image[] })?.images ?? []);
+  const displayName =
+    clusterId !== undefined && loadedClusterId === clusterId
+      ? clusterName
+      : ((data?.data as { cluster_name?: string })?.cluster_name ??
+        'random_name');
 
   const handleEditName = () => {
     setClusterName(clusterName);
@@ -118,7 +123,7 @@ export const PersonImages = () => {
           </Button>
         )}
       </div>
-      <h1 className="mb-6 text-2xl font-bold">{clusterName}</h1>
+      <h1 className="mb-6 text-2xl font-bold">{displayName}</h1>
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
         {personImages.map((image, index) => (
           <ImageCard

--- a/frontend/src/pages/PersonImages/PersonImages.tsx
+++ b/frontend/src/pages/PersonImages/PersonImages.tsx
@@ -83,8 +83,8 @@ export const PersonImages = () => {
     }
   };
   return (
-    <div className="p-6">
-      <div className="mb-6 flex items-center justify-between">
+    <div>
+      <div className="my-6 flex items-center justify-between">
         <Button
           variant="outline"
           onClick={() => navigate(`/${ROUTES.AI}`)}
@@ -124,15 +124,16 @@ export const PersonImages = () => {
         )}
       </div>
       <h1 className="mb-6 text-2xl font-bold">{displayName}</h1>
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+      <div className="grid grid-cols-1 gap-4 pb-6 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
         {personImages.map((image, index) => (
-          <ImageCard
-            key={image.id}
-            image={image}
-            imageIndex={index}
-            className="w-full"
-            onClick={() => dispatch(setCurrentViewIndex(index))}
-          />
+          <div key={image.id} className="group relative">
+            <ImageCard
+              image={image}
+              imageIndex={index}
+              className="w-full transition-transform duration-200 group-hover:scale-105"
+              onClick={() => dispatch(setCurrentViewIndex(index))}
+            />
+          </div>
         ))}
       </div>
 

--- a/frontend/src/pages/__tests__/PersonImages.test.tsx
+++ b/frontend/src/pages/__tests__/PersonImages.test.tsx
@@ -1,5 +1,6 @@
-import { render, screen, waitFor } from '@/test-utils';
-import { Routes, Route } from 'react-router';
+import { useLayoutEffect } from 'react';
+import { fireEvent, render, screen, waitFor } from '@/test-utils';
+import { Routes, Route, useNavigate } from 'react-router';
 import { PersonImages } from '@/pages/PersonImages/PersonImages';
 import type { Image } from '@/types/Media';
 import * as apiFunctions from '@/api/api-functions';
@@ -35,10 +36,55 @@ const personBImages = [
   makeImage('b2', '/personB/2.jpg'),
 ];
 
-const renderPerson = (clusterId: string) =>
+const CommitProbe = ({
+  onCommit,
+}: {
+  onCommit?: (headingText: string | null) => void;
+}) => {
+  useLayoutEffect(() => {
+    onCommit?.(document.querySelector('h1')?.textContent ?? null);
+  });
+
+  return null;
+};
+
+const PersonImagesWithNavigation = ({
+  onCommit,
+}: {
+  onCommit?: (headingText: string | null) => void;
+}) => {
+  const navigate = useNavigate();
+
+  return (
+    <>
+      <button type="button" onClick={() => navigate('/person/B')}>
+        Go to Person B
+      </button>
+      <PersonImages />
+      <CommitProbe onCommit={onCommit} />
+    </>
+  );
+};
+
+const renderPerson = (
+  clusterId: string,
+  options: {
+    withNavigation?: boolean;
+    onCommit?: (headingText: string | null) => void;
+  } = {},
+) =>
   render(
     <Routes>
-      <Route path="/person/:clusterId" element={<PersonImages />} />
+      <Route
+        path="/person/:clusterId"
+        element={
+          options.withNavigation ? (
+            <PersonImagesWithNavigation onCommit={options.onCommit} />
+          ) : (
+            <PersonImages />
+          )
+        }
+      />
     </Routes>,
     {
       preloadedState: {
@@ -70,20 +116,47 @@ beforeEach(() => {
 });
 
 describe('PersonImages (issue #1315: no flash of the previous page)', () => {
-  test('never paints the stale slice images, on the first frame or after', async () => {
-    const { container } = renderPerson('B');
-
-    expect(hasPersonA(container)).toBe(false);
-
-    // Let the query resolve, then confirm Person A never appears at any point.
-    await waitFor(() => {
-      expect(hasPersonB(container)).toBe(true);
+  test('never paints stale images or heading when navigating to a cached person', async () => {
+    const committedHeadings: Array<string | null> = [];
+    const { container, queryClient } = renderPerson('A', {
+      withNavigation: true,
+      onCommit: (headingText) => committedHeadings.push(headingText),
     });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { name: 'Alice' }),
+      ).toBeInTheDocument();
+      expect(hasPersonA(container)).toBe(true);
+    });
+
+    queryClient.setQueryData(['person-images', 'B'], {
+      success: true,
+      data: {
+        images: personBImages,
+        cluster_name: 'Bob',
+      },
+    });
+
+    committedHeadings.length = 0;
+    fireEvent.click(screen.getByRole('button', { name: 'Go to Person B' }));
+
+    expect(committedHeadings).not.toContain('Alice');
+    expect(
+      screen.queryByRole('heading', { name: 'Alice' }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Bob' })).toBeInTheDocument();
     expect(hasPersonA(container)).toBe(false);
+    expect(hasPersonB(container)).toBe(true);
   });
 
   test("renders the navigated cluster's images and name once loaded", async () => {
     const { container } = renderPerson('B');
+
+    expect(
+      screen.queryByRole('heading', { name: 'Alice' }),
+    ).not.toBeInTheDocument();
+    expect(hasPersonA(container)).toBe(false);
 
     expect(await screen.findByText('Bob')).toBeInTheDocument();
     await waitFor(() => {

--- a/frontend/src/pages/__tests__/PersonImages.test.tsx
+++ b/frontend/src/pages/__tests__/PersonImages.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen, waitFor } from '@/test-utils';
+import { Routes, Route } from 'react-router';
+import { PersonImages } from '@/pages/PersonImages/PersonImages';
+import type { Image } from '@/types/Media';
+import * as apiFunctions from '@/api/api-functions';
+
+// ImageCard resolves thumbnails through Tauri's convertFileSrc; return the path
+// unchanged so we can assert which person's images are in the DOM by their src.
+jest.mock('@tauri-apps/api/core', () => ({
+  invoke: jest.fn().mockResolvedValue(null),
+  convertFileSrc: (path: string) => path,
+}));
+
+jest.mock('@/api/api-functions', () => ({
+  fetchClusterImages: jest.fn(),
+  renameCluster: jest.fn(),
+}));
+
+const fetchClusterImages = apiFunctions.fetchClusterImages as jest.Mock;
+
+const makeImage = (id: string, path: string): Image => ({
+  id,
+  path,
+  thumbnailPath: path,
+  folder_id: 'folder',
+  isTagged: true,
+  isFavourite: false,
+  tags: [],
+});
+
+// "Person A" stands in for whatever the previous page (e.g. the Home gallery)
+// left in the shared `images` slice; "Person B" is the cluster we navigate to.
+const personAImages = [
+  makeImage('a1', '/personA/1.jpg'),
+  makeImage('a2', '/personA/2.jpg'),
+];
+const personBImages = [
+  makeImage('b1', '/personB/1.jpg'),
+  makeImage('b2', '/personB/2.jpg'),
+];
+
+const renderPerson = (clusterId: string) =>
+  render(
+    <Routes>
+      <Route path="/person/:clusterId" element={<PersonImages />} />
+    </Routes>,
+    {
+      // Pre-seed the shared slice with the previous page's images. This is the
+      // exact condition that produced the flash described in issue #1315.
+      preloadedState: {
+        images: { images: personAImages, currentViewIndex: -1 },
+      },
+      initialRoutes: [`/person/${clusterId}`],
+    },
+  );
+
+const imageSrcs = (container: HTMLElement) =>
+  Array.from(container.querySelectorAll('img')).map((img) =>
+    img.getAttribute('src'),
+  );
+
+const hasPersonA = (container: HTMLElement) =>
+  imageSrcs(container).some((src) => src?.startsWith('/personA/'));
+const hasPersonB = (container: HTMLElement) =>
+  imageSrcs(container).some((src) => src?.startsWith('/personB/'));
+
+beforeEach(() => {
+  fetchClusterImages.mockReset();
+  fetchClusterImages.mockImplementation(async ({ clusterId }) => ({
+    success: true,
+    data: {
+      images: clusterId === 'B' ? personBImages : personAImages,
+      cluster_name: clusterId === 'B' ? 'Bob' : 'Alice',
+    },
+  }));
+});
+
+describe('PersonImages (issue #1315: no flash of the previous page)', () => {
+  test('never paints the stale slice images, on the first frame or after', async () => {
+    const { container } = renderPerson('B');
+
+    // First frame: before the cluster query resolves, the shared slice still
+    // holds Person A's images. The grid must not paint them, otherwise the user
+    // sees the flash. (This assertion fails against the pre-fix code.)
+    expect(hasPersonA(container)).toBe(false);
+
+    // Let the query resolve, then confirm Person A never appears at any point.
+    await waitFor(() => {
+      expect(hasPersonB(container)).toBe(true);
+    });
+    expect(hasPersonA(container)).toBe(false);
+  });
+
+  test("renders the navigated cluster's images and name once loaded", async () => {
+    const { container } = renderPerson('B');
+
+    expect(await screen.findByText('Bob')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(hasPersonB(container)).toBe(true);
+    });
+  });
+});

--- a/frontend/src/pages/__tests__/PersonImages.test.tsx
+++ b/frontend/src/pages/__tests__/PersonImages.test.tsx
@@ -4,8 +4,6 @@ import { PersonImages } from '@/pages/PersonImages/PersonImages';
 import type { Image } from '@/types/Media';
 import * as apiFunctions from '@/api/api-functions';
 
-// ImageCard resolves thumbnails through Tauri's convertFileSrc; return the path
-// unchanged so we can assert which person's images are in the DOM by their src.
 jest.mock('@tauri-apps/api/core', () => ({
   invoke: jest.fn().mockResolvedValue(null),
   convertFileSrc: (path: string) => path,
@@ -28,8 +26,6 @@ const makeImage = (id: string, path: string): Image => ({
   tags: [],
 });
 
-// "Person A" stands in for whatever the previous page (e.g. the Home gallery)
-// left in the shared `images` slice; "Person B" is the cluster we navigate to.
 const personAImages = [
   makeImage('a1', '/personA/1.jpg'),
   makeImage('a2', '/personA/2.jpg'),
@@ -45,8 +41,6 @@ const renderPerson = (clusterId: string) =>
       <Route path="/person/:clusterId" element={<PersonImages />} />
     </Routes>,
     {
-      // Pre-seed the shared slice with the previous page's images. This is the
-      // exact condition that produced the flash described in issue #1315.
       preloadedState: {
         images: { images: personAImages, currentViewIndex: -1 },
       },
@@ -79,9 +73,6 @@ describe('PersonImages (issue #1315: no flash of the previous page)', () => {
   test('never paints the stale slice images, on the first frame or after', async () => {
     const { container } = renderPerson('B');
 
-    // First frame: before the cluster query resolves, the shared slice still
-    // holds Person A's images. The grid must not paint them, otherwise the user
-    // sees the flash. (This assertion fails against the pre-fix code.)
     expect(hasPersonA(container)).toBe(false);
 
     // Let the query resolve, then confirm Person A never appears at any point.


### PR DESCRIPTION
When a face cluster is opened from the Navbar search panel, `PersonImages` briefly rendered the previous page's images before the person's photos loaded, producing the flash described in the issue. This PR scopes the grid to the active cluster so the stale images can never paint.

  **Root cause:** the original "redirect to `/ai-tagging`" hypothesis did not match the code; `PersonImages` has no such redirect (it only navigates on the user-clicked "Back to AI Tagging" button). The real cause is the shared `images` Redux slice: the grid renders from `selectImages`, which still holds whatever the previous page left there until `fetchClusterImages` resolves and `setImages` runs. For the first frame(s) that stale set is on screen. Thanks to @VanshajPoonia for independently confirming this and flagging the cached-navigation case.

  **The fix (scoped to `PersonImages.tsx`):**
  - Track which cluster the shared slice holds via a `loadedClusterId` marker, set alongside `setImages` when the query succeeds.
  - Once the slice is in sync for the active `clusterId`, read the slice (so the optimistic favourite toggle keeps working); during the brief window before it syncs, fall back to the `['person-images', clusterId]` React Query data, which is already scoped to the active id and can only ever be the correct person's photos.
  - Point the grid and media viewer at this derived list instead of the raw slice.

  This does not rely on a loading flag, so it also covers person A to person B when B is already cached (`isLoading` is `false` immediately while the slice still holds A for a tick), which was @VanshajPoonia's review point.

  ###  Addressed Issues:

  Fixes #1315

  ###  Screenshots/Recordings:

 This is a sub-frame rendering flash, so it is covered by an automated regression test rather than a recording. `PersonImages.test.tsx` pre-seeds the shared slice with a previous page's images, navigates to a different cluster, and asserts the previous images never paint (on the first frame and after the query resolves). The test fails against the pre-fix code and passes with the fix.

  ###  Additional Notes:

  Reading the slice once synced (rather than reading query data everywhere) is deliberate: the favourite/heart toggle updates the slice, and its `['images']` cache invalidation does not match the `['person-images', id]` key, so reading query data everywhere would fix the flash but stop the heart icon from updating. The hybrid keeps both correct. Scope is limited to `PersonImages.tsx` and its test. Verified locally: full frontend suite (133 tests), `tsc`, and ESLint all pass.

  ### AI Usage Disclosure:

  We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact. AI slop is strongly discouraged and may lead to banning and blocking. Do not spam our repos with AI slop.

  Check one of the checkboxes below:

  - [ ] This PR does not contain AI-generated code at all.
  - [x] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I
  have tested the code locally and I am responsible for it.

  I have used the following AI models and tools: Claude Code (Anthropic Claude). I used it to investigate the root cause, draft the fix in `PersonImages.tsx`, and write the regression test. I reviewed every line, verified the diagnosis against the code myself, and confirmed the full frontend test suite, `tsc`, and ESLint pass locally before submitting.


  ## Checklist
  - [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
  - [x] My code follows the project's code style and conventions
  - [ ] If applicable, I have made corresponding changes or additions to the documentation
  - [x] If applicable, I have made corresponding changes or additions to tests
  - [x] My changes generate no new warnings or errors
  - [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with
  the project maintainers there
  - [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
  - [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
  - [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without
  review otherwise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented a flash of previously viewed images when switching between clusters by only displaying image data for the currently selected cluster and keeping the displayed cluster title synchronized as new images load.
  * Improved image grid and media modal to reflect the correct cluster-specific name and images.
* **Tests**
  * Added Jest + React Testing Library regression coverage to ensure stale cluster images never render during navigation and that the correct content appears after loading completes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->