### PR TITLE
refactor: replace broad except blocks with specific exceptions and logger

### DIFF
--- a/backend/app/database/connection.py
+++ b/backend/app/database/connection.py
@@ -2,6 +2,9 @@ import sqlite3
 from contextlib import contextmanager
 from typing import Generator
 from app.config.settings import DATABASE_PATH
+from app.logging.setup_logging import get_logger
+
+logger = get_logger(__name__)
 
 
 @contextmanager
@@ -25,7 +28,8 @@ def get_db_connection() -> Generator[sqlite3.Connection, None, None]:
     try:
         yield conn
         conn.commit()
-    except Exception:
+    except Exception as e:
+        logger.error(f"Database transaction failed, rolling back: {e}")
         conn.rollback()
         raise
     finally:

--- a/backend/app/database/face_clusters.py
+++ b/backend/app/database/face_clusters.py
@@ -1,6 +1,9 @@
 import sqlite3
 from typing import Optional, List, Dict, TypedDict, Union
 from app.config.settings import DATABASE_PATH
+from app.logging.setup_logging import get_logger
+
+logger = get_logger(__name__)
 
 # Type definitions
 ClusterId = str
@@ -60,10 +63,10 @@ def db_delete_all_clusters(cursor: Optional[sqlite3.Cursor] = None) -> int:
         if own_connection:
             conn.commit()
         return deleted_count
-    except Exception:
+    except sqlite3.Error as e:
         if own_connection:
             conn.rollback()
-        print("Error deleting all clusters.")
+        logger.error(f"Error deleting all clusters: {e}")
         raise
     finally:
         if own_connection:
@@ -114,9 +117,10 @@ def db_insert_clusters_batch(
         if own_connection:
             conn.commit()
         return cluster_ids
-    except Exception:
+    except sqlite3.Error as e:
         if own_connection:
             conn.rollback()
+        logger.error(f"Error inserting clusters batch: {e}")
         raise
     finally:
         if own_connection:

--- a/backend/app/database/faces.py
+++ b/backend/app/database/faces.py
@@ -3,6 +3,9 @@ import json
 import numpy as np
 from typing import Optional, List, Dict, Union, TypedDict
 from app.config.settings import DATABASE_PATH
+from app.logging.setup_logging import get_logger
+
+logger = get_logger(__name__)
 
 # Type definitions
 FaceId = int
@@ -331,10 +334,10 @@ def db_update_face_cluster_ids_batch(
 
         if own_connection:
             conn.commit()
-    except Exception:
+    except sqlite3.Error as e:
         if own_connection:
             conn.rollback()
-        print("Error updating face cluster IDs in batch.")
+        logger.error(f"Error updating face cluster IDs in batch: {e}")
         raise
     finally:
         if own_connection:

--- a/backend/app/database/faces.py
+++ b/backend/app/database/faces.py
@@ -315,14 +315,22 @@ def db_update_face_cluster_ids_batch(
         conn = sqlite3.connect(DATABASE_PATH)
         cursor = conn.cursor()
 
+    # 1. Prepare update data outside the DB transaction.
+    # mapping.get() calls could raise AttributeError if mappings are malformed;
+    # these are not sqlite3 errors and must be caught before the transaction.
     try:
-        # Prepare update data as tuples (cluster_id, face_id)
-        update_data = []
-        for mapping in face_cluster_mapping:
-            face_id = mapping.get("face_id")
-            cluster_id = mapping.get("cluster_id")
-            update_data.append((cluster_id, face_id))
+        update_data = [
+            (mapping.get("cluster_id"), mapping.get("face_id"))
+            for mapping in face_cluster_mapping
+        ]
+    except (AttributeError, KeyError, TypeError) as e:
+        if own_connection:
+            conn.close()
+        logger.error(f"Failed to prepare face cluster update data: {e}")
+        raise
 
+    # 2. Database transaction — only pure DB operations here, so sqlite3.Error is safe.
+    try:
         cursor.executemany(
             """
             UPDATE faces 

--- a/backend/app/database/metadata.py
+++ b/backend/app/database/metadata.py
@@ -71,14 +71,22 @@ def db_update_metadata(
     Returns:
         True if the metadata was updated, False otherwise
     """
+    # 1. Prepare/serialize data outside the DB transaction.
+    # json.dumps can raise TypeError/ValueError for non-serializable objects;
+    # these are not sqlite3 errors and must be caught separately.
+    try:
+        metadata_json = json.dumps(metadata)
+    except (TypeError, ValueError) as e:
+        logger.error(f"Failed to serialize metadata: {e}")
+        raise
+
     own_connection = cursor is None
     if own_connection:
         conn = sqlite3.connect(DATABASE_PATH)
         cursor = conn.cursor()
 
+    # 2. Database transaction — only pure DB operations here, so sqlite3.Error is safe.
     try:
-        metadata_json = json.dumps(metadata)
-
         # Delete all existing rows and insert new one
         cursor.execute("DELETE FROM metadata")
         cursor.execute("INSERT INTO metadata (metadata) VALUES (?)", (metadata_json,))
@@ -90,7 +98,6 @@ def db_update_metadata(
     except sqlite3.Error as e:
         if own_connection:
             conn.rollback()
-
         logger.error(f"Error updating metadata: {e}")
         raise
     finally:

--- a/backend/app/database/metadata.py
+++ b/backend/app/database/metadata.py
@@ -3,6 +3,9 @@ import sqlite3
 import json
 from typing import Optional, Dict, Any
 from app.config.settings import DATABASE_PATH
+from app.logging.setup_logging import get_logger
+
+logger = get_logger(__name__)
 
 
 def db_create_metadata_table() -> None:
@@ -84,11 +87,11 @@ def db_update_metadata(
         if own_connection:
             conn.commit()
         return success
-    except Exception as e:
+    except sqlite3.Error as e:
         if own_connection:
             conn.rollback()
 
-        print(f"Error updating metadata: {e}")
+        logger.error(f"Error updating metadata: {e}")
         raise
     finally:
         if own_connection:

--- a/backend/app/database/metadata.py
+++ b/backend/app/database/metadata.py
@@ -81,12 +81,14 @@ def db_update_metadata(
         raise
 
     own_connection = cursor is None
-    if own_connection:
-        conn = sqlite3.connect(DATABASE_PATH)
-        cursor = conn.cursor()
+    conn = None
 
-    # 2. Database transaction — only pure DB operations here, so sqlite3.Error is safe.
+    # 2. Database transaction / owned connection setup.
     try:
+        if own_connection:
+            conn = sqlite3.connect(DATABASE_PATH)
+            cursor = conn.cursor()
+
         # Delete all existing rows and insert new one
         cursor.execute("DELETE FROM metadata")
         cursor.execute("INSERT INTO metadata (metadata) VALUES (?)", (metadata_json,))
@@ -97,9 +99,10 @@ def db_update_metadata(
         return success
     except sqlite3.Error as e:
         if own_connection:
-            conn.rollback()
+            if conn is not None:
+                conn.rollback()
         logger.error(f"Error updating metadata: {e}")
         raise
     finally:
-        if own_connection:
+        if own_connection and conn is not None:
             conn.close()


### PR DESCRIPTION
### Description
This PR refactors the exception handling in the database modules under `backend/app/database/` (specifically `connection.py`, `metadata.py`, `faces.py`, and `face_clusters.py`). Broad `except Exception` blocks have been replaced with specific database exceptions (`sqlite3.Error`), and standard logger logging has been introduced instead of print statements to improve error reporting and maintainability.

### Changes
- **`connection.py`**:
  - Imported `get_logger` to capture and log transaction rollback occurrences.
  - Retained catching general exceptions in `get_db_connection` since it yields control to client blocks which can raise any standard Python error, but captured the error, logged the event, and re-raised it.
- **`metadata.py`**:
  - Replaced broad `except Exception` in `db_update_metadata` with `except sqlite3.Error`.
  - Logged errors using the project's standard logger instead of `print()`.
- **`faces.py`**:
  - Replaced broad `except Exception` in `db_update_face_cluster_ids_batch` with `except sqlite3.Error`.
  - Logged error messages to the standard logger instead of `print()`.
- **`face_clusters.py`**:
  - Replaced broad `except Exception` in `db_delete_all_clusters` and `db_insert_clusters_batch` with `except sqlite3.Error`.
  - Replaced `print()` with standard logger messages.

Closes #1334


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved database reliability with clearer, structured logging for transaction and batch-operation failures.
  * Updated error handling to distinguish SQLite errors from other failure types and perform more accurate rollback behavior.
  * Improved diagnostics by logging the underlying error details and handling JSON serialization failures before database writes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->