### PR TITLE
ISSUE - 1369: BUG FIX: Settings page does not update active YOLO model after changing it in Model Manager

### DIFF
--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -55,6 +55,11 @@ jest.mock('@tauri-apps/api/core', () => ({
   invoke: jest.fn().mockResolvedValue(null),
 }));
 
+jest.mock('@tauri-apps/api/event', () => ({
+  listen: jest.fn().mockResolvedValue(() => {}),
+  emit: jest.fn().mockResolvedValue(undefined),
+}));
+
 jest.mock('@tauri-apps/api/app', () => ({
   getVersion: jest.fn().mockResolvedValue('1.0.0'),
   getName: jest.fn().mockResolvedValue('PictoPy'),

--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -60,6 +60,15 @@ jest.mock('@tauri-apps/api/event', () => ({
   emit: jest.fn().mockResolvedValue(undefined),
 }));
 
+jest.mock('@tauri-apps/api/window', () => ({
+  getCurrentWindow: jest.fn(() => ({
+    onFocusChanged: jest.fn().mockResolvedValue(() => {}),
+    onCloseRequested: jest.fn().mockResolvedValue(() => {}),
+    close: jest.fn().mockResolvedValue(undefined),
+    destroy: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+
 jest.mock('@tauri-apps/api/app', () => ({
   getVersion: jest.fn().mockResolvedValue('1.0.0'),
   getName: jest.fn().mockResolvedValue('PictoPy'),

--- a/frontend/src-tauri/capabilities/model_manager.json
+++ b/frontend/src-tauri/capabilities/model_manager.json
@@ -1,5 +1,9 @@
 {
   "identifier": "model-manager-capabilities",
   "windows": ["model-manager"],
-  "permissions": ["core:window:default", "core:app:allow-version"]
+  "permissions": ["core:window:default",
+   "core:app:allow-version",
+    "core:event:default",
+     "core:window:allow-close",
+     "core:window:allow-destroy"]
 }

--- a/frontend/src-tauri/capabilities/model_manager.json
+++ b/frontend/src-tauri/capabilities/model_manager.json
@@ -5,7 +5,6 @@
     "core:window:default",
     "core:app:allow-version",
     "core:event:default",
-    "core:window:allow-close",
     "core:window:allow-destroy"
   ]
 }

--- a/frontend/src-tauri/capabilities/model_manager.json
+++ b/frontend/src-tauri/capabilities/model_manager.json
@@ -1,9 +1,11 @@
 {
   "identifier": "model-manager-capabilities",
   "windows": ["model-manager"],
-  "permissions": ["core:window:default",
-   "core:app:allow-version",
+  "permissions": [
+    "core:window:default",
+    "core:app:allow-version",
     "core:event:default",
-     "core:window:allow-close",
-     "core:window:allow-destroy"]
+    "core:window:allow-close",
+    "core:window:allow-destroy"
+  ]
 }

--- a/frontend/src/hooks/useUserPreferences.tsx
+++ b/frontend/src/hooks/useUserPreferences.tsx
@@ -99,11 +99,8 @@ export const useUserPreferences = () => {
     updateYoloModelSize,
     toggleGpuAcceleration,
 
-
     // For refetching preferences after external events (e.g., Model Manager window closing)
     refetch: preferencesQuery.refetch,
-    
-
 
     // Mutation state (for use in UI, e.g., disabling buttons)
     isUpdating: updatePreferencesMutation.isPending,

--- a/frontend/src/hooks/useUserPreferences.tsx
+++ b/frontend/src/hooks/useUserPreferences.tsx
@@ -99,6 +99,13 @@ export const useUserPreferences = () => {
     updateYoloModelSize,
     toggleGpuAcceleration,
 
+
+    // ISSUE - 1369: Exposed so other Tauri windows (e.g. Model Manager) can access it and 
+    // refresh the preferences after making changes inside Model-Manager Window.
+    refetch: preferencesQuery.refetch,
+    
+
+
     // Mutation state (for use in UI, e.g., disabling buttons)
     isUpdating: updatePreferencesMutation.isPending,
   };

--- a/frontend/src/hooks/useUserPreferences.tsx
+++ b/frontend/src/hooks/useUserPreferences.tsx
@@ -100,8 +100,7 @@ export const useUserPreferences = () => {
     toggleGpuAcceleration,
 
 
-    // ISSUE - 1369: Exposed so other Tauri windows (e.g. Model Manager) can access it and 
-    // refresh the preferences after making changes inside Model-Manager Window.
+    // For refetching preferences after external events (e.g., Model Manager window closing)
     refetch: preferencesQuery.refetch,
     
 

--- a/frontend/src/pages/ModelManager/ModelManager.tsx
+++ b/frontend/src/pages/ModelManager/ModelManager.tsx
@@ -66,26 +66,24 @@ export const ModelManager: React.FC = () => {
     }
   }, [statusData, downloadingTiers, installedJustNow]);
 
-
-// ISSUE - 1369: Tauri windows don't share state, so Model Manager emits 'models-updated' on close to notify Settings.
+  // ISSUE - 1369: Tauri windows don't share state, so Model Manager emits 'models-updated' on close to notify Settings.
   useEffect(() => {
-  const unlistenPromise = getCurrentWindow().onCloseRequested(async (event) => {
-    event.preventDefault(); 
-    try {
-      await emit('models-updated');
-    } catch (err) {
-      console.error('Failed to emit models-updated', err);
-    }
-    await getCurrentWindow().destroy();
-    
-  });
+    const unlistenPromise = getCurrentWindow().onCloseRequested(
+      async (event) => {
+        event.preventDefault();
+        try {
+          await emit('models-updated');
+        } catch (err) {
+          console.error('Failed to emit models-updated', err);
+        }
+        await getCurrentWindow().destroy();
+      },
+    );
 
-  return () => {
-    unlistenPromise.then((unlisten) => unlisten());
-  };
-}, []);
-
-
+    return () => {
+      unlistenPromise.then((unlisten) => unlisten());
+    };
+  }, []);
 
   const handleTabChange = (newTab: string) => {
     if (activeTab === 'Available' && newTab !== 'Available') {

--- a/frontend/src/pages/ModelManager/ModelManager.tsx
+++ b/frontend/src/pages/ModelManager/ModelManager.tsx
@@ -72,12 +72,14 @@ export const ModelManager: React.FC = () => {
   // They don't share React/query state. When the Model Manager closes, 
   // it emits 'models-updated' so Settings can get notified..
   useEffect(() => {
-  const unlistenPromise = getCurrentWindow().onCloseRequested(async () => {
+  const unlistenPromise = getCurrentWindow().onCloseRequested(async (event) => {
+    event.preventDefault(); 
     try {
       await emit('models-updated');
     } catch (err) {
       console.error('Failed to emit models-updated', err);
     }
+    await getCurrentWindow().destroy();
     
   });
 

--- a/frontend/src/pages/ModelManager/ModelManager.tsx
+++ b/frontend/src/pages/ModelManager/ModelManager.tsx
@@ -7,6 +7,10 @@ import { Download, Cloud } from 'lucide-react';
 import { usePictoQuery } from '@/hooks/useQueryExtension';
 import { fetchModelStatus } from '@/api/api-functions';
 
+// ISSUE - 1369: Importing emit and getCurrentWindow for the connection between settings and model manager.
+import { getCurrentWindow } from '@tauri-apps/api/window';
+import { emit } from '@tauri-apps/api/event';
+
 const TABS: TabConfig[] = [
   { id: 'Installed', label: 'Installed', icon: Download },
   { id: 'Available', label: 'Available', icon: Cloud },
@@ -62,6 +66,27 @@ export const ModelManager: React.FC = () => {
       }
     }
   }, [statusData, downloadingTiers, installedJustNow]);
+
+
+// ISSUE - 1369: Model Manager runs in its own Tauri window, separate from the Settings.
+  // They don't share React/query state. When the Model Manager closes, 
+  // it emits 'models-updated' so Settings can get notified..
+  useEffect(() => {
+  const unlistenPromise = getCurrentWindow().onCloseRequested(async () => {
+    try {
+      await emit('models-updated');
+    } catch (err) {
+      console.error('Failed to emit models-updated', err);
+    }
+    
+  });
+
+  return () => {
+    unlistenPromise.then((unlisten) => unlisten());
+  };
+}, []);
+
+
 
   const handleTabChange = (newTab: string) => {
     if (activeTab === 'Available' && newTab !== 'Available') {

--- a/frontend/src/pages/ModelManager/ModelManager.tsx
+++ b/frontend/src/pages/ModelManager/ModelManager.tsx
@@ -66,7 +66,7 @@ export const ModelManager: React.FC = () => {
     }
   }, [statusData, downloadingTiers, installedJustNow]);
 
-  // ISSUE - 1369: Tauri windows don't share state, so Model Manager emits 'models-updated' on close to notify Settings.
+  // Model Manager emits 'models-updated' on close to notify Settings.
   useEffect(() => {
     const unlistenPromise = getCurrentWindow().onCloseRequested(
       async (event) => {

--- a/frontend/src/pages/ModelManager/ModelManager.tsx
+++ b/frontend/src/pages/ModelManager/ModelManager.tsx
@@ -7,7 +7,6 @@ import { Download, Cloud } from 'lucide-react';
 import { usePictoQuery } from '@/hooks/useQueryExtension';
 import { fetchModelStatus } from '@/api/api-functions';
 
-// ISSUE - 1369: Importing emit and getCurrentWindow for the connection between settings and model manager.
 import { getCurrentWindow } from '@tauri-apps/api/window';
 import { emit } from '@tauri-apps/api/event';
 
@@ -68,9 +67,7 @@ export const ModelManager: React.FC = () => {
   }, [statusData, downloadingTiers, installedJustNow]);
 
 
-// ISSUE - 1369: Model Manager runs in its own Tauri window, separate from the Settings.
-  // They don't share React/query state. When the Model Manager closes, 
-  // it emits 'models-updated' so Settings can get notified..
+// ISSUE - 1369: Tauri windows don't share state, so Model Manager emits 'models-updated' on close to notify Settings.
   useEffect(() => {
   const unlistenPromise = getCurrentWindow().onCloseRequested(async (event) => {
     event.preventDefault(); 

--- a/frontend/src/pages/SettingsPage/components/UserPreferencesCard.tsx
+++ b/frontend/src/pages/SettingsPage/components/UserPreferencesCard.tsx
@@ -11,7 +11,11 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Button } from '@/components/ui/button';
+
+
 import { invoke } from '@tauri-apps/api/core';
+import { listen } from '@tauri-apps/api/event';
+
 
 import { useUserPreferences } from '@/hooks/useUserPreferences';
 import SettingsCard from './SettingsCard';
@@ -28,7 +32,7 @@ import {
  * Component for managing user preferences in settings
  */
 const UserPreferencesCard: React.FC = () => {
-  const { preferences, updateYoloModelSize, toggleGpuAcceleration } =
+  const { preferences, updateYoloModelSize, toggleGpuAcceleration, refetch } =
     useUserPreferences();
   const [installedTiers, setInstalledTiers] = useState<ModelTier[]>([]);
   const [loadingTiers, setLoadingTiers] = useState(true);
@@ -81,6 +85,36 @@ const UserPreferencesCard: React.FC = () => {
       controller.abort();
     };
   }, []);
+
+
+
+  // ISSUE - 1369: Model Manager runs in its own Tauri window and doesn't share state with
+  // Settings. It emits 'models-updated' when it closes; refresh both the
+  // installed-tiers list and the active preference here in response.
+  useEffect(() => {
+    const unlistenPromise = listen('models-updated', async () => {
+      try {
+        const res = await fetch(`${BACKEND_URL}/models/status`);
+        if (res.ok) {
+          const data: ModelStatusResponse = await res.json();
+          if (data.success && data.data) {
+            setInstalledTiers(getInstalledModelTiers(data.data));
+          }
+        }
+      } catch (err) {
+        console.error('Failed to refresh model status', err);
+      }
+      refetch();
+    });
+
+    return () => {
+      unlistenPromise.then((unlisten) => unlisten());
+    };
+  }, [refetch]);
+
+
+
+
 
   return (
     <SettingsCard

--- a/frontend/src/pages/SettingsPage/components/UserPreferencesCard.tsx
+++ b/frontend/src/pages/SettingsPage/components/UserPreferencesCard.tsx
@@ -104,7 +104,7 @@ const UserPreferencesCard: React.FC = () => {
       } catch (err) {
         console.error('Failed to refresh model status', err);
       }
-      refetch();
+      refetch().catch(console.error);
     });
 
     return () => {

--- a/frontend/src/pages/SettingsPage/components/UserPreferencesCard.tsx
+++ b/frontend/src/pages/SettingsPage/components/UserPreferencesCard.tsx
@@ -84,7 +84,7 @@ const UserPreferencesCard: React.FC = () => {
     };
   }, []);
 
-  // ISSUE - 1369: Model Manager (isolated Tauri window) emits 'models-updated' on close; use it here to refresh installed-tiers and active preference.
+  // Model Manager emits 'models-updated' on close to refresh installed-tiers and active preference.
   useEffect(() => {
     const unlistenPromise = listen('models-updated', async () => {
       try {

--- a/frontend/src/pages/SettingsPage/components/UserPreferencesCard.tsx
+++ b/frontend/src/pages/SettingsPage/components/UserPreferencesCard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useCallback, useState } from 'react';
 import { Cpu, ChevronDown, Zap } from 'lucide-react';
 
 import { Label } from '@/components/ui/label';
@@ -14,6 +14,7 @@ import { Button } from '@/components/ui/button';
 
 import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
+import { getCurrentWindow } from '@tauri-apps/api/window';
 
 import { useUserPreferences } from '@/hooks/useUserPreferences';
 import SettingsCard from './SettingsCard';
@@ -85,26 +86,39 @@ const UserPreferencesCard: React.FC = () => {
   }, []);
 
   // Model Manager emits 'models-updated' on close to refresh installed-tiers and active preference.
-  useEffect(() => {
-    const unlistenPromise = listen('models-updated', async () => {
-      try {
-        const res = await fetch(`${BACKEND_URL}/models/status`);
-        if (res.ok) {
-          const data: ModelStatusResponse = await res.json();
-          if (data.success && data.data) {
-            setInstalledTiers(getInstalledModelTiers(data.data));
-          }
+  const refreshAfterModelManager = useCallback(async () => {
+    try {
+      const res = await fetch(`${BACKEND_URL}/models/status`);
+      if (res.ok) {
+        const data: ModelStatusResponse = await res.json();
+        if (data.success && data.data) {
+          setInstalledTiers(getInstalledModelTiers(data.data));
         }
-      } catch (err) {
-        console.error('Failed to refresh model status', err);
       }
-      refetch().catch(console.error);
-    });
+    } catch (err) {
+      console.error('Failed to refresh model status', err);
+    }
+    refetch().catch(console.error);
+  }, [refetch]);
+
+  useEffect(() => {
+    const unlistenModelsPromise = listen(
+      'models-updated',
+      refreshAfterModelManager,
+    );
+    const unlistenFocusPromise = getCurrentWindow().onFocusChanged(
+      ({ payload: focused }) => {
+        if (focused) {
+          refreshAfterModelManager();
+        }
+      },
+    );
 
     return () => {
-      unlistenPromise.then((unlisten) => unlisten());
+      unlistenModelsPromise.then((unlisten) => unlisten());
+      unlistenFocusPromise.then((unlisten) => unlisten());
     };
-  }, [refetch]);
+  }, [refreshAfterModelManager]);
 
   return (
     <SettingsCard

--- a/frontend/src/pages/SettingsPage/components/UserPreferencesCard.tsx
+++ b/frontend/src/pages/SettingsPage/components/UserPreferencesCard.tsx
@@ -12,10 +12,8 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Button } from '@/components/ui/button';
 
-
 import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
-
 
 import { useUserPreferences } from '@/hooks/useUserPreferences';
 import SettingsCard from './SettingsCard';
@@ -107,10 +105,6 @@ const UserPreferencesCard: React.FC = () => {
       unlistenPromise.then((unlisten) => unlisten());
     };
   }, [refetch]);
-
-
-
-
 
   return (
     <SettingsCard

--- a/frontend/src/pages/SettingsPage/components/UserPreferencesCard.tsx
+++ b/frontend/src/pages/SettingsPage/components/UserPreferencesCard.tsx
@@ -86,11 +86,7 @@ const UserPreferencesCard: React.FC = () => {
     };
   }, []);
 
-
-
-  // ISSUE - 1369: Model Manager runs in its own Tauri window and doesn't share state with
-  // Settings. It emits 'models-updated' when it closes; refresh both the
-  // installed-tiers list and the active preference here in response.
+  // ISSUE - 1369: Model Manager (isolated Tauri window) emits 'models-updated' on close; use it here to refresh installed-tiers and active preference.
   useEffect(() => {
     const unlistenPromise = listen('models-updated', async () => {
       try {


### PR DESCRIPTION
###  Addressed Issues:

Fixes #(#1369)


###  Screenshots/Recordings:

**Pictopy Before:**

https://github.com/user-attachments/assets/d53a1836-fc19-4cea-be40-58634f2b6177

**Pictopy After:**


https://github.com/user-attachments/assets/620a5eaa-9902-4083-bcad-d586067f7673




###  Additional Notes:

TOTAL NUMBER OF FILES CHANGED : 4
TOTAL NUMBER OF LINES OF CODE WRITTEN : 38
NUMBER OF CHANGES AND DELETION MADE : 0

### Problem Statement:

PictoPy lets users configure which YOLO model is used for object detection, from a dropdown in Settings. 
To manage those models, Settings has a "Configure..." option that opens a separate Model Manager window.

**Bug:** 
When a user downloaded a new model tier or changed the active tier inside Model Manager, 
then closed that window and returned to Settings, the Settings dropdown did not reflect the change.
The user is in the need to refresh to see changes.

**Expected behavior:** 

Closing Model Manager should instantly refresh Settings.


### Reason for updating files:

Settings and Model Manager are not the same window layouts. They are different windows altogether with different rust commands.

In order to make a connection between the two so that they can communicate with each other, I have used emit() function.

**FILE 1 CHANGES:**

**Name of File:**  frontend/src/pages/modelmanager/ModelManager.tsx
<img width="793" height="290" alt="Screenshot 2026-07-09 at 10 19 33 PM" src="https://github.com/user-attachments/assets/b5df6177-cf9a-4769-b3fe-2244a6b2d5f5" />


Line 74 to 89.

**FILE 2 CHANGES:**

**Name of File:**  frontend/src/hooks/useUserPrefrences.tsx

<img width="1073" height="61" alt="Screenshot 2026-07-09 at 6 13 17 PM" src="https://github.com/user-attachments/assets/f0ecff64-0445-4846-8993-a17b2375cc80" />
LINE: 105

**FILE 3 CHANGES:**

**Name of File:**  frontend/src/settingsPage/components/UserPreferencesCard.tsx

<img width="798" height="271" alt="Screenshot 2026-07-09 at 10 20 27 PM" src="https://github.com/user-attachments/assets/75de77e9-2b08-4217-bc28-e1775a657199" />



LINE 94 - 113.


**FILE 4 CHANGES:**

**Name of File:**  frontend/src-tauri/capabilities/ModelManager.tsx

<img width="861" height="221" alt="Screenshot 2026-07-09 at 6 17 05 PM" src="https://github.com/user-attachments/assets/8d6e2b0e-21aa-4094-8308-611837240bdd" />

LINE 6 - 8.

**It was done for the closing of the ModelManager window **


**Conclusion:**

My code does not throw any error or stop any api calls but i still want the moderator or mentor to go through my code and PR.

My solution fixes the bug issue - 1369


### AI Usage Disclosure:

We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact. AI slop is strongly discouraged and may lead to banning and blocking. Do not spam our repos with AI slop.

Check one of the checkboxes below:

- [ ] This PR does not contain AI-generated code at all.
- [x] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools: TODO


## Checklist
<!-- Mark items with [x] to indicate completion -->
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [ ] If applicable, I have made corresponding changes or additions to the documentation
- [ ] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Model Manager and Settings now stay synchronized in real time between windows.
  * User preferences automatically refresh after model changes.

* **Bug Fixes**
  * When closing Model Manager, Settings now updates the installed model list and refreshes active preferences accordingly.

* **Tests**
  * Updated Jest setup to mock cross-window event handling for more reliable automated testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->