### PR TITLE
fix: navbar disappears on scroll past one frame size window, only returns at top Issue#1383

### DIFF
--- a/frontend/src/layout/layout.tsx
+++ b/frontend/src/layout/layout.tsx
@@ -20,7 +20,8 @@ const Layout: React.FC = () => {
         <Navbar />
         <div className="flex" style={{ height: 'calc(100vh - 56px)' }}>
           <AppSidebar />
-          <div className="m-4 w-full">
+          {/* Contain scrolling here so Navbar's parent height never exceeds 100vh — now the navbar is stuck it will not go away */}
+          <div className="m-4 w-full overflow-y-auto">
             <Outlet />
           </div>
         </div>


### PR DESCRIPTION
###  Addressed Issues:

Fixes #1383 : Navbar disappears on scroll down on Settings Page.


###  Screenshots/Recordings:

**PictoPy Before:**

Uploading navbarBUG.mov…

**PictoPy After:**

Uploading Screen Recording 2026-07-19 at 10.52.36 PM.mov…

###  Additional Notes:

**Problem:**
On the Settings page, once enough folders are added (or "View More" is expanded) that the page content exceeds one viewport height, scrolling down causes the top navbar to scroll out of view entirely. Scrolling back up does not bring it back — it only reappears once the user reaches scrollTop: 0.

Fix: 
File : frontend/src/layout/layout.tsx
`<div className="m-4 w-full overflow-y-auto">`
Only changed one line. 

the row below the navbar has a fixed height: calc(100vh - 56px) with no overflow-y-auto, so overflowing page content just spilled into the document instead of scrolling inside that row.

Since a sticky element can only stay stuck within its parent's box, and that box came out to exactly one viewport tall, Navbar ran out of room to stick to past the first screen and scrolled away with everything else. 

Fix: add overflow-y-auto to the outlet wrapper div so content scrolls inside the fixed-height row instead of the document 



### AI Usage Disclosure:

We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact. AI slop is strongly discouraged and may lead to banning and blocking. Do not spam our repos with AI slop.

Check one of the checkboxes below:

- [ ] This PR does not contain AI-generated code at all.
- [ x ] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools: Claude Sonnet 5


## Checklist
<!-- Mark items with [x] to indicate completion -->
- [ x ] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [ x ] My code follows the project's code style and conventions
- [ x ] If applicable, I have made corresponding changes or additions to the documentation
- [ x ] If applicable, I have made corresponding changes or additions to tests
- [ x ] My changes generate no new warnings or errors
- [ x ] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [ x ] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [ x ] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [ x ] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled vertical scrolling for the main content area, improving navigation through content on smaller screens or when pages exceed the viewport height.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->