### PR TITLE
Fix: Exclude CoreML provider for SigLIP2 sessions on macOS

### DIFF
--- a/backend/app/models/ONNXSessionBase.py
+++ b/backend/app/models/ONNXSessionBase.py
@@ -47,8 +47,13 @@ class ONNXSessionBase:
                 "Please install it from Settings → AI Models before using this feature."
             )
 
+        # CoreML only partially supports the SigLIP2 graph and its partitions
+        # fail at inference on Apple Silicon; run these sessions without it.
         session = onnxruntime.InferenceSession(
-            self.model_path, providers=ONNX_util_get_execution_providers()
+            self.model_path,
+            providers=ONNX_util_get_execution_providers(
+                exclude=("CoreMLExecutionProvider",)
+            ),
         )
         if self._model_key is not None and not self._session_registered:
             mark_model_session_active(self._model_key)

--- a/backend/app/utils/ONNX.py
+++ b/backend/app/utils/ONNX.py
@@ -1,14 +1,18 @@
 import onnxruntime
 
 
-def ONNX_util_get_execution_providers() -> list:
+def ONNX_util_get_execution_providers(exclude: tuple[str, ...] = ()) -> list:
     """
     Get ONNX execution providers based on GPU acceleration setting from metadata.
+
+    Args:
+        exclude: Provider names to filter out (e.g. providers known to be
+                 incompatible with a specific model graph).
 
     Returns:
         list: List of execution providers for ONNX runtime
               - If GPU_Acceleration is False: ["CPUExecutionProvider"]
-              - If GPU_Acceleration is True: All available providers
+              - If GPU_Acceleration is True: All available providers minus `exclude`
     """
     from app.database.metadata import db_get_metadata
 
@@ -25,6 +29,9 @@ def ONNX_util_get_execution_providers() -> list:
 
     # Return appropriate execution providers
     if gpu_acceleration:
-        return onnxruntime.get_available_providers()
+        providers = [
+            p for p in onnxruntime.get_available_providers() if p not in exclude
+        ]
+        return providers or ["CPUExecutionProvider"]
     else:
         return ["CPUExecutionProvider"]

--- a/backend/tests/test_onnx_providers.py
+++ b/backend/tests/test_onnx_providers.py
@@ -1,0 +1,67 @@
+from unittest.mock import MagicMock, patch
+
+from app.utils.ONNX import ONNX_util_get_execution_providers
+from app.models.SigLIP2Text import SigLIP2Text
+
+MACOS_PROVIDERS = ["CoreMLExecutionProvider", "CPUExecutionProvider"]
+
+
+def _metadata(gpu: bool) -> dict:
+    return {"user_preferences": {"GPU_Acceleration": gpu}}
+
+
+class TestExecutionProviderExclusion:
+    @patch("onnxruntime.get_available_providers", return_value=MACOS_PROVIDERS)
+    @patch("app.database.metadata.db_get_metadata", return_value=_metadata(True))
+    def test_exclude_filters_provider(self, mock_meta, mock_providers):
+        result = ONNX_util_get_execution_providers(exclude=("CoreMLExecutionProvider",))
+        assert result == ["CPUExecutionProvider"]
+
+    @patch("onnxruntime.get_available_providers", return_value=MACOS_PROVIDERS)
+    @patch("app.database.metadata.db_get_metadata", return_value=_metadata(True))
+    def test_no_exclude_keeps_all_providers(self, mock_meta, mock_providers):
+        assert ONNX_util_get_execution_providers() == MACOS_PROVIDERS
+
+    @patch(
+        "onnxruntime.get_available_providers",
+        return_value=["CoreMLExecutionProvider"],
+    )
+    @patch("app.database.metadata.db_get_metadata", return_value=_metadata(True))
+    def test_excluding_everything_falls_back_to_cpu(self, mock_meta, mock_providers):
+        result = ONNX_util_get_execution_providers(exclude=("CoreMLExecutionProvider",))
+        assert result == ["CPUExecutionProvider"]
+
+    @patch("app.database.metadata.db_get_metadata", return_value=_metadata(False))
+    def test_gpu_off_ignores_exclude(self, mock_meta):
+        result = ONNX_util_get_execution_providers(exclude=("CoreMLExecutionProvider",))
+        assert result == ["CPUExecutionProvider"]
+
+
+class TestSigLIP2SessionExcludesCoreML:
+    @patch("onnxruntime.get_available_providers", return_value=MACOS_PROVIDERS)
+    @patch("app.database.metadata.db_get_metadata", return_value=_metadata(True))
+    @patch("onnxruntime.InferenceSession")
+    @patch("os.path.exists", return_value=True)
+    def test_session_created_without_coreml(
+        self, mock_exists, mock_session_cls, mock_meta, mock_providers
+    ):
+        """Regression test for macOS: CoreML cannot run the full SigLIP2
+        graph, so ONNXSessionBase must never hand it to InferenceSession."""
+        fake = MagicMock()
+        tensor = MagicMock()
+        tensor.name = "input_ids"
+        tensor2 = MagicMock()
+        tensor2.name = "attention_mask"
+        fake.get_inputs.return_value = [tensor, tensor2]
+        fake.get_outputs.return_value = [MagicMock()]
+        mock_session_cls.return_value = fake
+
+        model = SigLIP2Text("app/models/ONNX_Exports/SigLIP2_Base_Text.onnx")
+        try:
+            model.get_session()
+        finally:
+            model.close()
+
+        providers = mock_session_cls.call_args.kwargs["providers"]
+        assert "CoreMLExecutionProvider" not in providers
+        assert providers == ["CPUExecutionProvider"]


### PR DESCRIPTION
Fixes #1376 

CoreML only supports 314 of 621 nodes in the SigLIP2 graph and its partitions fail at inference on Apple Silicon, stalling the embedding pass at 0%. SigLIP2 sessions now filter out CoreMLExecutionProvider; YOLO/FaceNet keep the full provider list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inference stability on macOS by avoiding unsupported CoreML execution paths.
  * Automatically falls back to CPU processing when available acceleration providers are unavailable or excluded.

* **Tests**
  * Added coverage for execution provider filtering, CPU fallback behavior, and macOS session initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->