### PR TITLE
test: add database metadata and YOLO mapping coverage

### DIFF
--- a/backend/tests/test_metadata.py
+++ b/backend/tests/test_metadata.py
@@ -1,128 +1,159 @@
 import json
+import os
 import sqlite3
+import tempfile
+from typing import Any, Dict, Iterator, List, Tuple
+from unittest.mock import patch
 
 import pytest
 
-from app.database import metadata as metadata_db
+from app.database.metadata import (
+    db_create_metadata_table,
+    db_get_metadata,
+    db_update_metadata,
+)
+
+# ##############################
+# Pytest Fixtures
+# ##############################
 
 
-@pytest.fixture()
-def metadata_database(tmp_path, monkeypatch):
-    db_path = tmp_path / "metadata.sqlite3"
-    monkeypatch.setattr(metadata_db, "DATABASE_PATH", str(db_path))
-    return db_path
+@pytest.fixture(scope="function")
+def test_db(monkeypatch: pytest.MonkeyPatch) -> Iterator[str]:
+    """Point the metadata DB module at a fresh tempfile database."""
+    db_fd, db_path = tempfile.mkstemp()
+    os.close(db_fd)
+
+    monkeypatch.setattr("app.config.settings.DATABASE_PATH", db_path)
+    monkeypatch.setattr("app.database.metadata.DATABASE_PATH", db_path)
+
+    db_create_metadata_table()
+
+    yield db_path
+
+    os.unlink(db_path)
 
 
-# Validates that metadata table creation inserts a default empty metadata row.
-def test_create_metadata_table_initializes_empty_metadata(metadata_database):
-    metadata_db.db_create_metadata_table()
-
-    with sqlite3.connect(str(metadata_database)) as conn:
-        rows = conn.execute("SELECT metadata FROM metadata").fetchall()
-
-    assert rows == [("{}",)]
-    assert metadata_db.db_get_metadata() == {}
+def stored_rows(db_path: str) -> List[Tuple[str]]:
+    """Read the raw metadata rows straight from the table."""
+    conn = sqlite3.connect(db_path)
+    rows = conn.execute("SELECT metadata FROM metadata").fetchall()
+    conn.close()
+    return rows
 
 
-# Validates that creating the metadata table again does not overwrite existing metadata.
-def test_create_metadata_table_preserves_existing_metadata(metadata_database):
-    metadata_db.db_create_metadata_table()
-    expected_metadata = {"user_preferences": {"YOLO_model_size": "medium"}}
-
-    assert metadata_db.db_update_metadata(expected_metadata) is True
-    metadata_db.db_create_metadata_table()
-
-    with sqlite3.connect(str(metadata_database)) as conn:
-        row_count = conn.execute("SELECT COUNT(*) FROM metadata").fetchone()[0]
-
-    assert row_count == 1
-    assert metadata_db.db_get_metadata() == expected_metadata
+def write_raw(db_path: str, sql: str, params: Tuple[Any, ...] = ()) -> None:
+    """Run a statement against the metadata table and commit it."""
+    conn = sqlite3.connect(db_path)
+    conn.execute(sql, params)
+    conn.commit()
+    conn.close()
 
 
-# Validates that metadata retrieval returns None when the table has no metadata row.
-def test_get_metadata_returns_none_when_no_row_exists(metadata_database):
-    metadata_db.db_create_metadata_table()
-
-    with sqlite3.connect(str(metadata_database)) as conn:
-        conn.execute("DELETE FROM metadata")
-
-    assert metadata_db.db_get_metadata() is None
+# ##############################
+# Table creation
+# ##############################
 
 
-# Validates that blank metadata content is treated as missing metadata.
-def test_get_metadata_returns_none_for_blank_metadata(metadata_database):
-    metadata_db.db_create_metadata_table()
+class TestCreateMetadataTable:
+    def test_seeds_a_single_empty_row(self, test_db):
+        assert stored_rows(test_db) == [("{}",)]
+        assert db_get_metadata() == {}
 
-    with sqlite3.connect(str(metadata_database)) as conn:
-        conn.execute("UPDATE metadata SET metadata = ?", ("",))
+    def test_preserves_existing_metadata(self, test_db):
+        expected: Dict[str, Any] = {"user_preferences": {"YOLO_model_size": "medium"}}
+        assert db_update_metadata(expected) is True
 
-    assert metadata_db.db_get_metadata() is None
+        db_create_metadata_table()  # re-running must not reseed the row
 
+        assert len(stored_rows(test_db)) == 1
+        assert db_get_metadata() == expected
 
-# Validates that invalid JSON in the metadata row is handled as missing metadata.
-def test_get_metadata_returns_none_for_invalid_json(metadata_database):
-    metadata_db.db_create_metadata_table()
-
-    with sqlite3.connect(str(metadata_database)) as conn:
-        conn.execute("UPDATE metadata SET metadata = ?", ("{invalid-json",))
-
-    assert metadata_db.db_get_metadata() is None
-
-
-# Validates that updating metadata stores nested JSON-compatible values.
-def test_update_metadata_stores_nested_values(metadata_database):
-    metadata_db.db_create_metadata_table()
-    expected_metadata = {
-        "user_preferences": {"YOLO_model_size": "nano", "GPU_Acceleration": False},
-        "recent_folders": ["photos", "archives"],
-        "version": 2,
-    }
-
-    assert metadata_db.db_update_metadata(expected_metadata) is True
-
-    assert metadata_db.db_get_metadata() == expected_metadata
+    def test_survives_a_connection_failure(self):
+        """connect() failing leaves conn as None, so the finally must no-op."""
+        with patch(
+            "app.database.metadata.sqlite3.connect", side_effect=sqlite3.Error("fail")
+        ):
+            with pytest.raises(sqlite3.Error):
+                db_create_metadata_table()
 
 
-# Validates that updating metadata replaces the previous row instead of appending another row.
-def test_update_metadata_replaces_existing_metadata_row(metadata_database):
-    metadata_db.db_create_metadata_table()
-    old_metadata = {"old": True}
-    new_metadata = {"new": True, "count": 3}
-
-    assert metadata_db.db_update_metadata(old_metadata) is True
-    assert metadata_db.db_update_metadata(new_metadata) is True
-
-    with sqlite3.connect(str(metadata_database)) as conn:
-        rows = conn.execute("SELECT metadata FROM metadata").fetchall()
-
-    assert len(rows) == 1
-    assert json.loads(rows[0][0]) == new_metadata
+# ##############################
+# Reading metadata
+# ##############################
 
 
-# Validates that metadata can be updated through an existing database cursor.
-def test_update_metadata_with_existing_cursor(metadata_database):
-    metadata_db.db_create_metadata_table()
-    expected_metadata = {"bulk_update": True}
+class TestGetMetadata:
+    def test_returns_none_without_a_row(self, test_db):
+        write_raw(test_db, "DELETE FROM metadata")
+        assert db_get_metadata() is None
 
-    conn = sqlite3.connect(str(metadata_database))
-    try:
-        cursor = conn.cursor()
-        assert metadata_db.db_update_metadata(expected_metadata, cursor) is True
-        conn.commit()
-    finally:
-        conn.close()
+    def test_returns_none_for_blank_metadata(self, test_db):
+        write_raw(test_db, "UPDATE metadata SET metadata = ?", ("",))
+        assert db_get_metadata() is None
 
-    assert metadata_db.db_get_metadata() == expected_metadata
+    def test_returns_none_for_invalid_json(self, test_db):
+        write_raw(test_db, "UPDATE metadata SET metadata = ?", ("{invalid-json",))
+        assert db_get_metadata() is None
 
 
-# Validates that update failures roll back without deleting previous metadata.
-def test_update_metadata_rolls_back_when_json_serialization_fails(metadata_database):
-    metadata_db.db_create_metadata_table()
-    original_metadata = {"safe": True}
+# ##############################
+# Updating metadata
+# ##############################
 
-    assert metadata_db.db_update_metadata(original_metadata) is True
 
-    with pytest.raises(TypeError):
-        metadata_db.db_update_metadata({"bad": object()})
+class TestUpdateMetadata:
+    def test_stores_nested_values(self, test_db):
+        expected: Dict[str, Any] = {
+            "user_preferences": {"YOLO_model_size": "nano", "GPU_Acceleration": False},
+            "recent_folders": ["photos", "archives"],
+            "version": 2,
+        }
+        assert db_update_metadata(expected) is True
+        assert db_get_metadata() == expected
 
-    assert metadata_db.db_get_metadata() == original_metadata
+    def test_replaces_the_previous_row(self, test_db):
+        assert db_update_metadata({"old": True}) is True
+        assert db_update_metadata({"new": True, "count": 3}) is True
+
+        rows = stored_rows(test_db)
+        assert len(rows) == 1
+        assert json.loads(rows[0][0]) == {"new": True, "count": 3}
+
+    def test_accepts_a_caller_supplied_cursor(self, test_db):
+        expected = {"bulk_update": True}
+
+        conn = sqlite3.connect(test_db)
+        try:
+            assert db_update_metadata(expected, conn.cursor()) is True
+            conn.commit()  # the helper leaves committing to the caller
+        finally:
+            conn.close()
+
+        assert db_get_metadata() == expected
+
+    def test_rolls_back_when_serialization_fails(self, test_db):
+        assert db_update_metadata({"safe": True}) is True
+
+        with pytest.raises(TypeError):
+            db_update_metadata({"bad": object()})
+
+        assert db_get_metadata() == {"safe": True}
+
+    def test_caller_cursor_failure_is_left_to_the_caller(self, test_db):
+        """On failure with a caller's cursor the helper must not roll back --
+        the caller owns the transaction."""
+        conn = sqlite3.connect(test_db)
+        try:
+            cursor = conn.cursor()
+            assert db_update_metadata({"safe": True}, cursor) is True
+
+            with pytest.raises(TypeError):
+                db_update_metadata({"bad": object()}, cursor)
+
+            # The earlier write survived, so the caller can still commit it
+            conn.commit()
+        finally:
+            conn.close()
+
+        assert db_get_metadata() == {"safe": True}

--- a/backend/tests/test_metadata.py
+++ b/backend/tests/test_metadata.py
@@ -1,0 +1,128 @@
+import json
+import sqlite3
+
+import pytest
+
+from app.database import metadata as metadata_db
+
+
+@pytest.fixture()
+def metadata_database(tmp_path, monkeypatch):
+    db_path = tmp_path / "metadata.sqlite3"
+    monkeypatch.setattr(metadata_db, "DATABASE_PATH", str(db_path))
+    return db_path
+
+
+# Validates that metadata table creation inserts a default empty metadata row.
+def test_create_metadata_table_initializes_empty_metadata(metadata_database):
+    metadata_db.db_create_metadata_table()
+
+    with sqlite3.connect(str(metadata_database)) as conn:
+        rows = conn.execute("SELECT metadata FROM metadata").fetchall()
+
+    assert rows == [("{}",)]
+    assert metadata_db.db_get_metadata() == {}
+
+
+# Validates that creating the metadata table again does not overwrite existing metadata.
+def test_create_metadata_table_preserves_existing_metadata(metadata_database):
+    metadata_db.db_create_metadata_table()
+    expected_metadata = {"user_preferences": {"YOLO_model_size": "medium"}}
+
+    assert metadata_db.db_update_metadata(expected_metadata) is True
+    metadata_db.db_create_metadata_table()
+
+    with sqlite3.connect(str(metadata_database)) as conn:
+        row_count = conn.execute("SELECT COUNT(*) FROM metadata").fetchone()[0]
+
+    assert row_count == 1
+    assert metadata_db.db_get_metadata() == expected_metadata
+
+
+# Validates that metadata retrieval returns None when the table has no metadata row.
+def test_get_metadata_returns_none_when_no_row_exists(metadata_database):
+    metadata_db.db_create_metadata_table()
+
+    with sqlite3.connect(str(metadata_database)) as conn:
+        conn.execute("DELETE FROM metadata")
+
+    assert metadata_db.db_get_metadata() is None
+
+
+# Validates that blank metadata content is treated as missing metadata.
+def test_get_metadata_returns_none_for_blank_metadata(metadata_database):
+    metadata_db.db_create_metadata_table()
+
+    with sqlite3.connect(str(metadata_database)) as conn:
+        conn.execute("UPDATE metadata SET metadata = ?", ("",))
+
+    assert metadata_db.db_get_metadata() is None
+
+
+# Validates that invalid JSON in the metadata row is handled as missing metadata.
+def test_get_metadata_returns_none_for_invalid_json(metadata_database):
+    metadata_db.db_create_metadata_table()
+
+    with sqlite3.connect(str(metadata_database)) as conn:
+        conn.execute("UPDATE metadata SET metadata = ?", ("{invalid-json",))
+
+    assert metadata_db.db_get_metadata() is None
+
+
+# Validates that updating metadata stores nested JSON-compatible values.
+def test_update_metadata_stores_nested_values(metadata_database):
+    metadata_db.db_create_metadata_table()
+    expected_metadata = {
+        "user_preferences": {"YOLO_model_size": "nano", "GPU_Acceleration": False},
+        "recent_folders": ["photos", "archives"],
+        "version": 2,
+    }
+
+    assert metadata_db.db_update_metadata(expected_metadata) is True
+
+    assert metadata_db.db_get_metadata() == expected_metadata
+
+
+# Validates that updating metadata replaces the previous row instead of appending another row.
+def test_update_metadata_replaces_existing_metadata_row(metadata_database):
+    metadata_db.db_create_metadata_table()
+    old_metadata = {"old": True}
+    new_metadata = {"new": True, "count": 3}
+
+    assert metadata_db.db_update_metadata(old_metadata) is True
+    assert metadata_db.db_update_metadata(new_metadata) is True
+
+    with sqlite3.connect(str(metadata_database)) as conn:
+        rows = conn.execute("SELECT metadata FROM metadata").fetchall()
+
+    assert len(rows) == 1
+    assert json.loads(rows[0][0]) == new_metadata
+
+
+# Validates that metadata can be updated through an existing database cursor.
+def test_update_metadata_with_existing_cursor(metadata_database):
+    metadata_db.db_create_metadata_table()
+    expected_metadata = {"bulk_update": True}
+
+    conn = sqlite3.connect(str(metadata_database))
+    try:
+        cursor = conn.cursor()
+        assert metadata_db.db_update_metadata(expected_metadata, cursor) is True
+        conn.commit()
+    finally:
+        conn.close()
+
+    assert metadata_db.db_get_metadata() == expected_metadata
+
+
+# Validates that update failures roll back without deleting previous metadata.
+def test_update_metadata_rolls_back_when_json_serialization_fails(metadata_database):
+    metadata_db.db_create_metadata_table()
+    original_metadata = {"safe": True}
+
+    assert metadata_db.db_update_metadata(original_metadata) is True
+
+    with pytest.raises(TypeError):
+        metadata_db.db_update_metadata({"bad": object()})
+
+    assert metadata_db.db_get_metadata() == original_metadata

--- a/backend/tests/test_metadata.py
+++ b/backend/tests/test_metadata.py
@@ -23,15 +23,16 @@ def test_db(monkeypatch: pytest.MonkeyPatch) -> Iterator[str]:
     """Point the metadata DB module at a fresh tempfile database."""
     db_fd, db_path = tempfile.mkstemp()
     os.close(db_fd)
+    try:
+        monkeypatch.setattr("app.config.settings.DATABASE_PATH", db_path)
+        monkeypatch.setattr("app.database.metadata.DATABASE_PATH", db_path)
 
-    monkeypatch.setattr("app.config.settings.DATABASE_PATH", db_path)
-    monkeypatch.setattr("app.database.metadata.DATABASE_PATH", db_path)
+        db_create_metadata_table()
 
-    db_create_metadata_table()
-
-    yield db_path
-
-    os.unlink(db_path)
+        yield db_path
+    finally:
+        # finally, not post-yield: a setup failure would otherwise leak the file
+        os.unlink(db_path)
 
 
 def stored_rows(db_path: str) -> List[Tuple[str]]:

--- a/backend/tests/test_metadata.py
+++ b/backend/tests/test_metadata.py
@@ -50,6 +50,25 @@ def write_raw(db_path: str, sql: str, params: Tuple[Any, ...] = ()) -> None:
     conn.close()
 
 
+class RollbackSpy:
+    """Real connection that records whether rollback() was called.
+
+    close() discards an uncommitted transaction on its own, so restored data
+    alone can't prove the rollback ran -- this pins it.
+    """
+
+    def __init__(self, conn: sqlite3.Connection):
+        self._conn = conn
+        self.rolled_back = False
+
+    def rollback(self) -> None:
+        self.rolled_back = True
+        self._conn.rollback()
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._conn, name)
+
+
 # ##############################
 # Table creation
 # ##############################
@@ -132,13 +151,45 @@ class TestUpdateMetadata:
 
         assert db_get_metadata() == expected
 
-    def test_rolls_back_when_serialization_fails(self, test_db):
+    def test_serialization_failure_never_touches_the_row(self, test_db):
+        # json.dumps raises before the DELETE, so nothing is written at all
         assert db_update_metadata({"safe": True}) is True
 
         with pytest.raises(TypeError):
             db_update_metadata({"bad": object()})
 
         assert db_get_metadata() == {"safe": True}
+
+    def test_rolls_back_a_write_that_fails_midway(self, test_db):
+        """Abort the INSERT so the DELETE has already applied -- the original
+        row must come back, which a pre-write failure can never prove."""
+        assert db_update_metadata({"safe": True}) is True
+
+        spies: List[RollbackSpy] = []
+        # Bind the real connect first: patching the attribute below rebinds it
+        # on the shared sqlite3 module, so calling it here would recurse.
+        real_connect = sqlite3.connect
+
+        def spied_connect(*args: Any, **kwargs: Any) -> RollbackSpy:
+            spy = RollbackSpy(real_connect(*args, **kwargs))
+            spies.append(spy)
+            return spy
+
+        write_raw(
+            test_db,
+            "CREATE TRIGGER block_insert BEFORE INSERT ON metadata "
+            "BEGIN SELECT RAISE(ABORT, 'blocked'); END",
+        )
+        try:
+            with patch("app.database.metadata.sqlite3.connect", spied_connect):
+                with pytest.raises(sqlite3.IntegrityError):
+                    db_update_metadata({"replacement": True})
+        finally:
+            write_raw(test_db, "DROP TRIGGER block_insert")
+
+        assert [spy.rolled_back for spy in spies] == [True]
+        assert db_get_metadata() == {"safe": True}
+        assert len(stored_rows(test_db)) == 1
 
     def test_caller_cursor_failure_is_left_to_the_caller(self, test_db):
         """On failure with a caller's cursor the helper must not roll back --

--- a/backend/tests/test_yolo_mapping.py
+++ b/backend/tests/test_yolo_mapping.py
@@ -1,75 +1,97 @@
+import os
 import sqlite3
+import tempfile
+from typing import Iterator, List, Tuple
+from unittest.mock import patch
 
 import pytest
 
-from app.database import yolo_mapping as yolo_mapping_db
+from app.database.yolo_mapping import db_create_YOLO_classes_table
+
+# ##############################
+# Pytest Fixtures
+# ##############################
 
 
-@pytest.fixture()
-def yolo_database(tmp_path, monkeypatch):
-    db_path = tmp_path / "yolo_mapping.sqlite3"
-    monkeypatch.setattr(yolo_mapping_db, "DATABASE_PATH", str(db_path))
-    return db_path
+@pytest.fixture(scope="function")
+def test_db(monkeypatch: pytest.MonkeyPatch) -> Iterator[str]:
+    """Point the YOLO mapping DB module at a fresh tempfile database."""
+    db_fd, db_path = tempfile.mkstemp()
+    os.close(db_fd)
+
+    monkeypatch.setattr("app.config.settings.DATABASE_PATH", db_path)
+    monkeypatch.setattr("app.database.yolo_mapping.DATABASE_PATH", db_path)
+
+    yield db_path
+
+    os.unlink(db_path)
 
 
-def fetch_mappings(db_path):
-    with sqlite3.connect(str(db_path)) as conn:
-        return conn.execute(
-            "SELECT class_id, name FROM mappings ORDER BY class_id"
-        ).fetchall()
+def set_class_names(monkeypatch: pytest.MonkeyPatch, names: List[str]) -> None:
+    """Swap the YOLO vocabulary the table is seeded from."""
+    monkeypatch.setattr("app.database.yolo_mapping.class_names", names)
 
 
-# Validates that YOLO class table creation stores each class name with its index.
-def test_create_yolo_classes_table_inserts_class_names(yolo_database, monkeypatch):
-    monkeypatch.setattr(yolo_mapping_db, "class_names", ["person", "bicycle", "car"])
-
-    yolo_mapping_db.db_create_YOLO_classes_table()
-
-    assert fetch_mappings(yolo_database) == [
-        (0, "person"),
-        (1, "bicycle"),
-        (2, "car"),
-    ]
+def fetch_mappings(db_path: str) -> List[Tuple[int, str]]:
+    """Read every mappings row, ordered by class_id."""
+    conn = sqlite3.connect(db_path)
+    rows = conn.execute(
+        "SELECT class_id, name FROM mappings ORDER BY class_id"
+    ).fetchall()
+    conn.close()
+    return rows
 
 
-# Validates that rerunning table creation does not duplicate existing class mappings.
-def test_create_yolo_classes_table_is_idempotent(yolo_database, monkeypatch):
-    monkeypatch.setattr(yolo_mapping_db, "class_names", ["person", "car"])
-
-    yolo_mapping_db.db_create_YOLO_classes_table()
-    yolo_mapping_db.db_create_YOLO_classes_table()
-
-    assert fetch_mappings(yolo_database) == [(0, "person"), (1, "car")]
+# ##############################
+# Table creation
+# ##############################
 
 
-# Validates that existing class IDs are replaced when class names change.
-def test_create_yolo_classes_table_replaces_existing_class_names(
-    yolo_database, monkeypatch
-):
-    monkeypatch.setattr(yolo_mapping_db, "class_names", ["old-person", "old-car"])
-    yolo_mapping_db.db_create_YOLO_classes_table()
+class TestCreateYOLOClassesTable:
+    def test_inserts_class_names_by_index(self, test_db, monkeypatch):
+        set_class_names(monkeypatch, ["person", "bicycle", "car"])
 
-    monkeypatch.setattr(yolo_mapping_db, "class_names", ["person", "car"])
-    yolo_mapping_db.db_create_YOLO_classes_table()
+        db_create_YOLO_classes_table()
 
-    assert fetch_mappings(yolo_database) == [(0, "person"), (1, "car")]
+        assert fetch_mappings(test_db) == [(0, "person"), (1, "bicycle"), (2, "car")]
 
+    def test_is_idempotent(self, test_db, monkeypatch):
+        set_class_names(monkeypatch, ["person", "car"])
 
-# Validates that table creation succeeds when no YOLO classes are configured.
-def test_create_yolo_classes_table_handles_empty_class_list(yolo_database, monkeypatch):
-    monkeypatch.setattr(yolo_mapping_db, "class_names", [])
+        db_create_YOLO_classes_table()
+        db_create_YOLO_classes_table()
 
-    yolo_mapping_db.db_create_YOLO_classes_table()
+        assert fetch_mappings(test_db) == [(0, "person"), (1, "car")]
 
-    assert fetch_mappings(yolo_database) == []
+    def test_replaces_renamed_classes(self, test_db, monkeypatch):
+        set_class_names(monkeypatch, ["old-person", "old-car"])
+        db_create_YOLO_classes_table()
 
+        # Same ids, new names -> INSERT OR REPLACE overwrites in place
+        set_class_names(monkeypatch, ["person", "car"])
+        db_create_YOLO_classes_table()
 
-# Validates that duplicate class names can be stored under different class IDs.
-def test_create_yolo_classes_table_allows_duplicate_names_with_distinct_ids(
-    yolo_database, monkeypatch
-):
-    monkeypatch.setattr(yolo_mapping_db, "class_names", ["person", "person"])
+        assert fetch_mappings(test_db) == [(0, "person"), (1, "car")]
 
-    yolo_mapping_db.db_create_YOLO_classes_table()
+    def test_handles_an_empty_class_list(self, test_db, monkeypatch):
+        set_class_names(monkeypatch, [])
 
-    assert fetch_mappings(yolo_database) == [(0, "person"), (1, "person")]
+        db_create_YOLO_classes_table()
+
+        assert fetch_mappings(test_db) == []
+
+    def test_allows_duplicate_names_with_distinct_ids(self, test_db, monkeypatch):
+        set_class_names(monkeypatch, ["person", "person"])
+
+        db_create_YOLO_classes_table()
+
+        assert fetch_mappings(test_db) == [(0, "person"), (1, "person")]
+
+    def test_survives_a_connection_failure(self):
+        """connect() failing leaves conn as None, so the finally must no-op."""
+        with patch(
+            "app.database.yolo_mapping.sqlite3.connect",
+            side_effect=sqlite3.Error("fail"),
+        ):
+            with pytest.raises(sqlite3.Error):
+                db_create_YOLO_classes_table()

--- a/backend/tests/test_yolo_mapping.py
+++ b/backend/tests/test_yolo_mapping.py
@@ -1,0 +1,75 @@
+import sqlite3
+
+import pytest
+
+from app.database import yolo_mapping as yolo_mapping_db
+
+
+@pytest.fixture()
+def yolo_database(tmp_path, monkeypatch):
+    db_path = tmp_path / "yolo_mapping.sqlite3"
+    monkeypatch.setattr(yolo_mapping_db, "DATABASE_PATH", str(db_path))
+    return db_path
+
+
+def fetch_mappings(db_path):
+    with sqlite3.connect(str(db_path)) as conn:
+        return conn.execute(
+            "SELECT class_id, name FROM mappings ORDER BY class_id"
+        ).fetchall()
+
+
+# Validates that YOLO class table creation stores each class name with its index.
+def test_create_yolo_classes_table_inserts_class_names(yolo_database, monkeypatch):
+    monkeypatch.setattr(yolo_mapping_db, "class_names", ["person", "bicycle", "car"])
+
+    yolo_mapping_db.db_create_YOLO_classes_table()
+
+    assert fetch_mappings(yolo_database) == [
+        (0, "person"),
+        (1, "bicycle"),
+        (2, "car"),
+    ]
+
+
+# Validates that rerunning table creation does not duplicate existing class mappings.
+def test_create_yolo_classes_table_is_idempotent(yolo_database, monkeypatch):
+    monkeypatch.setattr(yolo_mapping_db, "class_names", ["person", "car"])
+
+    yolo_mapping_db.db_create_YOLO_classes_table()
+    yolo_mapping_db.db_create_YOLO_classes_table()
+
+    assert fetch_mappings(yolo_database) == [(0, "person"), (1, "car")]
+
+
+# Validates that existing class IDs are replaced when class names change.
+def test_create_yolo_classes_table_replaces_existing_class_names(
+    yolo_database, monkeypatch
+):
+    monkeypatch.setattr(yolo_mapping_db, "class_names", ["old-person", "old-car"])
+    yolo_mapping_db.db_create_YOLO_classes_table()
+
+    monkeypatch.setattr(yolo_mapping_db, "class_names", ["person", "car"])
+    yolo_mapping_db.db_create_YOLO_classes_table()
+
+    assert fetch_mappings(yolo_database) == [(0, "person"), (1, "car")]
+
+
+# Validates that table creation succeeds when no YOLO classes are configured.
+def test_create_yolo_classes_table_handles_empty_class_list(yolo_database, monkeypatch):
+    monkeypatch.setattr(yolo_mapping_db, "class_names", [])
+
+    yolo_mapping_db.db_create_YOLO_classes_table()
+
+    assert fetch_mappings(yolo_database) == []
+
+
+# Validates that duplicate class names can be stored under different class IDs.
+def test_create_yolo_classes_table_allows_duplicate_names_with_distinct_ids(
+    yolo_database, monkeypatch
+):
+    monkeypatch.setattr(yolo_mapping_db, "class_names", ["person", "person"])
+
+    yolo_mapping_db.db_create_YOLO_classes_table()
+
+    assert fetch_mappings(yolo_database) == [(0, "person"), (1, "person")]

--- a/backend/tests/test_yolo_mapping.py
+++ b/backend/tests/test_yolo_mapping.py
@@ -18,13 +18,14 @@ def test_db(monkeypatch: pytest.MonkeyPatch) -> Iterator[str]:
     """Point the YOLO mapping DB module at a fresh tempfile database."""
     db_fd, db_path = tempfile.mkstemp()
     os.close(db_fd)
+    try:
+        monkeypatch.setattr("app.config.settings.DATABASE_PATH", db_path)
+        monkeypatch.setattr("app.database.yolo_mapping.DATABASE_PATH", db_path)
 
-    monkeypatch.setattr("app.config.settings.DATABASE_PATH", db_path)
-    monkeypatch.setattr("app.database.yolo_mapping.DATABASE_PATH", db_path)
-
-    yield db_path
-
-    os.unlink(db_path)
+        yield db_path
+    finally:
+        # finally, not post-yield: a setup failure would otherwise leak the file
+        os.unlink(db_path)
 
 
 def set_class_names(monkeypatch: pytest.MonkeyPatch, names: List[str]) -> None:


### PR DESCRIPTION
###  Addressed Issues:

Fixes #1238 

###  Screenshots/Recordings: 
<img width="855" height="552" alt="Screenshot 2026-06-26 021940" src="https://github.com/user-attachments/assets/c7f30e06-d285-4787-b0d4-7721b3222cb0" />


TODO: If applicable, add screenshots or recordings that demonstrate the interface **before** and **after** the changes.


###  Additional Notes:

Adds focused backend test coverage for:

- `backend/app/database/metadata.py`
- `backend/app/database/yolo_mapping.py`

The tests cover metadata table creation, default/empty/invalid metadata states, metadata updates with own and existing cursors, rollback behavior, YOLO class mapping insertion, idempotency, replacement behavior, empty class lists, and duplicate class names.

This PR keeps the scope limited to the metadata and YOLO mapping database modules discussed in #1238.

```text
14 passed in 0.55s
118 passed in 18.58s

### AI Usage Disclosure:

We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact. AI slop is strongly discouraged and may lead to banning and blocking. Do not spam our repos with AI slop.

Check one of the checkboxes below:

- [ ] This PR does not contain AI-generated code at all.
- [x] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools: ChatGPT


## Checklist
<!-- Mark items with [x] to indicate completion -->
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [x] If applicable, I have made corresponding changes or additions to the documentation
- [x] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for metadata table seeding, retrieval edge cases (missing/blank/invalid JSON), and metadata updates (nested structures, replacement vs append).
  * Added assertions for JSON serialization failures, rollback behavior on mid-write errors, and correct handling of caller-supplied cursors.
  * Expanded coverage for YOLO class mapping table creation: correct seeding by configured indices, idempotency, updates when names change, empty lists, duplicate names, and propagation of database connection failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->