### PR TITLE
fix(database): remove dead case_sensitive_like pragma (#1346)

### DIFF
--- a/backend/app/database/connection.py
+++ b/backend/app/database/connection.py
@@ -20,7 +20,6 @@ def get_db_connection() -> Generator[sqlite3.Connection, None, None]:
     conn.execute("PRAGMA ignore_check_constraints = OFF;")  # Enforce CHECK constraints
     conn.execute("PRAGMA recursive_triggers = ON;")  # Allow nested triggers
     conn.execute("PRAGMA defer_foreign_keys = OFF;")  # Immediate FK checking
-    conn.execute("PRAGMA case_sensitive_like = ON;")  # Make LIKE case-sensitive
 
     try:
         yield conn

--- a/backend/tests/test_folders.py
+++ b/backend/tests/test_folders.py
@@ -887,3 +887,34 @@ class TestFolderPathPrefixMatching:
         matched_paths = [path for _id, path in matched]
 
         assert matched_paths == ["/home/user/photos"]
+
+
+class TestSharedConnectionLikeCaseSensitivity:
+    """Regression test for issue #1346 covering the shared connection helper.
+
+    ``db_get_folder_ids_by_path_prefix`` opens SQLite directly, so it never
+    exercises ``get_db_connection()``. No production query currently runs
+    ``LIKE`` through that shared helper, but this guards it directly so a
+    future ``PRAGMA case_sensitive_like = ON`` reintroduced there would be
+    caught even before any query starts relying on it.
+    """
+
+    def test_like_is_case_insensitive_through_shared_connection(self):
+        from app.database import connection as connection_module
+
+        db_fd, db_path = tempfile.mkstemp()
+        try:
+            with patch.object(connection_module, "DATABASE_PATH", db_path):
+                with connection_module.get_db_connection() as conn:
+                    conn.execute("CREATE TABLE t (value TEXT)")
+                    conn.execute("INSERT INTO t (value) VALUES ('CamelCase')")
+
+                with connection_module.get_db_connection() as conn:
+                    rows = conn.execute(
+                        "SELECT value FROM t WHERE value LIKE ?", ("camelcase",)
+                    ).fetchall()
+        finally:
+            os.close(db_fd)
+            os.unlink(db_path)
+
+        assert [row[0] for row in rows] == ["CamelCase"]

--- a/backend/tests/test_folders.py
+++ b/backend/tests/test_folders.py
@@ -851,11 +851,13 @@ class TestFolderPathPrefixMatching:
         from app.database import folders as folders_module
 
         db_fd, db_path = tempfile.mkstemp()
-        with patch.object(folders_module, "DATABASE_PATH", db_path):
-            folders_module.db_create_folders_table()
-            yield folders_module
-        os.close(db_fd)
-        os.unlink(db_path)
+        try:
+            with patch.object(folders_module, "DATABASE_PATH", db_path):
+                folders_module.db_create_folders_table()
+                yield folders_module
+        finally:
+            os.close(db_fd)
+            os.unlink(db_path)
 
     def test_prefix_match_is_case_insensitive(self, folders_db):
         """A lower-case prefix must match folders stored with mixed case."""

--- a/backend/tests/test_folders.py
+++ b/backend/tests/test_folders.py
@@ -834,3 +834,56 @@ class TestFoldersAPI:
 
         mock_enable_batch.assert_called_once_with(folder_ids)
         mock_delete_batch.assert_called_once_with(folder_ids)
+
+
+class TestFolderPathPrefixMatching:
+    """Regression tests for case-insensitive folder prefix matching.
+
+    Guards against reintroducing ``PRAGMA case_sensitive_like = ON`` (see
+    issue #1346): the prefix query must keep using SQLite's default
+    case-insensitive ``LIKE`` so subfolders are still found on
+    case-insensitive filesystems (macOS/Windows).
+    """
+
+    @pytest.fixture
+    def folders_db(self):
+        """Temporary database with the folders table created."""
+        from app.database import folders as folders_module
+
+        db_fd, db_path = tempfile.mkstemp()
+        with patch.object(folders_module, "DATABASE_PATH", db_path):
+            folders_module.db_create_folders_table()
+            yield folders_module
+        os.close(db_fd)
+        os.unlink(db_path)
+
+    def test_prefix_match_is_case_insensitive(self, folders_db):
+        """A lower-case prefix must match folders stored with mixed case."""
+        # folders_data tuples: (folder_id, folder_path, parent_folder_id,
+        #                       last_modified_time, AI_Tagging, taggingCompleted)
+        folders_db.db_insert_folders_batch(
+            [
+                ("id-root", "/Users/Foo/Pics", None, 0, False, False),
+                ("id-sub", "/Users/Foo/Pics/Sub", "id-root", 0, False, False),
+                ("id-other", "/Other", None, 0, False, False),
+            ]
+        )
+
+        matched = folders_db.db_get_folder_ids_by_path_prefix("/users/foo/pics")
+        matched_paths = sorted(path for _id, path in matched)
+
+        assert matched_paths == ["/Users/Foo/Pics", "/Users/Foo/Pics/Sub"]
+
+    def test_prefix_match_excludes_non_matching_paths(self, folders_db):
+        """Folders outside the prefix must not be returned."""
+        folders_db.db_insert_folders_batch(
+            [
+                ("id-a", "/home/user/photos", None, 0, False, False),
+                ("id-b", "/home/user/documents", None, 0, False, False),
+            ]
+        )
+
+        matched = folders_db.db_get_folder_ids_by_path_prefix("/home/user/photos")
+        matched_paths = [path for _id, path in matched]
+
+        assert matched_paths == ["/home/user/photos"]


### PR DESCRIPTION
PRAGMA case_sensitive_like = ON in get_db_connection() affected zero queries: the only LIKE query (db_get_folder_ids_by_path_prefix) uses a raw sqlite3.connect() that never ran the pragma. Removing it keeps LIKE case-insensitive (SQLite default) and avoids a latent footgun where migrating a LIKE query onto the shared helper would silently turn subfolder prefix matching case-sensitive on macOS/Windows.

Add regression tests asserting case-insensitive folder prefix matching.

###  Addressed Issues:

Fixes #1346 


### AI Usage Disclosure:

We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact. AI slop is strongly discouraged and may lead to banning and blocking. Do not spam our repos with AI slop.

Check one of the checkboxes below:

- [ ] This PR does not contain AI-generated code at all.
- [x] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools: Codex


## Checklist
<!-- Mark items with [x] to indicate completion -->
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [x] If applicable, I have made corresponding changes or additions to the documentation
- [x] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * SQLite connections now enforce foreign-key and CHECK constraints more consistently.
  * Text matching through shared database connections is case-insensitive, improving consistency for folder and path searches.

* **Tests**
  * Added coverage confirming case-insensitive matching through shared connections.
  * Improved temporary database cleanup during folder-related tests.
  * Expanded regression coverage for folder path prefix matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->