### PR TITLE
Fix/videoplayer bugs

### DIFF
--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -66,7 +66,7 @@
         ],
         "enable": true
       },
-      "csp": "default-src 'self'; img-src 'self' data: asset: http://asset.localhost; media-src 'self' blob: data:; connect-src 'self' ipc: http://ipc.localhost http://localhost:52123 ws://localhost:52123 http://localhost:52124 ws://localhost:52124"
+      "csp": "default-src 'self'; img-src 'self' data: asset: http://asset.localhost; media-src 'self' blob: data: asset: http://asset.localhost; connect-src 'self' ipc: http://ipc.localhost http://localhost:52123 ws://localhost:52123 http://localhost:52124 ws://localhost:52124"
     }
   }
 }

--- a/frontend/src/components/VideoPlayer/NetflixStylePlayer.tsx
+++ b/frontend/src/components/VideoPlayer/NetflixStylePlayer.tsx
@@ -112,7 +112,11 @@ export default function NetflixStylePlayer({
       const clickPosition =
         (e.clientX - progressBar.getBoundingClientRect().left) /
         progressBar.offsetWidth;
-      const newTime = clickPosition * videoRef.current.duration;
+      const rawTime = clickPosition * videoRef.current.duration;
+      const maxTime = Number.isFinite(videoRef.current.duration)
+        ? videoRef.current.duration
+        : 0;
+      const newTime = Math.min(Math.max(rawTime, 0), maxTime);
       videoRef.current.currentTime = newTime;
       setCurrentTime(newTime);
     }
@@ -128,7 +132,11 @@ export default function NetflixStylePlayer({
 
   const skipTime = (seconds: number) => {
     if (videoRef.current) {
-      const newTime = videoRef.current.currentTime + seconds;
+      const rawTime = videoRef.current.currentTime + seconds;
+      const maxTime = Number.isFinite(videoRef.current.duration)
+        ? videoRef.current.duration
+        : 0;
+      const newTime = Math.min(Math.max(rawTime, 0), maxTime);
       videoRef.current.currentTime = newTime;
       setCurrentTime(newTime);
     }

--- a/frontend/src/components/VideoPlayer/NetflixStylePlayer.tsx
+++ b/frontend/src/components/VideoPlayer/NetflixStylePlayer.tsx
@@ -11,6 +11,7 @@ import {
   VolumeX,
 } from 'lucide-react';
 import { Slider } from '../../components/ui/Slider';
+import { convertFileSrc } from '@tauri-apps/api/core';
 
 interface NetflixStylePlayerProps {
   videoSrc: string;
@@ -38,22 +39,31 @@ export default function NetflixStylePlayer({
       timeout = setTimeout(() => setShowControls(false), 3000);
     };
 
+    const handleFullscreenChange = () => {
+      setIsFullscreen(document.fullscreenElement === containerRef.current);
+    };
+
     const container = containerRef.current;
     if (container) {
       container.addEventListener('mousemove', showControlsTemporarily);
       container.addEventListener('mouseenter', showControlsTemporarily);
     }
+    document.addEventListener('fullscreenchange', handleFullscreenChange);
 
     return () => {
       if (container) {
         container.removeEventListener('mousemove', showControlsTemporarily);
         container.removeEventListener('mouseenter', showControlsTemporarily);
       }
+      document.removeEventListener('fullscreenchange', handleFullscreenChange);
       clearTimeout(timeout);
     };
   }, []);
 
   const formatTime = (timeInSeconds: number) => {
+    if (isNaN(timeInSeconds) || !isFinite(timeInSeconds)) {
+      return '0:00';
+    }
     const hours = Math.floor(timeInSeconds / 3600);
     const minutes = Math.floor((timeInSeconds % 3600) / 60);
     const seconds = Math.floor(timeInSeconds % 60);
@@ -95,7 +105,6 @@ export default function NetflixStylePlayer({
     } else {
       document.exitFullscreen();
     }
-    setIsFullscreen(!isFullscreen);
   };
 
   const skipTime = (seconds: number) => {
@@ -108,6 +117,7 @@ export default function NetflixStylePlayer({
     if (videoRef.current) {
       const volumeValue = newVolume[0];
       videoRef.current.volume = volumeValue;
+      videoRef.current.muted = volumeValue === 0;
       setVolume(volumeValue);
       setIsMuted(volumeValue === 0);
     }
@@ -130,9 +140,11 @@ export default function NetflixStylePlayer({
       >
         <video
           ref={videoRef}
-          src={videoSrc}
+          src={convertFileSrc(videoSrc)}
           className="h-full w-full"
           onTimeUpdate={handleProgress}
+          onPlay={() => setIsPlaying(true)}
+          onPause={() => setIsPlaying(false)}
           preload="auto"
         />
       </div>

--- a/frontend/src/components/VideoPlayer/NetflixStylePlayer.tsx
+++ b/frontend/src/components/VideoPlayer/NetflixStylePlayer.tsx
@@ -1,5 +1,5 @@
 import type React from 'react';
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useMemo } from 'react';
 import {
   Play,
   Pause,
@@ -33,6 +33,8 @@ export default function NetflixStylePlayer({
   const videoRef = useRef<HTMLVideoElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
+  const resolvedSrc = useMemo(() => convertFileSrc(videoSrc), [videoSrc]);
+
   useEffect(() => {
     let timeout: NodeJS.Timeout;
     const showControlsTemporarily = () => {
@@ -41,29 +43,34 @@ export default function NetflixStylePlayer({
       timeout = setTimeout(() => setShowControls(false), 3000);
     };
 
-    const handleFullscreenChange = () => {
-      setIsFullscreen(document.fullscreenElement === containerRef.current);
-    };
-
     const container = containerRef.current;
     if (container) {
       container.addEventListener('mousemove', showControlsTemporarily);
       container.addEventListener('mouseenter', showControlsTemporarily);
     }
-    document.addEventListener('fullscreenchange', handleFullscreenChange);
 
     return () => {
       if (container) {
         container.removeEventListener('mousemove', showControlsTemporarily);
         container.removeEventListener('mouseenter', showControlsTemporarily);
       }
-      document.removeEventListener('fullscreenchange', handleFullscreenChange);
       clearTimeout(timeout);
     };
   }, []);
 
+  useEffect(() => {
+    const handleFullscreenChange = () => {
+      setIsFullscreen(document.fullscreenElement === containerRef.current);
+    };
+
+    document.addEventListener('fullscreenchange', handleFullscreenChange);
+    return () => {
+      document.removeEventListener('fullscreenchange', handleFullscreenChange);
+    };
+  }, []);
+
   const formatTime = (timeInSeconds: number) => {
-    if (isNaN(timeInSeconds) || !isFinite(timeInSeconds)) {
+    if (!Number.isFinite(timeInSeconds)) {
       return '0:00';
     }
     const hours = Math.floor(timeInSeconds / 3600);
@@ -77,9 +84,12 @@ export default function NetflixStylePlayer({
   };
 
   const togglePlay = () => {
-    if (videoRef.current) {
-      isPlaying ? videoRef.current.pause() : videoRef.current.play();
-      setIsPlaying(!isPlaying);
+    const video = videoRef.current;
+    if (!video) return;
+    if (video.paused) {
+      video.play().catch(() => {});
+    } else {
+      video.pause();
     }
   };
 
@@ -169,7 +179,7 @@ export default function NetflixStylePlayer({
       >
         <video
           ref={videoRef}
-          src={convertFileSrc(videoSrc)}
+          src={resolvedSrc}
           className="h-full w-full"
           onTimeUpdate={handleProgress}
           onLoadedMetadata={handleLoadedMetadata}

--- a/frontend/src/components/VideoPlayer/NetflixStylePlayer.tsx
+++ b/frontend/src/components/VideoPlayer/NetflixStylePlayer.tsx
@@ -49,11 +49,58 @@ export default function NetflixStylePlayer({
       container.addEventListener('mouseenter', showControlsTemporarily);
     }
 
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const activeEl = document.activeElement;
+      if (
+        activeEl &&
+        (activeEl.tagName === 'INPUT' ||
+          activeEl.tagName === 'TEXTAREA' ||
+          activeEl.getAttribute('contenteditable') === 'true')
+      ) {
+        return;
+      }
+
+      switch (e.key) {
+        case ' ':
+          e.preventDefault();
+          togglePlay();
+          showControlsTemporarily();
+          break;
+        case 'ArrowLeft':
+          e.preventDefault();
+          skipTime(-10);
+          showControlsTemporarily();
+          break;
+        case 'ArrowRight':
+          e.preventDefault();
+          skipTime(10);
+          showControlsTemporarily();
+          break;
+        case 'm':
+        case 'M':
+          e.preventDefault();
+          toggleMute();
+          showControlsTemporarily();
+          break;
+        case 'f':
+        case 'F':
+          e.preventDefault();
+          toggleFullScreen();
+          showControlsTemporarily();
+          break;
+        default:
+          break;
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
     return () => {
       if (container) {
         container.removeEventListener('mousemove', showControlsTemporarily);
         container.removeEventListener('mouseenter', showControlsTemporarily);
       }
+      document.removeEventListener('keydown', handleKeyDown);
       clearTimeout(timeout);
     };
   }, []);
@@ -164,7 +211,7 @@ export default function NetflixStylePlayer({
 
   const toggleMute = () => {
     if (videoRef.current) {
-      const newMuteState = !isMuted;
+      const newMuteState = !videoRef.current.muted;
       videoRef.current.muted = newMuteState;
       setIsMuted(newMuteState);
     }

--- a/frontend/src/components/VideoPlayer/NetflixStylePlayer.tsx
+++ b/frontend/src/components/VideoPlayer/NetflixStylePlayer.tsx
@@ -203,9 +203,7 @@ export default function NetflixStylePlayer({
             <FastForward size={24} />
           </button>
           <div className="text-white">
-            {formatTime(currentTime) +
-              ' / ' +
-              formatTime(duration)}
+            {formatTime(currentTime) + ' / ' + formatTime(duration)}
           </div>
         </div>
 

--- a/frontend/src/components/VideoPlayer/NetflixStylePlayer.tsx
+++ b/frontend/src/components/VideoPlayer/NetflixStylePlayer.tsx
@@ -28,6 +28,8 @@ export default function NetflixStylePlayer({
   const [isMuted, setIsMuted] = useState(false);
   const [showControls, setShowControls] = useState(false);
   const [isFullscreen, setIsFullscreen] = useState(false);
+  const [currentTime, setCurrentTime] = useState(0);
+  const [duration, setDuration] = useState(0);
   const videoRef = useRef<HTMLVideoElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -83,9 +85,24 @@ export default function NetflixStylePlayer({
 
   const handleProgress = () => {
     if (videoRef.current) {
+      setCurrentTime(videoRef.current.currentTime);
       setProgress(
-        (videoRef.current.currentTime / videoRef.current.duration) * 100,
+        videoRef.current.duration
+          ? (videoRef.current.currentTime / videoRef.current.duration) * 100
+          : 0,
       );
+    }
+  };
+
+  const handleLoadedMetadata = () => {
+    if (videoRef.current) {
+      setDuration(videoRef.current.duration);
+    }
+  };
+
+  const handleDurationChange = () => {
+    if (videoRef.current) {
+      setDuration(videoRef.current.duration);
     }
   };
 
@@ -95,7 +112,9 @@ export default function NetflixStylePlayer({
       const clickPosition =
         (e.clientX - progressBar.getBoundingClientRect().left) /
         progressBar.offsetWidth;
-      videoRef.current.currentTime = clickPosition * videoRef.current.duration;
+      const newTime = clickPosition * videoRef.current.duration;
+      videoRef.current.currentTime = newTime;
+      setCurrentTime(newTime);
     }
   };
 
@@ -109,7 +128,9 @@ export default function NetflixStylePlayer({
 
   const skipTime = (seconds: number) => {
     if (videoRef.current) {
-      videoRef.current.currentTime += seconds;
+      const newTime = videoRef.current.currentTime + seconds;
+      videoRef.current.currentTime = newTime;
+      setCurrentTime(newTime);
     }
   };
 
@@ -143,8 +164,11 @@ export default function NetflixStylePlayer({
           src={convertFileSrc(videoSrc)}
           className="h-full w-full"
           onTimeUpdate={handleProgress}
+          onLoadedMetadata={handleLoadedMetadata}
+          onDurationChange={handleDurationChange}
           onPlay={() => setIsPlaying(true)}
           onPause={() => setIsPlaying(false)}
+          onEnded={() => setIsPlaying(false)}
           preload="auto"
         />
       </div>
@@ -179,9 +203,9 @@ export default function NetflixStylePlayer({
             <FastForward size={24} />
           </button>
           <div className="text-white">
-            {formatTime(videoRef.current?.currentTime ?? 0) +
+            {formatTime(currentTime) +
               ' / ' +
-              formatTime(videoRef.current?.duration ?? 0)}
+              formatTime(duration)}
           </div>
         </div>
 

--- a/frontend/src/components/VideoPlayer/__tests__/NetflixStylePlayer.test.tsx
+++ b/frontend/src/components/VideoPlayer/__tests__/NetflixStylePlayer.test.tsx
@@ -1,4 +1,6 @@
 import { render, screen, fireEvent, act } from '@testing-library/react';
+import fs from 'fs';
+import path from 'path';
 import NetflixStylePlayer from '../NetflixStylePlayer';
 
 // Mock Tauri convertFileSrc API
@@ -232,5 +234,26 @@ describe('NetflixStylePlayer', () => {
     });
 
     expect(screen.getByTestId('icon-play')).toBeInTheDocument();
+  });
+
+  describe('Tauri CSP Policy Configuration', () => {
+    test('tauri.conf.json whitelists asset: and http://asset.localhost in media-src CSP', () => {
+      const configPath = path.resolve(
+        __dirname,
+        '../../../../src-tauri/tauri.conf.json',
+      );
+      const configRaw = fs.readFileSync(configPath, 'utf8');
+      const config = JSON.parse(configRaw);
+
+      const csp = config.app?.security?.csp;
+      expect(csp).toBeDefined();
+
+      const mediaSrcMatch = csp.match(/media-src\s+([^;]+)/);
+      expect(mediaSrcMatch).toBeTruthy();
+
+      const mediaSrcDirective = mediaSrcMatch[1];
+      expect(mediaSrcDirective).toContain('asset:');
+      expect(mediaSrcDirective).toContain('http://asset.localhost');
+    });
   });
 });

--- a/frontend/src/components/VideoPlayer/__tests__/NetflixStylePlayer.test.tsx
+++ b/frontend/src/components/VideoPlayer/__tests__/NetflixStylePlayer.test.tsx
@@ -236,6 +236,89 @@ describe('NetflixStylePlayer', () => {
     expect(screen.getByTestId('icon-play')).toBeInTheDocument();
   });
 
+  test('handles keyboard shortcuts for play/pause, seek, mute, and fullscreen', () => {
+    render(
+      <NetflixStylePlayer
+        videoSrc="video.mp4"
+        title="Test"
+        description="Desc"
+      />,
+    );
+
+    const video = document.querySelector('video') as HTMLVideoElement;
+
+    let setMutedVal = false;
+    let setVolumeVal = 1;
+    let setTimeVal = 0;
+    Object.defineProperty(video, 'muted', {
+      get: () => setMutedVal,
+      set: (val) => {
+        setMutedVal = val;
+      },
+      configurable: true,
+    });
+    Object.defineProperty(video, 'volume', {
+      get: () => setVolumeVal,
+      set: (val) => {
+        setVolumeVal = val;
+      },
+      configurable: true,
+    });
+    Object.defineProperty(video, 'currentTime', {
+      get: () => setTimeVal,
+      set: (val) => {
+        setTimeVal = val;
+      },
+      configurable: true,
+    });
+    Object.defineProperty(video, 'duration', {
+      value: 120,
+      writable: true,
+      configurable: true,
+    });
+
+    expect(screen.getByTestId('icon-play')).toBeInTheDocument();
+    act(() => {
+      fireEvent.keyDown(document, { key: ' ' });
+    });
+    expect(screen.getByTestId('icon-pause')).toBeInTheDocument();
+
+    expect(screen.queryByTestId('icon-mute')).not.toBeInTheDocument();
+    act(() => {
+      fireEvent.keyDown(document, { key: 'm' });
+    });
+    expect(setMutedVal).toBe(true);
+    expect(screen.getByTestId('icon-mute')).toBeInTheDocument();
+
+    expect(setTimeVal).toBe(0);
+    act(() => {
+      fireEvent.keyDown(document, { key: 'ArrowRight' });
+    });
+    expect(setTimeVal).toBe(10);
+
+    act(() => {
+      fireEvent.keyDown(document, { key: 'ArrowLeft' });
+    });
+    expect(setTimeVal).toBe(0);
+
+    expect(requestFullscreenMock).not.toHaveBeenCalled();
+    act(() => {
+      fireEvent.keyDown(document, { key: 'f' });
+    });
+    expect(requestFullscreenMock).toHaveBeenCalled();
+
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    input.focus();
+
+    act(() => {
+      fireEvent.keyDown(input, { key: ' ' });
+    });
+    expect(screen.getByTestId('icon-pause')).toBeInTheDocument();
+
+    document.body.removeChild(input);
+  });
+
   describe('Tauri CSP Policy Configuration', () => {
     test('tauri.conf.json whitelists asset: and http://asset.localhost in media-src CSP', () => {
       const configPath = path.resolve(

--- a/frontend/src/components/VideoPlayer/__tests__/NetflixStylePlayer.test.tsx
+++ b/frontend/src/components/VideoPlayer/__tests__/NetflixStylePlayer.test.tsx
@@ -47,6 +47,40 @@ jest.mock('lucide-react', () => ({
   Minimize2: () => <span data-testid="icon-minimize">Minimize</span>,
 }));
 
+const mockVideoProperties = (video: HTMLVideoElement) => {
+  const state = {
+    muted: false,
+    volume: 1,
+    currentTime: 0,
+  };
+
+  Object.defineProperty(video, 'muted', {
+    get: () => state.muted,
+    set: (val) => {
+      state.muted = val;
+    },
+    configurable: true,
+  });
+
+  Object.defineProperty(video, 'volume', {
+    get: () => state.volume,
+    set: (val) => {
+      state.volume = val;
+    },
+    configurable: true,
+  });
+
+  Object.defineProperty(video, 'currentTime', {
+    get: () => state.currentTime,
+    set: (val) => {
+      state.currentTime = val;
+    },
+    configurable: true,
+  });
+
+  return state;
+};
+
 describe('NetflixStylePlayer', () => {
   let requestFullscreenMock: jest.Mock;
   let exitFullscreenMock: jest.Mock;
@@ -172,22 +206,7 @@ describe('NetflixStylePlayer', () => {
     );
     const video = document.querySelector('video') as HTMLVideoElement;
 
-    let setMutedVal = false;
-    let setVolumeVal = 1;
-    Object.defineProperty(video, 'muted', {
-      get: () => setMutedVal,
-      set: (val) => {
-        setMutedVal = val;
-      },
-      configurable: true,
-    });
-    Object.defineProperty(video, 'volume', {
-      get: () => setVolumeVal,
-      set: (val) => {
-        setVolumeVal = val;
-      },
-      configurable: true,
-    });
+    const videoMockState = mockVideoProperties(video);
 
     const muteBtn = screen.getByTestId('icon-volume').closest('button');
     expect(muteBtn).toBeInTheDocument();
@@ -196,7 +215,7 @@ describe('NetflixStylePlayer', () => {
       fireEvent.click(muteBtn!);
     });
 
-    expect(setMutedVal).toBe(true);
+    expect(videoMockState.muted).toBe(true);
     expect(screen.getByTestId('icon-mute')).toBeInTheDocument();
 
     const slider = screen.getByTestId('volume-slider');
@@ -204,8 +223,8 @@ describe('NetflixStylePlayer', () => {
       fireEvent.change(slider, { target: { value: '0.5' } });
     });
 
-    expect(setVolumeVal).toBe(0.5);
-    expect(setMutedVal).toBe(false);
+    expect(videoMockState.volume).toBe(0.5);
+    expect(videoMockState.muted).toBe(false);
     expect(screen.getByTestId('icon-volume')).toBeInTheDocument();
   });
 
@@ -247,30 +266,7 @@ describe('NetflixStylePlayer', () => {
 
     const video = document.querySelector('video') as HTMLVideoElement;
 
-    let setMutedVal = false;
-    let setVolumeVal = 1;
-    let setTimeVal = 0;
-    Object.defineProperty(video, 'muted', {
-      get: () => setMutedVal,
-      set: (val) => {
-        setMutedVal = val;
-      },
-      configurable: true,
-    });
-    Object.defineProperty(video, 'volume', {
-      get: () => setVolumeVal,
-      set: (val) => {
-        setVolumeVal = val;
-      },
-      configurable: true,
-    });
-    Object.defineProperty(video, 'currentTime', {
-      get: () => setTimeVal,
-      set: (val) => {
-        setTimeVal = val;
-      },
-      configurable: true,
-    });
+    const videoMockState = mockVideoProperties(video);
     Object.defineProperty(video, 'duration', {
       value: 120,
       writable: true,
@@ -287,19 +283,19 @@ describe('NetflixStylePlayer', () => {
     act(() => {
       fireEvent.keyDown(document, { key: 'm' });
     });
-    expect(setMutedVal).toBe(true);
+    expect(videoMockState.muted).toBe(true);
     expect(screen.getByTestId('icon-mute')).toBeInTheDocument();
 
-    expect(setTimeVal).toBe(0);
+    expect(videoMockState.currentTime).toBe(0);
     act(() => {
       fireEvent.keyDown(document, { key: 'ArrowRight' });
     });
-    expect(setTimeVal).toBe(10);
+    expect(videoMockState.currentTime).toBe(10);
 
     act(() => {
       fireEvent.keyDown(document, { key: 'ArrowLeft' });
     });
-    expect(setTimeVal).toBe(0);
+    expect(videoMockState.currentTime).toBe(0);
 
     expect(requestFullscreenMock).not.toHaveBeenCalled();
     act(() => {
@@ -311,12 +307,14 @@ describe('NetflixStylePlayer', () => {
     document.body.appendChild(input);
     input.focus();
 
-    act(() => {
-      fireEvent.keyDown(input, { key: ' ' });
-    });
-    expect(screen.getByTestId('icon-pause')).toBeInTheDocument();
-
-    document.body.removeChild(input);
+    try {
+      act(() => {
+        fireEvent.keyDown(input, { key: ' ' });
+      });
+      expect(screen.getByTestId('icon-pause')).toBeInTheDocument();
+    } finally {
+      document.body.removeChild(input);
+    }
   });
 
   describe('Tauri CSP Policy Configuration', () => {

--- a/frontend/src/components/VideoPlayer/__tests__/NetflixStylePlayer.test.tsx
+++ b/frontend/src/components/VideoPlayer/__tests__/NetflixStylePlayer.test.tsx
@@ -1,0 +1,190 @@
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import NetflixStylePlayer from '../NetflixStylePlayer';
+
+// Mock Tauri convertFileSrc API
+jest.mock('@tauri-apps/api/core', () => ({
+  convertFileSrc: (path: string) => `tauri-converted://${path}`,
+}));
+
+// Mock Slider component to use simple range input for testing
+jest.mock('../../ui/Slider', () => ({
+  Slider: ({ onValueChange, value, min, max, step }: any) => (
+    <input
+      data-testid="volume-slider"
+      type="range"
+      min={min}
+      max={max}
+      step={step}
+      value={value[0]}
+      onChange={(e) => onValueChange([parseFloat(e.target.value)])}
+    />
+  ),
+}));
+
+// Mock lucide icons for easy querying
+jest.mock('lucide-react', () => ({
+  Play: () => <span data-testid="icon-play">Play</span>,
+  Pause: () => <span data-testid="icon-pause">Pause</span>,
+  Rewind: () => <span data-testid="icon-rewind">Rewind</span>,
+  FastForward: () => <span data-testid="icon-fastforward">FastForward</span>,
+  Volume2: () => <span data-testid="icon-volume">Volume</span>,
+  VolumeX: () => <span data-testid="icon-mute">Mute</span>,
+  Maximize2: () => <span data-testid="icon-maximize">Maximize</span>,
+  Minimize2: () => <span data-testid="icon-minimize">Minimize</span>,
+}));
+
+describe('NetflixStylePlayer', () => {
+  let requestFullscreenMock: jest.Mock;
+  let exitFullscreenMock: jest.Mock;
+
+  beforeEach(() => {
+    // Mock HTMLMediaElement play and pause
+    window.HTMLMediaElement.prototype.play = jest.fn().mockImplementation(function (this: HTMLVideoElement) {
+      const playEvent = new Event('play');
+      this.dispatchEvent(playEvent);
+      return Promise.resolve();
+    });
+
+    window.HTMLMediaElement.prototype.pause = jest.fn().mockImplementation(function (this: HTMLVideoElement) {
+      const pauseEvent = new Event('pause');
+      this.dispatchEvent(pauseEvent);
+    });
+
+    requestFullscreenMock = jest.fn();
+    exitFullscreenMock = jest.fn();
+
+    HTMLElement.prototype.requestFullscreen = requestFullscreenMock;
+    document.exitFullscreen = exitFullscreenMock;
+
+    Object.defineProperty(document, 'fullscreenElement', {
+      value: null,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('converts video source using convertFileSrc for Tauri support', () => {
+    render(<NetflixStylePlayer videoSrc="local-path/video.mp4" title="Test" description="Desc" />);
+    const video = document.querySelector('video') as HTMLVideoElement;
+    expect(video).toBeInTheDocument();
+    expect(video.src).toBe('tauri-converted://local-path/video.mp4');
+  });
+
+  test('updates isFullscreen state on fullscreenchange event', () => {
+    const { container } = render(<NetflixStylePlayer videoSrc="test-video.mp4" title="Test" description="Desc" />);
+
+    expect(screen.queryByTestId('icon-minimize')).not.toBeInTheDocument();
+    expect(screen.getByTestId('icon-maximize')).toBeInTheDocument();
+
+    Object.defineProperty(document, 'fullscreenElement', {
+      value: container.firstChild,
+      writable: true,
+      configurable: true,
+    });
+
+    act(() => {
+      document.dispatchEvent(new Event('fullscreenchange'));
+    });
+
+    expect(screen.getByTestId('icon-minimize')).toBeInTheDocument();
+    expect(screen.queryByTestId('icon-maximize')).not.toBeInTheDocument();
+
+    Object.defineProperty(document, 'fullscreenElement', {
+      value: null,
+      writable: true,
+      configurable: true,
+    });
+
+    act(() => {
+      document.dispatchEvent(new Event('fullscreenchange'));
+    });
+
+    expect(screen.queryByTestId('icon-minimize')).not.toBeInTheDocument();
+    expect(screen.getByTestId('icon-maximize')).toBeInTheDocument();
+  });
+
+  test('renders 0:00 before video metadata is loaded and updates on loadedmetadata', () => {
+    render(<NetflixStylePlayer videoSrc="video.mp4" title="Test" description="Desc" />);
+
+    expect(screen.getByText('0:00 / 0:00')).toBeInTheDocument();
+
+    const video = document.querySelector('video') as HTMLVideoElement;
+
+    Object.defineProperty(video, 'duration', {
+      configurable: true,
+      value: 125,
+    });
+
+    act(() => {
+      fireEvent(video, new Event('loadedmetadata'));
+    });
+
+    expect(screen.getByText('0:00 / 2:05')).toBeInTheDocument();
+  });
+
+  test('volume slider updates volume and unmutes video', () => {
+    render(<NetflixStylePlayer videoSrc="video.mp4" title="Test" description="Desc" />);
+    const video = document.querySelector('video') as HTMLVideoElement;
+
+    let setMutedVal = false;
+    let setVolumeVal = 1;
+    Object.defineProperty(video, 'muted', {
+      get: () => setMutedVal,
+      set: (val) => {
+        setMutedVal = val;
+      },
+      configurable: true,
+    });
+    Object.defineProperty(video, 'volume', {
+      get: () => setVolumeVal,
+      set: (val) => {
+        setVolumeVal = val;
+      },
+      configurable: true,
+    });
+
+    const muteBtn = screen.getByTestId('icon-volume').closest('button');
+    expect(muteBtn).toBeInTheDocument();
+
+    act(() => {
+      fireEvent.click(muteBtn!);
+    });
+
+    expect(setMutedVal).toBe(true);
+    expect(screen.getByTestId('icon-mute')).toBeInTheDocument();
+
+    const slider = screen.getByTestId('volume-slider');
+    act(() => {
+      fireEvent.change(slider, { target: { value: '0.5' } });
+    });
+
+    expect(setVolumeVal).toBe(0.5);
+    expect(setMutedVal).toBe(false);
+    expect(screen.getByTestId('icon-volume')).toBeInTheDocument();
+  });
+
+  test('play/pause button updates when video ends', () => {
+    render(<NetflixStylePlayer videoSrc="video.mp4" title="Test" description="Desc" />);
+
+    const playBtn = screen.getByTestId('icon-play').closest('button');
+    expect(playBtn).toBeInTheDocument();
+
+    act(() => {
+      fireEvent.click(playBtn!);
+    });
+
+    expect(screen.getByTestId('icon-pause')).toBeInTheDocument();
+
+    const video = document.querySelector('video') as HTMLVideoElement;
+
+    act(() => {
+      fireEvent(video, new Event('ended'));
+    });
+
+    expect(screen.getByTestId('icon-play')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/VideoPlayer/__tests__/NetflixStylePlayer.test.tsx
+++ b/frontend/src/components/VideoPlayer/__tests__/NetflixStylePlayer.test.tsx
@@ -8,7 +8,19 @@ jest.mock('@tauri-apps/api/core', () => ({
 
 // Mock Slider component to use simple range input for testing
 jest.mock('../../ui/Slider', () => ({
-  Slider: ({ onValueChange, value, min, max, step }: any) => (
+  Slider: ({
+    onValueChange,
+    value = [0],
+    min,
+    max,
+    step,
+  }: {
+    onValueChange?: (value: number[]) => void;
+    value?: number[];
+    min?: number;
+    max?: number;
+    step?: number;
+  }) => (
     <input
       data-testid="volume-slider"
       type="range"
@@ -16,7 +28,7 @@ jest.mock('../../ui/Slider', () => ({
       max={max}
       step={step}
       value={value[0]}
-      onChange={(e) => onValueChange([parseFloat(e.target.value)])}
+      onChange={(e) => onValueChange?.([Number.parseFloat(e.target.value)])}
     />
   ),
 }));

--- a/frontend/src/components/VideoPlayer/__tests__/NetflixStylePlayer.test.tsx
+++ b/frontend/src/components/VideoPlayer/__tests__/NetflixStylePlayer.test.tsx
@@ -39,16 +39,20 @@ describe('NetflixStylePlayer', () => {
 
   beforeEach(() => {
     // Mock HTMLMediaElement play and pause
-    window.HTMLMediaElement.prototype.play = jest.fn().mockImplementation(function (this: HTMLVideoElement) {
-      const playEvent = new Event('play');
-      this.dispatchEvent(playEvent);
-      return Promise.resolve();
-    });
+    window.HTMLMediaElement.prototype.play = jest
+      .fn()
+      .mockImplementation(function (this: HTMLVideoElement) {
+        const playEvent = new Event('play');
+        this.dispatchEvent(playEvent);
+        return Promise.resolve();
+      });
 
-    window.HTMLMediaElement.prototype.pause = jest.fn().mockImplementation(function (this: HTMLVideoElement) {
-      const pauseEvent = new Event('pause');
-      this.dispatchEvent(pauseEvent);
-    });
+    window.HTMLMediaElement.prototype.pause = jest
+      .fn()
+      .mockImplementation(function (this: HTMLVideoElement) {
+        const pauseEvent = new Event('pause');
+        this.dispatchEvent(pauseEvent);
+      });
 
     requestFullscreenMock = jest.fn();
     exitFullscreenMock = jest.fn();
@@ -68,14 +72,26 @@ describe('NetflixStylePlayer', () => {
   });
 
   test('converts video source using convertFileSrc for Tauri support', () => {
-    render(<NetflixStylePlayer videoSrc="local-path/video.mp4" title="Test" description="Desc" />);
+    render(
+      <NetflixStylePlayer
+        videoSrc="local-path/video.mp4"
+        title="Test"
+        description="Desc"
+      />,
+    );
     const video = document.querySelector('video') as HTMLVideoElement;
     expect(video).toBeInTheDocument();
     expect(video.src).toBe('tauri-converted://local-path/video.mp4');
   });
 
   test('updates isFullscreen state on fullscreenchange event', () => {
-    const { container } = render(<NetflixStylePlayer videoSrc="test-video.mp4" title="Test" description="Desc" />);
+    const { container } = render(
+      <NetflixStylePlayer
+        videoSrc="test-video.mp4"
+        title="Test"
+        description="Desc"
+      />,
+    );
 
     expect(screen.queryByTestId('icon-minimize')).not.toBeInTheDocument();
     expect(screen.getByTestId('icon-maximize')).toBeInTheDocument();
@@ -108,7 +124,13 @@ describe('NetflixStylePlayer', () => {
   });
 
   test('renders 0:00 before video metadata is loaded and updates on loadedmetadata', () => {
-    render(<NetflixStylePlayer videoSrc="video.mp4" title="Test" description="Desc" />);
+    render(
+      <NetflixStylePlayer
+        videoSrc="video.mp4"
+        title="Test"
+        description="Desc"
+      />,
+    );
 
     expect(screen.getByText('0:00 / 0:00')).toBeInTheDocument();
 
@@ -127,7 +149,13 @@ describe('NetflixStylePlayer', () => {
   });
 
   test('volume slider updates volume and unmutes video', () => {
-    render(<NetflixStylePlayer videoSrc="video.mp4" title="Test" description="Desc" />);
+    render(
+      <NetflixStylePlayer
+        videoSrc="video.mp4"
+        title="Test"
+        description="Desc"
+      />,
+    );
     const video = document.querySelector('video') as HTMLVideoElement;
 
     let setMutedVal = false;
@@ -168,7 +196,13 @@ describe('NetflixStylePlayer', () => {
   });
 
   test('play/pause button updates when video ends', () => {
-    render(<NetflixStylePlayer videoSrc="video.mp4" title="Test" description="Desc" />);
+    render(
+      <NetflixStylePlayer
+        videoSrc="video.mp4"
+        title="Test"
+        description="Desc"
+      />,
+    );
 
     const playBtn = screen.getByTestId('icon-play').closest('button');
     expect(playBtn).toBeInTheDocument();


### PR DESCRIPTION
###  Addressed Issues:

Fixes #1329


###  Screenshots/Recordings:

*No changes were made to the overall UI layout or styling. However, functional interface fixes are visible to the user:*
- Time display now correctly renders `0:00 / 0:00` (and updates on load) instead of `NaN:NaN`.
- Play/Pause toggle now correctly resets to "Play" when the video ends.
- Volume slider now correctly toggles the mute icon/state when dragging.
- Fullscreen toggle now correctly updates between Maximize/Minimize icons when exiting.



###  Additional Notes:

This PR resolves all five desync/rendering bugs in the `NetflixStylePlayer` component:
1. **Local File Loading:** Configured the video element's source to use `convertFileSrc` for Tauri compatibility.
2. **Fullscreen Desync:** Listened to the `fullscreenchange` event on the document level, syncing `isFullscreen` status correctly when exited via `Esc`.
3. **NaN Display:** Added state hooks for `currentTime` and `duration` and formatted the output using `formatTime` which falls back to `0:00` for non-finite values before video metadata loads. Added `onLoadedMetadata` and `onDurationChange` to update these states reactively.
4. **Muted State Desync:** Adjusted `handleVolumeChange` to correctly unmute the video state and reference (`videoRef.current.muted = false`) when the volume slider is moved to a value greater than `0`.
5. **Playback State Desync:** Registered `onEnded` to automatically reset the playing state back to `false` when video playback ends.

Also added a complete Jest unit test suite covering all 5 scenarios to prevent regressions.


### AI Usage Disclosure:

Check one of the checkboxes below:

- [ ] This PR does not contain AI-generated code at all.
- [x] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools: Gemini 3.5 Flash (via Antigravity IDE)


## Checklist
<!-- Mark items with [x] to indicate completion -->
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [ ] If applicable, I have made corresponding changes or additions to the documentation
- [x] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [ ] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] My read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Netflix-style video player timing with consistent elapsed/total display during playback and seeking
  * Volume slider, mute button, and mute icon now stay fully synchronized
  * More reliable fullscreen UI updates and keyboard shortcut support for playback, mute, seeking, and fullscreen
* **Bug Fixes**
  * Safer time formatting for missing/invalid durations (shows `0:00 / 0:00` until ready)
  * Seeking and play/pause state now follow media timing/events more accurately
* **Tests**
  * Expanded player tests for media behavior, fullscreen, timing, volume/mute, seeking, and keyboard shortcuts
* **Security**
  * Updated CSP `media-src` formatting to fix directive parsing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->