### PR TITLE
fix: eliminate image flicker by gating opacity on fit-transform readiness

### DIFF
--- a/frontend/src/components/Media/ZoomableImage.tsx
+++ b/frontend/src/components/Media/ZoomableImage.tsx
@@ -39,6 +39,7 @@ export const ZoomableImage = forwardRef<ZoomableImageRef, ZoomableImageProps>(
       zoomIn,
       zoomOut,
       reset,
+      isFitReady
     } = useZoomTransform({ imagePath, rotation, resetSignal });
 
     useImperativeHandle(
@@ -113,6 +114,8 @@ export const ZoomableImage = forwardRef<ZoomableImageRef, ZoomableImageProps>(
               transform: `rotate(${rotation}deg)`,
               transformOrigin: 'center center',
               pointerEvents: 'none',
+              opacity: isFitReady ? 1 : 0,
+              transition: isFitReady ? 'opacity 120ms ease-out' : 'none',
             }}
           />
         </div>

--- a/frontend/src/components/Media/__tests__/ZoomableImage.test.tsx
+++ b/frontend/src/components/Media/__tests__/ZoomableImage.test.tsx
@@ -698,6 +698,8 @@ describe('ZoomableImage controlled transform behavior', () => {
   });
 
   test('keeps the image hidden until the fit transform is ready, then fades it in', () => {
+    const { flushNextFrame } = setupManualAnimationFrames();
+
     renderZoomableImage();
 
     const viewport = screen.getByTestId('zoom-viewport');
@@ -714,6 +716,7 @@ describe('ZoomableImage controlled transform behavior', () => {
     mockImageDimensions(image, { width: 1000, height: 800 });
 
     fireEvent.load(image);
+    flushNextFrame();
 
     expect(image.style.opacity).toBe('1');
     expect(image.style.transition).toBe('opacity 120ms ease-out');

--- a/frontend/src/components/Media/__tests__/ZoomableImage.test.tsx
+++ b/frontend/src/components/Media/__tests__/ZoomableImage.test.tsx
@@ -697,6 +697,28 @@ describe('ZoomableImage controlled transform behavior', () => {
     expect(image.style.height).toBe('');
   });
 
+  test('keeps the image hidden until the fit transform is ready, then fades it in', () => {
+    renderZoomableImage();
+
+    const viewport = screen.getByTestId('zoom-viewport');
+    const image = screen.getByAltText('test image');
+
+    expect(image.style.opacity).toBe('0');
+    expect(image.style.transition).toBe('none');
+
+    mockElementRect(
+      viewport,
+      { width: 500, height: 400, left: 0, top: 0 },
+      { clientWidth: 500, clientHeight: 400 },
+    );
+    mockImageDimensions(image, { width: 1000, height: 800 });
+
+    fireEvent.load(image);
+
+    expect(image.style.opacity).toBe('1');
+    expect(image.style.transition).toBe('opacity 120ms ease-out');
+  });
+
   test('starts from the new image fit transform after switching images', () => {
     const { viewport, rerender } = setupScene({
       viewportSize: { width: 500, height: 400 },

--- a/frontend/src/hooks/useZoomTransform.ts
+++ b/frontend/src/hooks/useZoomTransform.ts
@@ -71,6 +71,7 @@ export const useZoomTransform = ({
   const [isOverflowing, setIsOverflowing] = useState(false);
   const [isPanning, setIsPanning] = useState(false);
   const [isButtonZoom, setIsButtonZoom] = useState(false);
+  const [isFitReady, setIsFitReady] = useState(false);
 
   const setRawImageDimensions = useCallback((dimensions: Size | null) => {
     rawDimensionsRef.current = dimensions;
@@ -196,6 +197,7 @@ export const useZoomTransform = ({
       isFitInitializedRef.current = true;
       hasUserInteractedRef.current = false;
       fitRetryCountRef.current = 0;
+      setIsFitReady(true);
     }
 
     return didApply;
@@ -297,6 +299,7 @@ export const useZoomTransform = ({
   useEffect(() => {
     setIsOverflowing(false);
     setRawImageDimensions(null);
+    setIsFitReady(false);
     resetToFit();
   }, [imagePath, resetToFit, setRawImageDimensions]);
 
@@ -556,5 +559,6 @@ export const useZoomTransform = ({
     zoomIn,
     zoomOut,
     reset: resetToFit,
+    isFitReady,
   };
 };

--- a/frontend/src/hooks/useZoomTransform.ts
+++ b/frontend/src/hooks/useZoomTransform.ts
@@ -235,6 +235,8 @@ export const useZoomTransform = ({
         if (!applied && fitRetryCountRef.current < MAX_FIT_RETRY_FRAMES) {
           fitRetryCountRef.current += 1;
           scheduleFitTransform(false);
+        } else {
+          setIsFitReady(true);
         }
       });
     },

--- a/frontend/src/hooks/useZoomTransform.ts
+++ b/frontend/src/hooks/useZoomTransform.ts
@@ -232,11 +232,13 @@ export const useZoomTransform = ({
         fitFrameRef.current = null;
         const applied = applyFitTransform();
 
-        if (!applied && fitRetryCountRef.current < MAX_FIT_RETRY_FRAMES) {
-          fitRetryCountRef.current += 1;
-          scheduleFitTransform(false);
-        } else {
-          setIsFitReady(true);
+        if (!applied) {
+          if (fitRetryCountRef.current < MAX_FIT_RETRY_FRAMES) {
+            fitRetryCountRef.current += 1;
+            scheduleFitTransform(false);
+          } else {
+            setIsFitReady(true);
+          }
         }
       });
     },


### PR DESCRIPTION
###  Addressed Issues:
Fixes #1366 

###  Additional Notes:
## Description
Fixes the image flicker at the top-left corner during slideshow/navigation transitions.

## Root Cause
The image became visible before its fit/zoom transform had actually been applied. There were two gaps:
1. Image rendered at natural size/position briefly before dimensions were calculated on load
2. Even after dimensions were known, the fit transform applied one frame later via `requestAnimationFrame`, causing a visible flash at the untransformed (top-left) position

## Fix
Added an `isFitReady` state that only becomes `true` once the fit transform has actually been applied. Image opacity is now gated on this instead of just `contentDimensions`, so the image stays hidden until it's fully positioned and scaled correctly — eliminating the top-left flicker.

## Changes
- `useZoomTransform.ts`: added `isFitReady` state, set/reset logic, exposed from hook
- `ZoomableImage.tsx`: gated image opacity/transition on `isFitReady`

Minimal, modular change — ~5 lines across 2 files, no unrelated modifications.

## Testing
Confirmed the top-left flicker is eliminated across multiple transitions, rapid navigation, and slideshow mode.
### AI Usage Disclosure:

We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact. AI slop is strongly discouraged and may lead to banning and blocking. Do not spam our repos with AI slop.

Check one of the checkboxes below:

- [ ] This PR does not contain AI-generated code at all.
- [x] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools: Claude


## Checklist
<!-- Mark items with [x] to indicate completion -->
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [ ] If applicable, I have made corresponding changes or additions to the documentation
- [ ] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Images now remain hidden (`opacity: 0`) until the initial fit-to-view step completes, then fade in to `opacity: 1`.
* **Bug Fixes**
  * Prevents flicker by avoiding any opacity transition until the image is ready; also ensures the hidden state is restored during image resets.
* **Tests**
  * Added coverage to verify initial `opacity: 0` with no opacity transition, then fade-in to `opacity: 1` with `opacity 120ms ease-out` after image load.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->