### PR TITLE
Predefined Semantic Vocabulary layer with Cached AI Tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ videos_cache.txt
 venv/
 frontend/dist
 env/
+
+# semantic vocabulary source downloads (cache for scripts/build_semantic_vocabulary.py)
+backend/scripts/vocabulary/sources/
+backend/scripts/vocabulary/eval_images/

--- a/backend/app/config/settings.py
+++ b/backend/app/config/settings.py
@@ -160,6 +160,21 @@ SIGLIP2_TOKENIZER_PAD_TOKEN = "<pad>"
 # bare-noun queries score low in absolute terms; 0.02 measured to cut true positives.
 SIGLIP2_MATCH_THRESHOLD = _get_env_float("SIGLIP2_MATCH_THRESHOLD", 0.01, min_value=0.0)
 
+# Curated-vocabulary pre-scoring. Ensembled label vectors score ~2 orders of
+# magnitude below live queries, so these floors are NOT comparable to
+# SIGLIP2_MATCH_THRESHOLD. Calibrated against a 151-image stratified eval set;
+# see backend/scripts/vocabulary/calibration_report.json.
+SEMANTIC_SCORE_TOP_K = _get_env_int("SEMANTIC_SCORE_TOP_K", 15, min_value=1)
+# stricter cut for tag chips / tag lists; stored rows keep the full top-K
+SEMANTIC_DISPLAY_TOP_K = _get_env_int("SEMANTIC_DISPLAY_TOP_K", 5, min_value=1)
+SEMANTIC_BUCKET_THRESHOLDS = {
+    "scene": 5e-05,
+    "object": 1e-04,
+    "event": 5e-05,
+    "attribute": 1e-04,
+}
+SEMANTIC_DEFAULT_THRESHOLD = 5e-05
+
 # Clustering Configuration
 PICTO_CLUSTERING_EPS = _get_env_float("PICTO_CLUSTERING_EPS", 0.75, min_value=0.0)
 PICTO_CLUSTERING_MIN_SAMPLES = _get_env_int(

--- a/backend/app/data/semantic_vocabulary.json
+++ b/backend/app/data/semantic_vocabulary.json
@@ -1,0 +1,3462 @@
+{
+  "vocab_version": 1,
+  "notes": "Seed vocabulary v1 with authored descriptions. Derived from scripts/vocabulary/raw_candidates.json (Places365 + Open Images minus COCO-80) via hand-prune, plus hand-written event and attribute blocks. Descriptions are caption-shaped, lowercase, visually diagnostic; the label embedding is the renormalized mean of their text embeddings.",
+  "label_count": 395,
+  "labels": [
+    {
+      "name": "airplane cabin",
+      "category": "scene",
+      "descriptions": [
+        "rows of seats inside an airplane cabin",
+        "passengers seated in the aisle of a plane",
+        "the view down a narrow airplane aisle with overhead bins"
+      ]
+    },
+    {
+      "name": "airport terminal",
+      "category": "scene",
+      "descriptions": [
+        "travelers with luggage walking through an airport terminal",
+        "a departure hall with check in counters and flight boards",
+        "people waiting with suitcases near airport gates"
+      ]
+    },
+    {
+      "name": "alley",
+      "category": "scene",
+      "descriptions": [
+        "a narrow alley between old buildings",
+        "a dim back alley with brick walls",
+        "a cobbled lane squeezed between houses"
+      ]
+    },
+    {
+      "name": "amphitheater",
+      "category": "scene",
+      "descriptions": [
+        "an ancient stone amphitheater with tiered seating",
+        "curved rows of stone seats around an open stage",
+        "tourists walking among the ruins of a roman amphitheater"
+      ]
+    },
+    {
+      "name": "amusement park",
+      "category": "scene",
+      "descriptions": [
+        "a colorful amusement park with a ferris wheel and rides",
+        "people riding a roller coaster at a theme park",
+        "bright carnival rides and game stalls at an amusement park"
+      ]
+    },
+    {
+      "name": "apartment building",
+      "category": "scene",
+      "descriptions": [
+        "a tall apartment building with rows of balconies",
+        "the facade of a residential block with many windows",
+        "an apartment complex seen from the street"
+      ]
+    },
+    {
+      "name": "aquarium",
+      "category": "scene",
+      "descriptions": [
+        "people watching fish through a large aquarium tank window",
+        "colorful fish swimming in a glowing blue aquarium",
+        "a child pressing hands against glass at an aquarium"
+      ]
+    },
+    {
+      "name": "arcade",
+      "category": "scene",
+      "descriptions": [
+        "rows of glowing arcade game machines",
+        "people playing video games in a dark arcade",
+        "claw machines and arcade cabinets with bright screens"
+      ]
+    },
+    {
+      "name": "arena",
+      "category": "scene",
+      "descriptions": [
+        "a large indoor arena filled with spectators",
+        "bright lights over the floor of a sports arena",
+        "crowded stands surrounding an arena floor"
+      ]
+    },
+    {
+      "name": "art gallery",
+      "category": "scene",
+      "descriptions": [
+        "framed paintings hanging on white gallery walls",
+        "visitors looking at artwork in an art gallery",
+        "a bright exhibition room with pictures on the walls"
+      ]
+    },
+    {
+      "name": "art studio",
+      "category": "scene",
+      "descriptions": [
+        "an artist painting on a canvas at an easel",
+        "a messy studio with paint tubes and brushes",
+        "canvases and easels in a painters workspace"
+      ]
+    },
+    {
+      "name": "attic",
+      "category": "scene",
+      "descriptions": [
+        "a dusty attic with wooden beams and stored boxes",
+        "old furniture stored under a sloped attic roof",
+        "a cramped loft space lit by a small window"
+      ]
+    },
+    {
+      "name": "auditorium",
+      "category": "scene",
+      "descriptions": [
+        "rows of seats facing a stage in an auditorium",
+        "an audience seated in a large hall for a presentation",
+        "a speaker on stage in front of a seated crowd"
+      ]
+    },
+    {
+      "name": "backyard",
+      "category": "scene",
+      "descriptions": [
+        "a backyard with a lawn and a wooden fence",
+        "children playing on grass behind a house",
+        "a garden chair and plants in a home backyard"
+      ]
+    },
+    {
+      "name": "bakery",
+      "category": "scene",
+      "descriptions": [
+        "fresh loaves of bread on display in a bakery",
+        "shelves of pastries and cakes behind a bakery counter",
+        "a baker arranging baked goods in a shop"
+      ]
+    },
+    {
+      "name": "balcony",
+      "category": "scene",
+      "descriptions": [
+        "a view from a balcony with a railing",
+        "potted plants and chairs on a small balcony",
+        "a person leaning on a balcony railing overlooking the street"
+      ]
+    },
+    {
+      "name": "ball pit",
+      "category": "scene",
+      "descriptions": [
+        "a child playing in a pit full of colorful plastic balls",
+        "hundreds of bright plastic balls in a play area",
+        "kids jumping into a ball pit at a play center"
+      ]
+    },
+    {
+      "name": "ballroom",
+      "category": "scene",
+      "descriptions": [
+        "an ornate ballroom with chandeliers and a polished floor",
+        "couples dancing in a grand decorated hall",
+        "round tables set for an event in a ballroom"
+      ]
+    },
+    {
+      "name": "bamboo forest",
+      "category": "scene",
+      "descriptions": [
+        "a path through a dense bamboo forest",
+        "tall green bamboo stalks growing close together",
+        "sunlight filtering through a grove of bamboo"
+      ]
+    },
+    {
+      "name": "banquet hall",
+      "category": "scene",
+      "descriptions": [
+        "long tables set with dishes in a banquet hall",
+        "a decorated hall prepared for a wedding reception",
+        "guests dining at round tables under chandeliers"
+      ]
+    },
+    {
+      "name": "bar",
+      "category": "scene",
+      "descriptions": [
+        "bottles lined up behind a bar counter",
+        "a bartender pouring drinks at a bar",
+        "people sitting on stools at a counter with drinks"
+      ]
+    },
+    {
+      "name": "barn",
+      "category": "scene",
+      "descriptions": [
+        "a red wooden barn in a farm field",
+        "hay bales stacked inside a wooden barn",
+        "a rustic barn with large doors and a pitched roof"
+      ]
+    },
+    {
+      "name": "baseball field",
+      "category": "scene",
+      "descriptions": [
+        "a baseball diamond with dirt base paths and green grass",
+        "players on a baseball field during a game",
+        "a pitcher on the mound of a baseball field"
+      ]
+    },
+    {
+      "name": "basement",
+      "category": "scene",
+      "descriptions": [
+        "an unfinished basement with concrete walls and pipes",
+        "storage boxes and shelves in a dim basement",
+        "a cellar room below a house with low ceilings"
+      ]
+    },
+    {
+      "name": "basketball court",
+      "category": "scene",
+      "descriptions": [
+        "players shooting hoops on an indoor basketball court",
+        "a basketball hoop above a polished court floor",
+        "a marked court with players dribbling a basketball"
+      ]
+    },
+    {
+      "name": "bathroom",
+      "category": "scene",
+      "descriptions": [
+        "a bathroom with a sink mirror and toilet",
+        "white tiles and a bathtub in a clean bathroom",
+        "a modern bathroom with a glass shower"
+      ]
+    },
+    {
+      "name": "beach",
+      "category": "scene",
+      "descriptions": [
+        "a sandy beach where the ocean meets the shore",
+        "people relaxing on a beach on a sunny day",
+        "waves washing onto a sandy shoreline with footprints"
+      ]
+    },
+    {
+      "name": "beach house",
+      "category": "scene",
+      "descriptions": [
+        "a wooden house on stilts by the seashore",
+        "a cottage overlooking the beach and ocean",
+        "a seaside house with a deck facing the water"
+      ]
+    },
+    {
+      "name": "beauty salon",
+      "category": "scene",
+      "descriptions": [
+        "a hairdresser cutting hair in a salon chair",
+        "mirrors and styling chairs in a beauty salon",
+        "a woman getting her hair styled at a salon"
+      ]
+    },
+    {
+      "name": "bedroom",
+      "category": "scene",
+      "descriptions": [
+        "a bedroom with a neatly made bed and pillows",
+        "a cozy bedroom with a lamp on the nightstand",
+        "morning light falling on a bed in a bedroom"
+      ]
+    },
+    {
+      "name": "beer garden",
+      "category": "scene",
+      "descriptions": [
+        "people drinking beer at long wooden tables outdoors",
+        "an outdoor beer garden with benches under trees",
+        "friends raising beer mugs at an outdoor table"
+      ]
+    },
+    {
+      "name": "boardwalk",
+      "category": "scene",
+      "descriptions": [
+        "a wooden boardwalk along the beach",
+        "people strolling on a boardwalk by the sea",
+        "a long wooden walkway over sand and dunes"
+      ]
+    },
+    {
+      "name": "boat deck",
+      "category": "scene",
+      "descriptions": [
+        "passengers standing on the deck of a boat at sea",
+        "the wooden deck of a ship with railings and ocean views",
+        "people enjoying the breeze on a cruise ship deck"
+      ]
+    },
+    {
+      "name": "bookstore",
+      "category": "scene",
+      "descriptions": [
+        "shelves packed with books in a bookstore",
+        "a person browsing books in a book shop",
+        "stacks of books on display tables in a store"
+      ]
+    },
+    {
+      "name": "botanical garden",
+      "category": "scene",
+      "descriptions": [
+        "flower beds and labeled plants in a botanical garden",
+        "visitors walking among exotic plants in a glasshouse",
+        "manicured garden paths lined with flowers and trees"
+      ]
+    },
+    {
+      "name": "bowling alley",
+      "category": "scene",
+      "descriptions": [
+        "polished bowling lanes with pins at the end",
+        "a person throwing a bowling ball down a lane",
+        "glowing lanes and seating at a bowling alley"
+      ]
+    },
+    {
+      "name": "boxing ring",
+      "category": "scene",
+      "descriptions": [
+        "two boxers fighting in a roped boxing ring",
+        "a boxing ring with red and blue corner posts",
+        "a fighter training in a gym boxing ring"
+      ]
+    },
+    {
+      "name": "bridge",
+      "category": "scene",
+      "descriptions": [
+        "a long bridge spanning across a river",
+        "a suspension bridge with tall towers and cables",
+        "cars crossing a bridge over water"
+      ]
+    },
+    {
+      "name": "butcher shop",
+      "category": "scene",
+      "descriptions": [
+        "cuts of meat displayed in a butcher shop counter",
+        "a butcher slicing meat behind a glass case",
+        "sausages and meat hanging in a butchery"
+      ]
+    },
+    {
+      "name": "cabin",
+      "category": "scene",
+      "descriptions": [
+        "a log cabin in the woods",
+        "a small wooden cabin surrounded by trees",
+        "a rustic timber cottage with a chimney in the forest"
+      ]
+    },
+    {
+      "name": "cafeteria",
+      "category": "scene",
+      "descriptions": [
+        "people eating at long tables in a cafeteria",
+        "trays of food at a self service cafeteria counter",
+        "a school canteen with students having lunch"
+      ]
+    },
+    {
+      "name": "campsite",
+      "category": "scene",
+      "descriptions": [
+        "tents pitched at a campsite in the woods",
+        "camping chairs around a fire pit at a campsite",
+        "a campground with tents and a picnic table"
+      ]
+    },
+    {
+      "name": "campus",
+      "category": "scene",
+      "descriptions": [
+        "students walking between university buildings",
+        "a college campus with lawns and academic halls",
+        "a university quad with students and trees"
+      ]
+    },
+    {
+      "name": "canal",
+      "category": "scene",
+      "descriptions": [
+        "boats moving along a canal between buildings",
+        "a narrow waterway lined with old houses",
+        "a canal with arched bridges crossing it"
+      ]
+    },
+    {
+      "name": "candy store",
+      "category": "scene",
+      "descriptions": [
+        "jars of colorful sweets in a candy store",
+        "shelves of lollipops and chocolates in a sweet shop",
+        "a display of candies in bright wrappers"
+      ]
+    },
+    {
+      "name": "canyon",
+      "category": "scene",
+      "descriptions": [
+        "steep red rock walls of a deep canyon",
+        "a river winding at the bottom of a canyon",
+        "layered rock cliffs carved into a gorge"
+      ]
+    },
+    {
+      "name": "carousel",
+      "category": "scene",
+      "descriptions": [
+        "a carousel with painted horses spinning at a fair",
+        "children riding a colorful merry go round",
+        "the lights of a carousel turning at dusk"
+      ]
+    },
+    {
+      "name": "castle",
+      "category": "scene",
+      "descriptions": [
+        "a medieval stone castle with towers and battlements",
+        "a fortress castle on a hilltop",
+        "the walls and turrets of an old castle"
+      ]
+    },
+    {
+      "name": "cave",
+      "category": "scene",
+      "descriptions": [
+        "the dark entrance of a rocky cave",
+        "stalactites hanging inside a limestone cave",
+        "a person exploring a cavern with a light"
+      ]
+    },
+    {
+      "name": "cemetery",
+      "category": "scene",
+      "descriptions": [
+        "rows of gravestones in a quiet cemetery",
+        "old tombstones under trees in a graveyard",
+        "flowers laid on graves in a cemetery"
+      ]
+    },
+    {
+      "name": "church",
+      "category": "scene",
+      "descriptions": [
+        "a church with a steeple and arched windows",
+        "wooden pews and a stained glass window inside a church",
+        "the altar and nave of an old church"
+      ]
+    },
+    {
+      "name": "city",
+      "category": "scene",
+      "descriptions": [
+        "a downtown skyline of tall city buildings",
+        "busy streets and skyscrapers in a big city",
+        "a city viewed from above with dense buildings"
+      ]
+    },
+    {
+      "name": "classroom",
+      "category": "scene",
+      "descriptions": [
+        "students sitting at desks in a classroom",
+        "a whiteboard and rows of desks in a school room",
+        "a teacher writing on a board in front of students"
+      ]
+    },
+    {
+      "name": "cliff",
+      "category": "scene",
+      "descriptions": [
+        "a steep rocky cliff dropping to the sea",
+        "a person standing at the edge of a high cliff",
+        "sheer rock cliffs along a coastline"
+      ]
+    },
+    {
+      "name": "closet",
+      "category": "scene",
+      "descriptions": [
+        "clothes hanging on rails inside a closet",
+        "shelves of folded clothes and shoes in a wardrobe",
+        "an organized walk in closet with hangers"
+      ]
+    },
+    {
+      "name": "clothing store",
+      "category": "scene",
+      "descriptions": [
+        "racks of clothes in a fashion store",
+        "mannequins displaying outfits in a clothing shop",
+        "a person browsing garments on store racks"
+      ]
+    },
+    {
+      "name": "coast",
+      "category": "scene",
+      "descriptions": [
+        "a rocky coastline with waves crashing on rocks",
+        "a winding shoreline seen from above",
+        "cliffs and sea meeting along a rugged coast"
+      ]
+    },
+    {
+      "name": "cockpit",
+      "category": "scene",
+      "descriptions": [
+        "the instrument panel and controls of an airplane cockpit",
+        "pilots seated at the controls of an aircraft",
+        "switches and screens inside a plane cockpit"
+      ]
+    },
+    {
+      "name": "coffee shop",
+      "category": "scene",
+      "descriptions": [
+        "people drinking coffee at small cafe tables",
+        "a barista making coffee behind a cafe counter",
+        "a cozy coffee shop with cups and pastries"
+      ]
+    },
+    {
+      "name": "conference room",
+      "category": "scene",
+      "descriptions": [
+        "a long table with chairs in a meeting room",
+        "colleagues in a meeting around a conference table",
+        "a presentation screen in a corporate meeting room"
+      ]
+    },
+    {
+      "name": "construction site",
+      "category": "scene",
+      "descriptions": [
+        "cranes and scaffolding at a construction site",
+        "workers in hard hats on a building site",
+        "concrete and steel framework of an unfinished building"
+      ]
+    },
+    {
+      "name": "convenience store",
+      "category": "scene",
+      "descriptions": [
+        "shelves of snacks and drinks in a small convenience store",
+        "a brightly lit corner store with packed shelves",
+        "refrigerated drink cases in a mini mart"
+      ]
+    },
+    {
+      "name": "cottage",
+      "category": "scene",
+      "descriptions": [
+        "a small cottage with a garden and flowers",
+        "a quaint stone cottage with a thatched roof",
+        "a charming little house in the countryside"
+      ]
+    },
+    {
+      "name": "courtyard",
+      "category": "scene",
+      "descriptions": [
+        "an inner courtyard surrounded by building walls",
+        "a paved courtyard with plants and a fountain",
+        "an open patio enclosed by arched walkways"
+      ]
+    },
+    {
+      "name": "creek",
+      "category": "scene",
+      "descriptions": [
+        "a small creek flowing over rocks",
+        "a shallow stream running through the woods",
+        "clear water trickling along a narrow brook"
+      ]
+    },
+    {
+      "name": "dam",
+      "category": "scene",
+      "descriptions": [
+        "a massive concrete dam holding back a reservoir",
+        "water spilling down the face of a dam",
+        "a hydroelectric dam across a river valley"
+      ]
+    },
+    {
+      "name": "desert",
+      "category": "scene",
+      "descriptions": [
+        "rolling sand dunes in a vast desert",
+        "a dry desert landscape with sparse cactus plants",
+        "cracked earth and sand stretching to the horizon"
+      ]
+    },
+    {
+      "name": "dining room",
+      "category": "scene",
+      "descriptions": [
+        "a dining table set with plates and chairs",
+        "a family eating dinner at a dining room table",
+        "a chandelier above a wooden dining table"
+      ]
+    },
+    {
+      "name": "driveway",
+      "category": "scene",
+      "descriptions": [
+        "a car parked on a driveway in front of a house",
+        "a paved driveway leading to a garage",
+        "a concrete drive beside a front lawn"
+      ]
+    },
+    {
+      "name": "elevator",
+      "category": "scene",
+      "descriptions": [
+        "the metal doors of an elevator in a hallway",
+        "buttons and mirrors inside an elevator car",
+        "people standing inside a lift"
+      ]
+    },
+    {
+      "name": "escalator",
+      "category": "scene",
+      "descriptions": [
+        "moving escalator steps in a shopping center",
+        "people riding an escalator between floors",
+        "parallel escalators going up and down"
+      ]
+    },
+    {
+      "name": "farm",
+      "category": "scene",
+      "descriptions": [
+        "a farmhouse and fields on a rural farm",
+        "tractors and crops on farmland",
+        "farm animals grazing near a barn"
+      ]
+    },
+    {
+      "name": "field",
+      "category": "scene",
+      "descriptions": [
+        "a wide open grassy field under the sky",
+        "tall grass swaying in an open meadow",
+        "a green field stretching to the horizon"
+      ]
+    },
+    {
+      "name": "fire station",
+      "category": "scene",
+      "descriptions": [
+        "a red fire truck parked in a fire station",
+        "the garage bays of a firehouse",
+        "firefighters and equipment at a fire station"
+      ]
+    },
+    {
+      "name": "flea market",
+      "category": "scene",
+      "descriptions": [
+        "stalls of secondhand goods at a flea market",
+        "people browsing antiques at an outdoor market",
+        "tables piled with used items for sale"
+      ]
+    },
+    {
+      "name": "flower shop",
+      "category": "scene",
+      "descriptions": [
+        "buckets of fresh flowers in a florist shop",
+        "a florist arranging a bouquet",
+        "colorful flower bouquets on display for sale"
+      ]
+    },
+    {
+      "name": "football field",
+      "category": "scene",
+      "descriptions": [
+        "a striped football field with goalposts",
+        "players on a floodlit football pitch",
+        "a stadium field marked with yard lines"
+      ]
+    },
+    {
+      "name": "forest",
+      "category": "scene",
+      "descriptions": [
+        "tall trees in a dense green forest",
+        "sunlight filtering through the forest canopy",
+        "a trail winding between mossy trees in the woods"
+      ]
+    },
+    {
+      "name": "fountain",
+      "category": "scene",
+      "descriptions": [
+        "water spraying from a stone fountain in a plaza",
+        "an ornate fountain with sculpted figures",
+        "a round fountain with jets of water"
+      ]
+    },
+    {
+      "name": "garage",
+      "category": "scene",
+      "descriptions": [
+        "a car parked inside a home garage",
+        "tools and shelves along a garage wall",
+        "an open garage door with storage inside"
+      ]
+    },
+    {
+      "name": "garden",
+      "category": "scene",
+      "descriptions": [
+        "a garden with blooming flower beds",
+        "a person watering plants in a home garden",
+        "green shrubs and flowers along a garden path"
+      ]
+    },
+    {
+      "name": "gas station",
+      "category": "scene",
+      "descriptions": [
+        "fuel pumps under the canopy of a gas station",
+        "a car being refueled at a petrol station",
+        "a gas station with price signs and pumps"
+      ]
+    },
+    {
+      "name": "gazebo",
+      "category": "scene",
+      "descriptions": [
+        "a white gazebo in the middle of a garden",
+        "an open sided pavilion with a pointed roof",
+        "a wooden gazebo with benches inside"
+      ]
+    },
+    {
+      "name": "gift shop",
+      "category": "scene",
+      "descriptions": [
+        "souvenirs and trinkets displayed in a gift shop",
+        "shelves of mugs and keepsakes in a souvenir store",
+        "postcards and gifts on display racks"
+      ]
+    },
+    {
+      "name": "glacier",
+      "category": "scene",
+      "descriptions": [
+        "a massive glacier flowing between mountains",
+        "blue ice walls of a glacier",
+        "cracked glacial ice stretching down a valley"
+      ]
+    },
+    {
+      "name": "golf course",
+      "category": "scene",
+      "descriptions": [
+        "manicured green fairways of a golf course",
+        "a golfer swinging a club on a green",
+        "sand bunkers and flags on a golf course"
+      ]
+    },
+    {
+      "name": "greenhouse",
+      "category": "scene",
+      "descriptions": [
+        "rows of plants growing inside a glass greenhouse",
+        "sunlight streaming into a greenhouse full of seedlings",
+        "a glass house with potted plants on benches"
+      ]
+    },
+    {
+      "name": "gym",
+      "category": "scene",
+      "descriptions": [
+        "exercise machines and weights in a gym",
+        "people working out with dumbbells at a fitness center",
+        "treadmills lined up in a fitness gym"
+      ]
+    },
+    {
+      "name": "hallway",
+      "category": "scene",
+      "descriptions": [
+        "a long hallway with doors on both sides",
+        "an empty corridor with overhead lights",
+        "a narrow passage inside a building"
+      ]
+    },
+    {
+      "name": "harbor",
+      "category": "scene",
+      "descriptions": [
+        "boats moored in a harbor at the waterfront",
+        "sailboats and yachts docked at a marina",
+        "fishing boats tied up along a harbor quay"
+      ]
+    },
+    {
+      "name": "highway",
+      "category": "scene",
+      "descriptions": [
+        "cars driving down a multi lane highway",
+        "a long straight freeway stretching into the distance",
+        "highway lanes with traffic and road signs"
+      ]
+    },
+    {
+      "name": "home office",
+      "category": "scene",
+      "descriptions": [
+        "a desk with a computer in a home office",
+        "a person working at a desk in a study room",
+        "bookshelves and a laptop in a home workspace"
+      ]
+    },
+    {
+      "name": "home theater",
+      "category": "scene",
+      "descriptions": [
+        "a large screen and recliner seats in a home theater",
+        "a dark room with a projector screen and sofas",
+        "a movie playing on a big home cinema screen"
+      ]
+    },
+    {
+      "name": "hospital",
+      "category": "scene",
+      "descriptions": [
+        "the exterior of a hospital building with an entrance sign",
+        "nurses and a corridor inside a hospital",
+        "a hospital lobby with wheelchairs and staff"
+      ]
+    },
+    {
+      "name": "hospital room",
+      "category": "scene",
+      "descriptions": [
+        "a patient in a hospital bed with monitors",
+        "medical equipment beside a hospital bed",
+        "a white hospital room with an iv stand"
+      ]
+    },
+    {
+      "name": "hot spring",
+      "category": "scene",
+      "descriptions": [
+        "steam rising from a natural hot spring pool",
+        "people bathing in a rocky thermal spring",
+        "a turquoise geothermal pool with steam"
+      ]
+    },
+    {
+      "name": "hot tub",
+      "category": "scene",
+      "descriptions": [
+        "people relaxing in a bubbling hot tub",
+        "a steaming jacuzzi with jets of water",
+        "a round spa tub on a wooden deck"
+      ]
+    },
+    {
+      "name": "hotel",
+      "category": "scene",
+      "descriptions": [
+        "the entrance and sign of a hotel building",
+        "a grand hotel facade with many windows",
+        "a resort hotel with palm trees at the entrance"
+      ]
+    },
+    {
+      "name": "hotel room",
+      "category": "scene",
+      "descriptions": [
+        "a hotel room with a large bed and lamps",
+        "neatly arranged twin beds in a hotel room",
+        "a suitcase on the bed of a tidy hotel room"
+      ]
+    },
+    {
+      "name": "house",
+      "category": "scene",
+      "descriptions": [
+        "a family house with a front yard",
+        "a two story home with a driveway",
+        "a suburban house with a porch and garden"
+      ]
+    },
+    {
+      "name": "ice rink",
+      "category": "scene",
+      "descriptions": [
+        "people ice skating on a rink",
+        "a smooth ice rink surrounded by barriers",
+        "skaters gliding across an ice skating rink"
+      ]
+    },
+    {
+      "name": "iceberg",
+      "category": "scene",
+      "descriptions": [
+        "a huge iceberg floating in cold water",
+        "a white and blue iceberg against a gray sea",
+        "chunks of ice drifting near a large iceberg"
+      ]
+    },
+    {
+      "name": "igloo",
+      "category": "scene",
+      "descriptions": [
+        "a dome shaped igloo built from snow blocks",
+        "an igloo on a snowy plain",
+        "the entrance tunnel of a snow igloo"
+      ]
+    },
+    {
+      "name": "island",
+      "category": "scene",
+      "descriptions": [
+        "a small green island surrounded by blue sea",
+        "a tropical island with palm trees and beaches",
+        "an island seen from the air amid turquoise water"
+      ]
+    },
+    {
+      "name": "japanese garden",
+      "category": "scene",
+      "descriptions": [
+        "a japanese garden with a red bridge and koi pond",
+        "raked gravel and stone lanterns in a zen garden",
+        "manicured bonsai trees and a wooden tea house"
+      ]
+    },
+    {
+      "name": "kitchen",
+      "category": "scene",
+      "descriptions": [
+        "a kitchen with cabinets stove and counters",
+        "someone cooking at a kitchen counter",
+        "pots and utensils in a home kitchen"
+      ]
+    },
+    {
+      "name": "laboratory",
+      "category": "scene",
+      "descriptions": [
+        "scientists working with equipment in a laboratory",
+        "test tubes and instruments on a lab bench",
+        "a researcher in a white coat using lab apparatus"
+      ]
+    },
+    {
+      "name": "lake",
+      "category": "scene",
+      "descriptions": [
+        "a calm lake surrounded by trees",
+        "still lake water reflecting the mountains",
+        "a wooden dock extending into a quiet lake"
+      ]
+    },
+    {
+      "name": "laundromat",
+      "category": "scene",
+      "descriptions": [
+        "rows of washing machines in a laundromat",
+        "a person loading laundry into a machine",
+        "coin operated dryers along a laundromat wall"
+      ]
+    },
+    {
+      "name": "library",
+      "category": "scene",
+      "descriptions": [
+        "tall shelves of books in a library",
+        "people reading at tables in a quiet library",
+        "aisles of bookshelves under library lighting"
+      ]
+    },
+    {
+      "name": "lighthouse",
+      "category": "scene",
+      "descriptions": [
+        "a lighthouse standing on a rocky shore",
+        "a striped lighthouse tower against the sky",
+        "a lighthouse beacon overlooking the sea"
+      ]
+    },
+    {
+      "name": "living room",
+      "category": "scene",
+      "descriptions": [
+        "a living room with a sofa and coffee table",
+        "a family relaxing on couches in a living room",
+        "a tv and cushions in a cozy lounge room"
+      ]
+    },
+    {
+      "name": "lobby",
+      "category": "scene",
+      "descriptions": [
+        "a spacious hotel lobby with seating and a front desk",
+        "people checking in at a reception counter",
+        "a marble floored entrance hall of a building"
+      ]
+    },
+    {
+      "name": "mansion",
+      "category": "scene",
+      "descriptions": [
+        "a grand mansion with columns and manicured grounds",
+        "a huge luxury house with many windows",
+        "an elegant estate home behind iron gates"
+      ]
+    },
+    {
+      "name": "market",
+      "category": "scene",
+      "descriptions": [
+        "stalls piled with fresh produce at a market",
+        "vendors selling fruits and vegetables at a street market",
+        "a busy bazaar with goods on display"
+      ]
+    },
+    {
+      "name": "mosque",
+      "category": "scene",
+      "descriptions": [
+        "a mosque with domes and tall minarets",
+        "the ornate arched interior of a mosque",
+        "worshippers praying in rows inside a mosque"
+      ]
+    },
+    {
+      "name": "mountain",
+      "category": "scene",
+      "descriptions": [
+        "a tall mountain peak against the sky",
+        "rocky mountain slopes rising above a valley",
+        "a hiker looking at distant mountain ranges"
+      ]
+    },
+    {
+      "name": "movie theater",
+      "category": "scene",
+      "descriptions": [
+        "rows of red seats facing a cinema screen",
+        "an audience watching a film in a dark theater",
+        "a large movie screen glowing in a cinema hall"
+      ]
+    },
+    {
+      "name": "museum",
+      "category": "scene",
+      "descriptions": [
+        "exhibits displayed in glass cases at a museum",
+        "visitors viewing displays in a museum hall",
+        "sculptures and artifacts in a museum gallery"
+      ]
+    },
+    {
+      "name": "music studio",
+      "category": "scene",
+      "descriptions": [
+        "a mixing console and monitors in a recording studio",
+        "a singer recording behind a studio microphone",
+        "soundproof panels and instruments in a music studio"
+      ]
+    },
+    {
+      "name": "nightclub",
+      "category": "scene",
+      "descriptions": [
+        "people dancing under colorful lights in a nightclub",
+        "a dj performing at a crowded club",
+        "laser lights and a packed dance floor"
+      ]
+    },
+    {
+      "name": "nursery",
+      "category": "scene",
+      "descriptions": [
+        "a baby crib in a softly decorated nursery",
+        "pastel walls and toys in a baby room",
+        "a rocking chair beside a crib in a nursery"
+      ]
+    },
+    {
+      "name": "ocean",
+      "category": "scene",
+      "descriptions": [
+        "open ocean waves stretching to the horizon",
+        "deep blue sea water with rolling swells",
+        "sunlight sparkling on the surface of the sea"
+      ]
+    },
+    {
+      "name": "office",
+      "category": "scene",
+      "descriptions": [
+        "desks with computers in an office",
+        "coworkers at workstations in an open office",
+        "a tidy office desk with a monitor and papers"
+      ]
+    },
+    {
+      "name": "office building",
+      "category": "scene",
+      "descriptions": [
+        "a tall glass office building downtown",
+        "the mirrored facade of a corporate tower",
+        "an office block with rows of windows"
+      ]
+    },
+    {
+      "name": "orchard",
+      "category": "scene",
+      "descriptions": [
+        "rows of fruit trees in an orchard",
+        "apples ripening on trees in an orchard",
+        "a person picking fruit from an orchard tree"
+      ]
+    },
+    {
+      "name": "pagoda",
+      "category": "scene",
+      "descriptions": [
+        "a multi tiered pagoda tower with curved roofs",
+        "an asian pagoda temple among trees",
+        "a red pagoda rising above a garden"
+      ]
+    },
+    {
+      "name": "palace",
+      "category": "scene",
+      "descriptions": [
+        "an ornate palace with gilded decoration",
+        "a grand royal palace with sprawling courtyards",
+        "the lavish facade of a historic palace"
+      ]
+    },
+    {
+      "name": "pantry",
+      "category": "scene",
+      "descriptions": [
+        "shelves stocked with jars and cans in a pantry",
+        "organized food containers in a kitchen pantry",
+        "a narrow storage room lined with groceries"
+      ]
+    },
+    {
+      "name": "park",
+      "category": "scene",
+      "descriptions": [
+        "a public park with lawns and walking paths",
+        "people relaxing on benches under park trees",
+        "a green city park on a sunny day"
+      ]
+    },
+    {
+      "name": "parking lot",
+      "category": "scene",
+      "descriptions": [
+        "rows of parked cars in a parking lot",
+        "an outdoor car park with painted lines",
+        "a half empty parking area beside a building"
+      ]
+    },
+    {
+      "name": "pasture",
+      "category": "scene",
+      "descriptions": [
+        "cows grazing in a green pasture",
+        "a fenced meadow with livestock",
+        "rolling grassland dotted with grazing animals"
+      ]
+    },
+    {
+      "name": "patio",
+      "category": "scene",
+      "descriptions": [
+        "an outdoor patio with chairs and a table",
+        "a paved terrace with potted plants",
+        "people dining outside on a patio"
+      ]
+    },
+    {
+      "name": "pharmacy",
+      "category": "scene",
+      "descriptions": [
+        "shelves of medicine boxes in a pharmacy",
+        "a pharmacist at the counter of a drug store",
+        "rows of health products in a chemist shop"
+      ]
+    },
+    {
+      "name": "phone booth",
+      "category": "scene",
+      "descriptions": [
+        "a red telephone booth on a street corner",
+        "an old public phone box on the sidewalk",
+        "a glass phone booth with a telephone inside"
+      ]
+    },
+    {
+      "name": "pier",
+      "category": "scene",
+      "descriptions": [
+        "a long wooden pier stretching over the sea",
+        "people walking along a pier at the shore",
+        "wooden pilings of a pier above the waves"
+      ]
+    },
+    {
+      "name": "playground",
+      "category": "scene",
+      "descriptions": [
+        "children playing on slides and swings at a playground",
+        "a colorful playground with climbing frames",
+        "kids on a jungle gym in a play area"
+      ]
+    },
+    {
+      "name": "playroom",
+      "category": "scene",
+      "descriptions": [
+        "toys scattered across a childrens playroom",
+        "a bright room with toy shelves and a play mat",
+        "kids playing with blocks in a playroom"
+      ]
+    },
+    {
+      "name": "plaza",
+      "category": "scene",
+      "descriptions": [
+        "a wide open city square with people walking",
+        "a paved plaza surrounded by historic buildings",
+        "pigeons and pedestrians in a town square"
+      ]
+    },
+    {
+      "name": "pond",
+      "category": "scene",
+      "descriptions": [
+        "a small pond with lily pads",
+        "ducks swimming on a garden pond",
+        "still green water of a quiet pond"
+      ]
+    },
+    {
+      "name": "porch",
+      "category": "scene",
+      "descriptions": [
+        "a front porch with rocking chairs",
+        "a wooden veranda attached to a house",
+        "steps leading up to a covered porch"
+      ]
+    },
+    {
+      "name": "racetrack",
+      "category": "scene",
+      "descriptions": [
+        "race cars speeding around a racetrack",
+        "horses racing on an oval track",
+        "the curved asphalt of a racing circuit"
+      ]
+    },
+    {
+      "name": "railroad track",
+      "category": "scene",
+      "descriptions": [
+        "steel railroad tracks stretching into the distance",
+        "railway lines crossing wooden sleepers",
+        "train tracks curving through the landscape"
+      ]
+    },
+    {
+      "name": "rainforest",
+      "category": "scene",
+      "descriptions": [
+        "dense green rainforest with hanging vines",
+        "a misty jungle thick with tropical plants",
+        "huge leaves and ferns in a humid rainforest"
+      ]
+    },
+    {
+      "name": "residential neighborhood",
+      "category": "scene",
+      "descriptions": [
+        "a quiet street lined with family homes",
+        "rows of houses in a suburban neighborhood",
+        "sidewalks and front yards along a residential street"
+      ]
+    },
+    {
+      "name": "restaurant",
+      "category": "scene",
+      "descriptions": [
+        "diners eating at tables in a restaurant",
+        "a waiter serving food in a restaurant",
+        "set tables and ambient lighting in a dining venue"
+      ]
+    },
+    {
+      "name": "rice paddy",
+      "category": "scene",
+      "descriptions": [
+        "terraced rice paddies on a green hillside",
+        "farmers working in a flooded rice field",
+        "young rice plants growing in water covered fields"
+      ]
+    },
+    {
+      "name": "river",
+      "category": "scene",
+      "descriptions": [
+        "a wide river flowing through the landscape",
+        "a river winding between banks of trees",
+        "boats floating down a calm river"
+      ]
+    },
+    {
+      "name": "rock arch",
+      "category": "scene",
+      "descriptions": [
+        "a natural rock arch carved by erosion",
+        "a sandstone arch against the desert sky",
+        "a stone arch formation over a trail"
+      ]
+    },
+    {
+      "name": "ruins",
+      "category": "scene",
+      "descriptions": [
+        "crumbling stone ruins of an ancient building",
+        "broken columns at an archaeological site",
+        "tourists exploring weathered ancient ruins"
+      ]
+    },
+    {
+      "name": "runway",
+      "category": "scene",
+      "descriptions": [
+        "an airplane taking off from an airport runway",
+        "a long paved runway with markings",
+        "a jet taxiing on the tarmac"
+      ]
+    },
+    {
+      "name": "sandbox",
+      "category": "scene",
+      "descriptions": [
+        "a child playing with buckets in a sandbox",
+        "toys in the sand of a play sandbox",
+        "kids digging in a sandpit at a playground"
+      ]
+    },
+    {
+      "name": "sauna",
+      "category": "scene",
+      "descriptions": [
+        "wooden benches inside a steamy sauna",
+        "people relaxing in a hot wooden sauna",
+        "steam rising over sauna stones"
+      ]
+    },
+    {
+      "name": "shed",
+      "category": "scene",
+      "descriptions": [
+        "a small garden shed with tools inside",
+        "a wooden storage shed in a backyard",
+        "rakes and pots stored in a garden hut"
+      ]
+    },
+    {
+      "name": "shopping mall",
+      "category": "scene",
+      "descriptions": [
+        "shoppers walking through a bright shopping mall",
+        "multiple floors of stores inside a mall atrium",
+        "storefronts and escalators in a shopping center"
+      ]
+    },
+    {
+      "name": "shower",
+      "category": "scene",
+      "descriptions": [
+        "water spraying from a shower head",
+        "a glass shower stall with steam",
+        "a tiled shower with running water"
+      ]
+    },
+    {
+      "name": "ski resort",
+      "category": "scene",
+      "descriptions": [
+        "ski lodges and lifts at a snowy ski resort",
+        "skiers gathering at the base of a ski slope",
+        "chairlifts rising over groomed ski runs"
+      ]
+    },
+    {
+      "name": "sky",
+      "category": "scene",
+      "descriptions": [
+        "a wide blue sky with scattered clouds",
+        "the open sky stretching above the horizon",
+        "a bright clear sky on a sunny day"
+      ]
+    },
+    {
+      "name": "skyscraper",
+      "category": "scene",
+      "descriptions": [
+        "a glass skyscraper towering into the sky",
+        "looking up at a tall high rise building",
+        "skyscrapers forming a city skyline"
+      ]
+    },
+    {
+      "name": "snowfield",
+      "category": "scene",
+      "descriptions": [
+        "a wide field completely covered in snow",
+        "untouched white snow stretching to the horizon",
+        "footprints crossing a snowy plain"
+      ]
+    },
+    {
+      "name": "snowy mountain",
+      "category": "scene",
+      "descriptions": [
+        "a mountain peak covered in snow",
+        "snowcapped mountains under a clear sky",
+        "white slopes of a snowy mountain range"
+      ]
+    },
+    {
+      "name": "soccer field",
+      "category": "scene",
+      "descriptions": [
+        "players on a green soccer pitch with goals",
+        "a soccer field with white boundary lines",
+        "kids playing football on a grass field"
+      ]
+    },
+    {
+      "name": "stable",
+      "category": "scene",
+      "descriptions": [
+        "horses standing in stalls inside a stable",
+        "a horse looking out over a stable door",
+        "hay and saddles in a horse barn"
+      ]
+    },
+    {
+      "name": "stadium",
+      "category": "scene",
+      "descriptions": [
+        "a packed stadium with tiers of spectators",
+        "floodlights over a large sports stadium",
+        "fans filling the stands of an arena bowl"
+      ]
+    },
+    {
+      "name": "stage",
+      "category": "scene",
+      "descriptions": [
+        "performers under spotlights on a stage",
+        "a theater stage with curtains and lighting",
+        "musicians performing on a concert stage"
+      ]
+    },
+    {
+      "name": "staircase",
+      "category": "scene",
+      "descriptions": [
+        "a winding staircase with a wooden railing",
+        "stone steps of a spiral staircase",
+        "a grand staircase inside a building"
+      ]
+    },
+    {
+      "name": "storefront",
+      "category": "scene",
+      "descriptions": [
+        "the glass front window of a small shop",
+        "a store entrance with signs and displays",
+        "shop windows along a commercial street"
+      ]
+    },
+    {
+      "name": "street",
+      "category": "scene",
+      "descriptions": [
+        "a city street with shops and pedestrians",
+        "cars and people moving along a busy street",
+        "a quiet street lined with lampposts"
+      ]
+    },
+    {
+      "name": "subway station",
+      "category": "scene",
+      "descriptions": [
+        "passengers waiting on a subway platform",
+        "a metro train arriving at an underground station",
+        "tiled walls and tracks of a subway stop"
+      ]
+    },
+    {
+      "name": "supermarket",
+      "category": "scene",
+      "descriptions": [
+        "aisles of groceries in a supermarket",
+        "a shopping cart in front of stocked store shelves",
+        "people shopping in a grocery store"
+      ]
+    },
+    {
+      "name": "swamp",
+      "category": "scene",
+      "descriptions": [
+        "murky water and trees in a swamp",
+        "mangrove roots rising from swampy water",
+        "mist over a marshy wetland"
+      ]
+    },
+    {
+      "name": "swimming pool",
+      "category": "scene",
+      "descriptions": [
+        "clear blue water of a swimming pool",
+        "people swimming laps in a pool",
+        "sun loungers beside an outdoor pool"
+      ]
+    },
+    {
+      "name": "synagogue",
+      "category": "scene",
+      "descriptions": [
+        "the ornate interior of a synagogue",
+        "a synagogue with arched windows and a dome",
+        "rows of seats facing the ark in a synagogue"
+      ]
+    },
+    {
+      "name": "temple",
+      "category": "scene",
+      "descriptions": [
+        "an ornate temple with carved stone towers",
+        "worshippers at a traditional asian temple",
+        "incense burning at a temple shrine"
+      ]
+    },
+    {
+      "name": "tower",
+      "category": "scene",
+      "descriptions": [
+        "a tall historic tower rising above the city",
+        "a famous landmark tower against the sky",
+        "a stone tower overlooking the surroundings"
+      ]
+    },
+    {
+      "name": "toy store",
+      "category": "scene",
+      "descriptions": [
+        "shelves packed with toys in a toy store",
+        "stuffed animals and games on display in a shop",
+        "a child looking at toys in a toy shop aisle"
+      ]
+    },
+    {
+      "name": "train station",
+      "category": "scene",
+      "descriptions": [
+        "a train waiting at a station platform",
+        "passengers boarding a train at a railway station",
+        "the arched roof of a grand train station"
+      ]
+    },
+    {
+      "name": "tree house",
+      "category": "scene",
+      "descriptions": [
+        "a wooden tree house built among branches",
+        "a ladder leading up to a tree house",
+        "children playing in a house built in a tree"
+      ]
+    },
+    {
+      "name": "tundra",
+      "category": "scene",
+      "descriptions": [
+        "flat treeless tundra stretching to the horizon",
+        "low arctic vegetation on a cold plain",
+        "a barren northern landscape under gray sky"
+      ]
+    },
+    {
+      "name": "underwater",
+      "category": "scene",
+      "descriptions": [
+        "an underwater view of fish and coral",
+        "sun rays shining down through the sea",
+        "a diver photographing life under the surface"
+      ]
+    },
+    {
+      "name": "valley",
+      "category": "scene",
+      "descriptions": [
+        "a green valley between rolling hills",
+        "a river running through a wide valley",
+        "farmland spread across a mountain valley"
+      ]
+    },
+    {
+      "name": "vegetable garden",
+      "category": "scene",
+      "descriptions": [
+        "rows of vegetables growing in a garden plot",
+        "tomato and lettuce plants in raised beds",
+        "a person tending vegetable rows in a garden"
+      ]
+    },
+    {
+      "name": "village",
+      "category": "scene",
+      "descriptions": [
+        "small houses clustered in a rural village",
+        "a quiet village lane with old cottages",
+        "a hillside village with tiled roofs"
+      ]
+    },
+    {
+      "name": "vineyard",
+      "category": "scene",
+      "descriptions": [
+        "rows of grapevines stretching across a vineyard",
+        "ripe grapes hanging on vines in a vineyard",
+        "rolling hills covered with grape vines"
+      ]
+    },
+    {
+      "name": "volcano",
+      "category": "scene",
+      "descriptions": [
+        "a volcanic cone with a crater at the top",
+        "smoke rising from an active volcano",
+        "lava rock slopes of a volcano"
+      ]
+    },
+    {
+      "name": "volleyball court",
+      "category": "scene",
+      "descriptions": [
+        "players jumping at the net on a volleyball court",
+        "a beach volleyball net on the sand",
+        "people playing volleyball over a net"
+      ]
+    },
+    {
+      "name": "waiting room",
+      "category": "scene",
+      "descriptions": [
+        "people sitting in chairs in a waiting room",
+        "rows of seats in a clinic waiting area",
+        "magazines on a table in a waiting lounge"
+      ]
+    },
+    {
+      "name": "water park",
+      "category": "scene",
+      "descriptions": [
+        "colorful water slides at a water park",
+        "people splashing in a wave pool",
+        "twisting slides above swimming pools at a water park"
+      ]
+    },
+    {
+      "name": "waterfall",
+      "category": "scene",
+      "descriptions": [
+        "a waterfall cascading over rocks",
+        "white water plunging into a pool below",
+        "mist rising at the base of a tall waterfall"
+      ]
+    },
+    {
+      "name": "wave",
+      "category": "scene",
+      "descriptions": [
+        "a large ocean wave curling and breaking",
+        "white foam of waves crashing on the shore",
+        "a big wave rising in the open sea"
+      ]
+    },
+    {
+      "name": "wheat field",
+      "category": "scene",
+      "descriptions": [
+        "golden wheat swaying in a field",
+        "ripe grain stalks under a summer sky",
+        "a farm field of golden wheat at harvest"
+      ]
+    },
+    {
+      "name": "wind farm",
+      "category": "scene",
+      "descriptions": [
+        "rows of wind turbines on open hills",
+        "tall white windmill turbines generating power",
+        "wind turbines spinning against the sky"
+      ]
+    },
+    {
+      "name": "windmill",
+      "category": "scene",
+      "descriptions": [
+        "an old wooden windmill with large blades",
+        "a traditional dutch windmill in a field",
+        "a stone windmill turning in the wind"
+      ]
+    },
+    {
+      "name": "zoo",
+      "category": "scene",
+      "descriptions": [
+        "visitors watching animals in zoo enclosures",
+        "animals behind fences at a zoo exhibit",
+        "families walking between animal habitats at a zoo"
+      ]
+    },
+    {
+      "name": "alpaca",
+      "category": "object",
+      "descriptions": [
+        "a fluffy alpaca standing in a field",
+        "an alpaca with a long neck and woolly coat"
+      ]
+    },
+    {
+      "name": "antelope",
+      "category": "object",
+      "descriptions": [
+        "an antelope with curved horns on a grassland",
+        "a herd of antelope grazing on a savanna"
+      ]
+    },
+    {
+      "name": "balloon",
+      "category": "object",
+      "descriptions": [
+        "colorful balloons floating on strings",
+        "a bunch of helium balloons at a celebration",
+        "a hot air balloon drifting in the sky"
+      ]
+    },
+    {
+      "name": "bathtub",
+      "category": "object",
+      "descriptions": [
+        "a white bathtub with a faucet in a bathroom",
+        "a bubble bath filled tub",
+        "a freestanding bathtub on a tiled floor"
+      ]
+    },
+    {
+      "name": "bee",
+      "category": "object",
+      "descriptions": [
+        "a bee collecting pollen from a flower",
+        "a close view of a honeybee on a blossom"
+      ]
+    },
+    {
+      "name": "beehive",
+      "category": "object",
+      "descriptions": [
+        "wooden beehive boxes in a field",
+        "bees swarming around a hive"
+      ]
+    },
+    {
+      "name": "beer",
+      "category": "object",
+      "descriptions": [
+        "a glass of beer with a foamy head",
+        "friends clinking beer mugs together",
+        "a cold beer bottle on a table"
+      ]
+    },
+    {
+      "name": "bookshelf",
+      "category": "object",
+      "descriptions": [
+        "a bookshelf filled with rows of books",
+        "wooden shelves stacked with colorful book spines"
+      ]
+    },
+    {
+      "name": "bread",
+      "category": "object",
+      "descriptions": [
+        "a fresh loaf of crusty bread",
+        "sliced bread on a cutting board",
+        "baked bread rolls in a basket"
+      ]
+    },
+    {
+      "name": "butterfly",
+      "category": "object",
+      "descriptions": [
+        "a butterfly with colorful wings on a flower",
+        "a monarch butterfly resting with wings spread"
+      ]
+    },
+    {
+      "name": "camel",
+      "category": "object",
+      "descriptions": [
+        "a camel with a hump standing in the desert",
+        "people riding camels across sand dunes"
+      ]
+    },
+    {
+      "name": "camera",
+      "category": "object",
+      "descriptions": [
+        "a dslr camera with a large lens",
+        "a person holding a camera up to take a photo",
+        "a vintage film camera on a table"
+      ]
+    },
+    {
+      "name": "candle",
+      "category": "object",
+      "descriptions": [
+        "a lit candle with a glowing flame",
+        "several candles burning in a dark room",
+        "a decorative candle on a holder"
+      ]
+    },
+    {
+      "name": "candy",
+      "category": "object",
+      "descriptions": [
+        "colorful wrapped candies in a pile",
+        "gummy sweets and lollipops",
+        "a jar full of assorted candy"
+      ]
+    },
+    {
+      "name": "canoe",
+      "category": "object",
+      "descriptions": [
+        "a canoe gliding across a calm lake",
+        "a wooden canoe pulled up on the shore",
+        "people paddling a canoe on a river"
+      ]
+    },
+    {
+      "name": "cheese",
+      "category": "object",
+      "descriptions": [
+        "wedges of cheese on a wooden board",
+        "a platter of assorted cheeses"
+      ]
+    },
+    {
+      "name": "cheetah",
+      "category": "object",
+      "descriptions": [
+        "a cheetah with spotted fur standing alert",
+        "a cheetah sprinting across a grassland"
+      ]
+    },
+    {
+      "name": "cherry blossom",
+      "category": "object",
+      "descriptions": [
+        "pink cherry blossom flowers on tree branches",
+        "cherry trees in full bloom along a path",
+        "petals falling from blossoming cherry trees"
+      ]
+    },
+    {
+      "name": "chicken",
+      "category": "object",
+      "descriptions": [
+        "a hen pecking at the ground",
+        "chickens in a farmyard coop",
+        "a rooster with red comb standing in a yard"
+      ]
+    },
+    {
+      "name": "christmas tree",
+      "category": "object",
+      "descriptions": [
+        "a decorated christmas tree with lights and ornaments",
+        "presents under a christmas tree",
+        "a star on top of a lit christmas tree"
+      ]
+    },
+    {
+      "name": "cocktail",
+      "category": "object",
+      "descriptions": [
+        "a colorful cocktail with a garnish in a glass",
+        "cocktails served with straws and fruit slices",
+        "a martini glass with a mixed drink"
+      ]
+    },
+    {
+      "name": "coconut",
+      "category": "object",
+      "descriptions": [
+        "a coconut cut open showing white flesh",
+        "coconuts hanging on a palm tree",
+        "a coconut drink with a straw"
+      ]
+    },
+    {
+      "name": "coffee",
+      "category": "object",
+      "descriptions": [
+        "a cup of coffee with latte art",
+        "steam rising from a mug of hot coffee",
+        "an espresso cup on a saucer"
+      ]
+    },
+    {
+      "name": "cookie",
+      "category": "object",
+      "descriptions": [
+        "chocolate chip cookies on a plate",
+        "freshly baked cookies cooling on a rack"
+      ]
+    },
+    {
+      "name": "crab",
+      "category": "object",
+      "descriptions": [
+        "a crab with claws on wet sand",
+        "a red crab walking on the beach"
+      ]
+    },
+    {
+      "name": "crib",
+      "category": "object",
+      "descriptions": [
+        "a baby sleeping in a wooden crib",
+        "a crib with soft bedding in a nursery"
+      ]
+    },
+    {
+      "name": "crocodile",
+      "category": "object",
+      "descriptions": [
+        "a crocodile lying at the edge of the water",
+        "the open jaws of a large crocodile"
+      ]
+    },
+    {
+      "name": "deer",
+      "category": "object",
+      "descriptions": [
+        "a deer with antlers standing in a forest clearing",
+        "a doe and fawn grazing at the forest edge"
+      ]
+    },
+    {
+      "name": "dessert",
+      "category": "object",
+      "descriptions": [
+        "a plated dessert with cream and fruit",
+        "a slice of layered cake on a plate",
+        "sweet pastries and puddings on a table"
+      ]
+    },
+    {
+      "name": "dinosaur",
+      "category": "object",
+      "descriptions": [
+        "a dinosaur skeleton displayed in a museum",
+        "a life size dinosaur model with sharp teeth",
+        "a toy dinosaur figure"
+      ]
+    },
+    {
+      "name": "dolphin",
+      "category": "object",
+      "descriptions": [
+        "a dolphin leaping out of the sea",
+        "dolphins swimming alongside a boat"
+      ]
+    },
+    {
+      "name": "dress",
+      "category": "object",
+      "descriptions": [
+        "a woman wearing an elegant long dress",
+        "a colorful summer dress on a hanger",
+        "a flowing gown worn at a formal event"
+      ]
+    },
+    {
+      "name": "drum",
+      "category": "object",
+      "descriptions": [
+        "a drummer playing a drum kit",
+        "hands beating a traditional drum"
+      ]
+    },
+    {
+      "name": "duck",
+      "category": "object",
+      "descriptions": [
+        "a duck floating on a pond",
+        "a mother duck with ducklings in a row"
+      ]
+    },
+    {
+      "name": "dumbbell",
+      "category": "object",
+      "descriptions": [
+        "a rack of dumbbells at a gym",
+        "a person lifting a dumbbell during a workout"
+      ]
+    },
+    {
+      "name": "eagle",
+      "category": "object",
+      "descriptions": [
+        "an eagle soaring with wings spread wide",
+        "a bald eagle perched on a branch"
+      ]
+    },
+    {
+      "name": "egg",
+      "category": "object",
+      "descriptions": [
+        "fried eggs in a pan",
+        "a carton of white eggs",
+        "boiled eggs cut in half"
+      ]
+    },
+    {
+      "name": "fireplace",
+      "category": "object",
+      "descriptions": [
+        "logs burning in a brick fireplace",
+        "a cozy living room fireplace with flames",
+        "stockings hung over a mantel with a fire below"
+      ]
+    },
+    {
+      "name": "fish",
+      "category": "object",
+      "descriptions": [
+        "a colorful fish swimming in clear water",
+        "a school of fish underwater",
+        "a freshly caught fish held up"
+      ]
+    },
+    {
+      "name": "flag",
+      "category": "object",
+      "descriptions": [
+        "a flag waving on a flagpole",
+        "a national flag fluttering in the wind"
+      ]
+    },
+    {
+      "name": "flower",
+      "category": "object",
+      "descriptions": [
+        "a colorful flower in full bloom",
+        "a bouquet of fresh flowers",
+        "wildflowers blooming in a field"
+      ]
+    },
+    {
+      "name": "flute",
+      "category": "object",
+      "descriptions": [
+        "a person playing a silver flute",
+        "a flute held sideways during a performance"
+      ]
+    },
+    {
+      "name": "fox",
+      "category": "object",
+      "descriptions": [
+        "a red fox with a bushy tail in the wild",
+        "a fox walking through snow"
+      ]
+    },
+    {
+      "name": "french fries",
+      "category": "object",
+      "descriptions": [
+        "golden french fries in a paper container",
+        "crispy fries with ketchup on the side"
+      ]
+    },
+    {
+      "name": "frog",
+      "category": "object",
+      "descriptions": [
+        "a green frog sitting on a lily pad",
+        "a close view of a frog with bulging eyes"
+      ]
+    },
+    {
+      "name": "fruit",
+      "category": "object",
+      "descriptions": [
+        "a bowl of mixed fresh fruit",
+        "assorted fruits displayed at a market",
+        "sliced tropical fruits on a plate"
+      ]
+    },
+    {
+      "name": "glasses",
+      "category": "object",
+      "descriptions": [
+        "a pair of eyeglasses folded on a table",
+        "a person wearing round reading glasses"
+      ]
+    },
+    {
+      "name": "goat",
+      "category": "object",
+      "descriptions": [
+        "a goat with horns standing on rocks",
+        "goats grazing on a hillside"
+      ]
+    },
+    {
+      "name": "gondola",
+      "category": "object",
+      "descriptions": [
+        "a gondolier rowing a gondola down a canal",
+        "black gondola boats moored in venice"
+      ]
+    },
+    {
+      "name": "grape",
+      "category": "object",
+      "descriptions": [
+        "a bunch of purple grapes on the vine",
+        "green grapes in a bowl"
+      ]
+    },
+    {
+      "name": "guitar",
+      "category": "object",
+      "descriptions": [
+        "a person strumming an acoustic guitar",
+        "an electric guitar on a stand",
+        "hands playing chords on a guitar neck"
+      ]
+    },
+    {
+      "name": "hamburger",
+      "category": "object",
+      "descriptions": [
+        "a hamburger with lettuce and cheese in a bun",
+        "a juicy burger served with fries"
+      ]
+    },
+    {
+      "name": "hamster",
+      "category": "object",
+      "descriptions": [
+        "a hamster stuffing food into its cheeks",
+        "a small hamster in a cage with bedding"
+      ]
+    },
+    {
+      "name": "hat",
+      "category": "object",
+      "descriptions": [
+        "a person wearing a wide brimmed hat",
+        "a straw hat resting on a chair",
+        "a knitted winter hat with a pompom"
+      ]
+    },
+    {
+      "name": "headphones",
+      "category": "object",
+      "descriptions": [
+        "a person wearing large over ear headphones",
+        "headphones resting around someone's neck"
+      ]
+    },
+    {
+      "name": "hedgehog",
+      "category": "object",
+      "descriptions": [
+        "a small hedgehog with spines curled up",
+        "a hedgehog walking through grass"
+      ]
+    },
+    {
+      "name": "helicopter",
+      "category": "object",
+      "descriptions": [
+        "a helicopter hovering with spinning rotors",
+        "a helicopter landing on a helipad"
+      ]
+    },
+    {
+      "name": "helmet",
+      "category": "object",
+      "descriptions": [
+        "a person wearing a safety helmet",
+        "a motorcycle helmet resting on a seat"
+      ]
+    },
+    {
+      "name": "high heels",
+      "category": "object",
+      "descriptions": [
+        "a pair of high heeled shoes",
+        "a woman walking in stiletto heels"
+      ]
+    },
+    {
+      "name": "hippopotamus",
+      "category": "object",
+      "descriptions": [
+        "a hippo submerged in water with eyes showing",
+        "a hippopotamus with a huge open mouth"
+      ]
+    },
+    {
+      "name": "ice cream",
+      "category": "object",
+      "descriptions": [
+        "scoops of ice cream in a waffle cone",
+        "a sundae with ice cream and toppings",
+        "a child licking an ice cream cone"
+      ]
+    },
+    {
+      "name": "jellyfish",
+      "category": "object",
+      "descriptions": [
+        "a translucent jellyfish drifting in dark water",
+        "glowing jellyfish with trailing tentacles"
+      ]
+    },
+    {
+      "name": "jet ski",
+      "category": "object",
+      "descriptions": [
+        "a person riding a jet ski across the water",
+        "a jet ski spraying water at speed"
+      ]
+    },
+    {
+      "name": "kangaroo",
+      "category": "object",
+      "descriptions": [
+        "a kangaroo standing upright in the outback",
+        "a kangaroo hopping with a joey in its pouch"
+      ]
+    },
+    {
+      "name": "koala",
+      "category": "object",
+      "descriptions": [
+        "a koala clinging to a eucalyptus tree",
+        "a sleepy koala resting on a branch"
+      ]
+    },
+    {
+      "name": "ladybug",
+      "category": "object",
+      "descriptions": [
+        "a red ladybug with black spots on a leaf",
+        "a ladybug crawling along a plant stem"
+      ]
+    },
+    {
+      "name": "lantern",
+      "category": "object",
+      "descriptions": [
+        "a glowing paper lantern hanging at night",
+        "an old metal lantern with a candle inside",
+        "rows of festive lanterns strung overhead"
+      ]
+    },
+    {
+      "name": "lemon",
+      "category": "object",
+      "descriptions": [
+        "bright yellow lemons with green leaves",
+        "lemon slices beside a glass of lemonade"
+      ]
+    },
+    {
+      "name": "leopard",
+      "category": "object",
+      "descriptions": [
+        "a leopard with spotted fur lying on a branch",
+        "a leopard prowling through tall grass"
+      ]
+    },
+    {
+      "name": "life jacket",
+      "category": "object",
+      "descriptions": [
+        "a person wearing an orange life jacket on a boat",
+        "life vests hanging in a row"
+      ]
+    },
+    {
+      "name": "limousine",
+      "category": "object",
+      "descriptions": [
+        "a long stretch limousine parked at an event",
+        "a black limo waiting outside a venue"
+      ]
+    },
+    {
+      "name": "lion",
+      "category": "object",
+      "descriptions": [
+        "a male lion with a thick mane",
+        "a lioness resting in the savanna grass",
+        "a lion lying on a rock at a wildlife park"
+      ]
+    },
+    {
+      "name": "lizard",
+      "category": "object",
+      "descriptions": [
+        "a lizard basking on a warm rock",
+        "a green lizard clinging to a branch"
+      ]
+    },
+    {
+      "name": "lobster",
+      "category": "object",
+      "descriptions": [
+        "a red lobster with large claws on a plate",
+        "a live lobster in a tank"
+      ]
+    },
+    {
+      "name": "mango",
+      "category": "object",
+      "descriptions": [
+        "ripe yellow mangoes in a basket",
+        "sliced mango showing orange flesh"
+      ]
+    },
+    {
+      "name": "microphone",
+      "category": "object",
+      "descriptions": [
+        "a singer holding a microphone on stage",
+        "a studio microphone on a stand"
+      ]
+    },
+    {
+      "name": "mirror",
+      "category": "object",
+      "descriptions": [
+        "a framed mirror hanging on a wall",
+        "a person's reflection in a bathroom mirror"
+      ]
+    },
+    {
+      "name": "monkey",
+      "category": "object",
+      "descriptions": [
+        "a monkey sitting on a tree branch",
+        "a monkey eating fruit with its hands",
+        "monkeys grooming each other"
+      ]
+    },
+    {
+      "name": "mushroom",
+      "category": "object",
+      "descriptions": [
+        "wild mushrooms growing on the forest floor",
+        "a red capped mushroom among fallen leaves"
+      ]
+    },
+    {
+      "name": "necklace",
+      "category": "object",
+      "descriptions": [
+        "a gold necklace with a pendant",
+        "a woman wearing a beaded necklace"
+      ]
+    },
+    {
+      "name": "ostrich",
+      "category": "object",
+      "descriptions": [
+        "an ostrich with a long neck standing tall",
+        "an ostrich running across dry grassland"
+      ]
+    },
+    {
+      "name": "otter",
+      "category": "object",
+      "descriptions": [
+        "an otter floating on its back in the water",
+        "a sea otter holding food with its paws"
+      ]
+    },
+    {
+      "name": "owl",
+      "category": "object",
+      "descriptions": [
+        "an owl with large round eyes perched on a branch",
+        "a white owl staring straight at the camera"
+      ]
+    },
+    {
+      "name": "palm tree",
+      "category": "object",
+      "descriptions": [
+        "tall palm trees against a blue sky",
+        "a row of palm trees along a tropical beach"
+      ]
+    },
+    {
+      "name": "pancake",
+      "category": "object",
+      "descriptions": [
+        "a stack of pancakes with syrup dripping down",
+        "pancakes topped with berries and butter"
+      ]
+    },
+    {
+      "name": "panda",
+      "category": "object",
+      "descriptions": [
+        "a giant panda eating bamboo",
+        "a black and white panda lying on grass"
+      ]
+    },
+    {
+      "name": "parachute",
+      "category": "object",
+      "descriptions": [
+        "a skydiver descending under an open parachute",
+        "a colorful parachute canopy in the sky"
+      ]
+    },
+    {
+      "name": "parrot",
+      "category": "object",
+      "descriptions": [
+        "a colorful parrot with bright feathers",
+        "a parrot perched on a person's shoulder"
+      ]
+    },
+    {
+      "name": "pasta",
+      "category": "object",
+      "descriptions": [
+        "a plate of spaghetti with sauce",
+        "fresh pasta noodles being tossed in a pan"
+      ]
+    },
+    {
+      "name": "pastry",
+      "category": "object",
+      "descriptions": [
+        "flaky golden pastries on a tray",
+        "a croissant on a plate with coffee"
+      ]
+    },
+    {
+      "name": "penguin",
+      "category": "object",
+      "descriptions": [
+        "a penguin standing on ice",
+        "a group of penguins waddling together"
+      ]
+    },
+    {
+      "name": "piano",
+      "category": "object",
+      "descriptions": [
+        "hands playing the keys of a piano",
+        "a grand piano on a stage",
+        "a child practicing at an upright piano"
+      ]
+    },
+    {
+      "name": "picnic basket",
+      "category": "object",
+      "descriptions": [
+        "a wicker picnic basket on a blanket",
+        "an open picnic basket packed with food"
+      ]
+    },
+    {
+      "name": "pig",
+      "category": "object",
+      "descriptions": [
+        "a pink pig in a muddy pen",
+        "a piglet standing on a farm"
+      ]
+    },
+    {
+      "name": "pineapple",
+      "category": "object",
+      "descriptions": [
+        "a whole pineapple with spiky leaves",
+        "pineapple slices on a plate"
+      ]
+    },
+    {
+      "name": "pool table",
+      "category": "object",
+      "descriptions": [
+        "colored balls on a green pool table",
+        "a person lining up a shot with a cue stick"
+      ]
+    },
+    {
+      "name": "popcorn",
+      "category": "object",
+      "descriptions": [
+        "a bucket overflowing with popcorn",
+        "popcorn kernels popped and buttery"
+      ]
+    },
+    {
+      "name": "pumpkin",
+      "category": "object",
+      "descriptions": [
+        "orange pumpkins in a field",
+        "a carved pumpkin glowing with candlelight",
+        "pumpkins stacked at a harvest market"
+      ]
+    },
+    {
+      "name": "rabbit",
+      "category": "object",
+      "descriptions": [
+        "a rabbit with long ears sitting in grass",
+        "a fluffy white bunny nibbling a vegetable"
+      ]
+    },
+    {
+      "name": "raccoon",
+      "category": "object",
+      "descriptions": [
+        "a raccoon with a black mask on its face",
+        "a raccoon climbing on a fence at night"
+      ]
+    },
+    {
+      "name": "rangoli",
+      "category": "object",
+      "descriptions": [
+        "a colorful rangoli pattern drawn on the floor",
+        "an intricate design made of colored powder and petals",
+        "a decorative rangoli with flowers and diyas at an entrance"
+      ]
+    },
+    {
+      "name": "rhinoceros",
+      "category": "object",
+      "descriptions": [
+        "a rhinoceros with a large horn grazing",
+        "a rhino walking across a dusty plain"
+      ]
+    },
+    {
+      "name": "rocket",
+      "category": "object",
+      "descriptions": [
+        "a rocket launching with flames and smoke",
+        "a tall rocket standing on a launch pad"
+      ]
+    },
+    {
+      "name": "roller skates",
+      "category": "object",
+      "descriptions": [
+        "a person skating in four wheeled roller skates",
+        "a pair of retro roller skates"
+      ]
+    },
+    {
+      "name": "rose",
+      "category": "object",
+      "descriptions": [
+        "a single red rose in bloom",
+        "a bouquet of roses wrapped in paper"
+      ]
+    },
+    {
+      "name": "salad",
+      "category": "object",
+      "descriptions": [
+        "a fresh green salad in a bowl",
+        "a salad with tomatoes and leafy greens"
+      ]
+    },
+    {
+      "name": "saxophone",
+      "category": "object",
+      "descriptions": [
+        "a person playing a brass saxophone",
+        "a saxophone gleaming under stage lights"
+      ]
+    },
+    {
+      "name": "sculpture",
+      "category": "object",
+      "descriptions": [
+        "a carved stone sculpture on display",
+        "a bronze statue in a public square",
+        "an abstract sculpture in a gallery"
+      ]
+    },
+    {
+      "name": "seal",
+      "category": "object",
+      "descriptions": [
+        "a seal lying on a rocky shore",
+        "a seal poking its head out of the water"
+      ]
+    },
+    {
+      "name": "shark",
+      "category": "object",
+      "descriptions": [
+        "a shark swimming with its fin above water",
+        "a great white shark underwater with sharp teeth"
+      ]
+    },
+    {
+      "name": "snail",
+      "category": "object",
+      "descriptions": [
+        "a snail with a spiral shell on a leaf",
+        "a snail slowly crossing a wet path"
+      ]
+    },
+    {
+      "name": "snake",
+      "category": "object",
+      "descriptions": [
+        "a coiled snake with patterned scales",
+        "a snake slithering through grass"
+      ]
+    },
+    {
+      "name": "snowman",
+      "category": "object",
+      "descriptions": [
+        "a snowman with a carrot nose and scarf",
+        "children building a snowman in the yard"
+      ]
+    },
+    {
+      "name": "spider",
+      "category": "object",
+      "descriptions": [
+        "a spider sitting in the center of its web",
+        "a close view of a hairy spider"
+      ]
+    },
+    {
+      "name": "squirrel",
+      "category": "object",
+      "descriptions": [
+        "a squirrel holding a nut in its paws",
+        "a squirrel climbing a tree trunk"
+      ]
+    },
+    {
+      "name": "starfish",
+      "category": "object",
+      "descriptions": [
+        "an orange starfish on wet sand",
+        "a starfish clinging to a rock in a tide pool"
+      ]
+    },
+    {
+      "name": "strawberry",
+      "category": "object",
+      "descriptions": [
+        "ripe red strawberries with green stems",
+        "a basket of fresh picked strawberries"
+      ]
+    },
+    {
+      "name": "suit",
+      "category": "object",
+      "descriptions": [
+        "a man wearing a tailored business suit",
+        "a suit jacket and tie on a hanger"
+      ]
+    },
+    {
+      "name": "sunflower",
+      "category": "object",
+      "descriptions": [
+        "a bright yellow sunflower facing the sun",
+        "a field of tall blooming sunflowers"
+      ]
+    },
+    {
+      "name": "sunglasses",
+      "category": "object",
+      "descriptions": [
+        "a person wearing dark sunglasses",
+        "a pair of sunglasses resting on a table"
+      ]
+    },
+    {
+      "name": "sushi",
+      "category": "object",
+      "descriptions": [
+        "sushi rolls arranged on a wooden board",
+        "nigiri sushi with chopsticks and soy sauce"
+      ]
+    },
+    {
+      "name": "swan",
+      "category": "object",
+      "descriptions": [
+        "a white swan gliding on a lake",
+        "a swan with curved neck reflected in water"
+      ]
+    },
+    {
+      "name": "taco",
+      "category": "object",
+      "descriptions": [
+        "tacos filled with meat and vegetables",
+        "a hand holding a folded taco"
+      ]
+    },
+    {
+      "name": "tea",
+      "category": "object",
+      "descriptions": [
+        "a cup of tea with steam rising",
+        "tea being poured from a teapot into a cup"
+      ]
+    },
+    {
+      "name": "tent",
+      "category": "object",
+      "descriptions": [
+        "a dome tent pitched on grass",
+        "a glowing tent lit from inside at night"
+      ]
+    },
+    {
+      "name": "tiger",
+      "category": "object",
+      "descriptions": [
+        "a tiger with orange and black stripes",
+        "a tiger walking through jungle grass",
+        "a tiger cooling off in the water"
+      ]
+    },
+    {
+      "name": "toy",
+      "category": "object",
+      "descriptions": [
+        "colorful toys scattered on the floor",
+        "a child playing with building blocks",
+        "stuffed animals piled on a bed"
+      ]
+    },
+    {
+      "name": "tree",
+      "category": "object",
+      "descriptions": [
+        "a large tree with a wide green canopy",
+        "a lone tree standing in an open field",
+        "the thick trunk and branches of an old tree"
+      ]
+    },
+    {
+      "name": "trumpet",
+      "category": "object",
+      "descriptions": [
+        "a person playing a shiny brass trumpet",
+        "a trumpet held up during a performance"
+      ]
+    },
+    {
+      "name": "turkey",
+      "category": "object",
+      "descriptions": [
+        "a turkey with fanned tail feathers",
+        "a roasted turkey on a serving platter"
+      ]
+    },
+    {
+      "name": "turtle",
+      "category": "object",
+      "descriptions": [
+        "a turtle with a patterned shell walking on sand",
+        "a sea turtle swimming over a reef"
+      ]
+    },
+    {
+      "name": "vegetable",
+      "category": "object",
+      "descriptions": [
+        "a pile of fresh mixed vegetables",
+        "chopped vegetables on a cutting board",
+        "baskets of vegetables at a farm stand"
+      ]
+    },
+    {
+      "name": "violin",
+      "category": "object",
+      "descriptions": [
+        "a violinist playing with a bow",
+        "a violin resting on sheet music"
+      ]
+    },
+    {
+      "name": "waffle",
+      "category": "object",
+      "descriptions": [
+        "a golden waffle topped with berries and syrup",
+        "waffles with a square grid pattern on a plate"
+      ]
+    },
+    {
+      "name": "watch",
+      "category": "object",
+      "descriptions": [
+        "a wristwatch with a leather strap",
+        "a close view of a watch face and hands"
+      ]
+    },
+    {
+      "name": "watermelon",
+      "category": "object",
+      "descriptions": [
+        "slices of red watermelon with black seeds",
+        "a whole watermelon cut in half"
+      ]
+    },
+    {
+      "name": "whale",
+      "category": "object",
+      "descriptions": [
+        "a whale breaching out of the ocean",
+        "the tail fluke of a whale above the water"
+      ]
+    },
+    {
+      "name": "wheelchair",
+      "category": "object",
+      "descriptions": [
+        "a person sitting in a wheelchair",
+        "an empty wheelchair in a hallway"
+      ]
+    },
+    {
+      "name": "wine",
+      "category": "object",
+      "descriptions": [
+        "red wine being poured into a glass",
+        "wine glasses raised in a toast",
+        "a wine bottle beside filled glasses"
+      ]
+    },
+    {
+      "name": "baby shower",
+      "category": "event",
+      "descriptions": [
+        "a baby shower party with pastel balloons and gifts",
+        "a pregnant woman celebrating with friends and presents",
+        "a decorated table with baby themed cake and gifts"
+      ]
+    },
+    {
+      "name": "barbecue",
+      "category": "event",
+      "descriptions": [
+        "food grilling over a smoky barbecue",
+        "a person flipping skewers on an outdoor grill",
+        "friends gathered around a backyard barbecue"
+      ]
+    },
+    {
+      "name": "birthday",
+      "category": "event",
+      "descriptions": [
+        "a person blowing out candles on a birthday cake",
+        "a birthday party with balloons and streamers",
+        "children in party hats around a birthday cake"
+      ]
+    },
+    {
+      "name": "bonfire",
+      "category": "event",
+      "descriptions": [
+        "people gathered around a large bonfire at night",
+        "tall flames of a bonfire against the dark",
+        "friends sitting around a campfire roasting food on sticks"
+      ]
+    },
+    {
+      "name": "carnival",
+      "category": "event",
+      "descriptions": [
+        "performers in feathered costumes dancing at a carnival",
+        "a carnival parade with elaborate colorful costumes",
+        "dancers and drummers in a street carnival celebration"
+      ]
+    },
+    {
+      "name": "christmas",
+      "category": "event",
+      "descriptions": [
+        "a decorated christmas tree with lights and ornaments",
+        "people opening presents around a christmas tree",
+        "a living room decorated with stockings and christmas lights",
+        "santa hats and festive red and green decorations"
+      ]
+    },
+    {
+      "name": "circus",
+      "category": "event",
+      "descriptions": [
+        "acrobats performing inside a circus tent",
+        "a circus ring with performers under spotlights",
+        "a big top tent with an audience watching a show"
+      ]
+    },
+    {
+      "name": "concert",
+      "category": "event",
+      "descriptions": [
+        "a crowd with raised hands at a live concert",
+        "a band performing on stage under bright lights",
+        "a singer on stage in front of a large audience"
+      ]
+    },
+    {
+      "name": "cricket",
+      "category": "event",
+      "descriptions": [
+        "a batsman striking a cricket ball on a pitch",
+        "a bowler delivering a ball in a cricket match",
+        "children playing cricket in the street with a bat",
+        "a cricket match underway on an oval green field"
+      ]
+    },
+    {
+      "name": "dance",
+      "category": "event",
+      "descriptions": [
+        "dancers performing a routine on stage",
+        "a couple dancing together at a celebration",
+        "a group dance performance in matching costumes"
+      ]
+    },
+    {
+      "name": "diwali",
+      "category": "event",
+      "descriptions": [
+        "rows of glowing clay oil lamps lit for diwali",
+        "a home decorated with strings of lights and burning diyas",
+        "people lighting sparklers during a diwali celebration",
+        "a rangoli surrounded by small oil lamps at night"
+      ]
+    },
+    {
+      "name": "durga puja",
+      "category": "event",
+      "descriptions": [
+        "an ornate pandal with an idol of the goddess durga",
+        "a durga idol with many arms decorated with ornaments",
+        "crowds visiting a decorated festival pandal at night"
+      ]
+    },
+    {
+      "name": "easter",
+      "category": "event",
+      "descriptions": [
+        "children hunting for painted easter eggs in a garden",
+        "a basket filled with decorated easter eggs",
+        "colorful dyed eggs hidden in spring grass"
+      ]
+    },
+    {
+      "name": "eid",
+      "category": "event",
+      "descriptions": [
+        "people in traditional clothes embracing in greeting on eid",
+        "a table of dates and sweets for an eid feast",
+        "crescent moon and lantern decorations for eid"
+      ]
+    },
+    {
+      "name": "engagement",
+      "category": "event",
+      "descriptions": [
+        "a person proposing on one knee with a ring",
+        "a couple showing off an engagement ring",
+        "an engagement ring being slipped onto a finger"
+      ]
+    },
+    {
+      "name": "festival",
+      "category": "event",
+      "descriptions": [
+        "a large outdoor festival crowd with flags and tents",
+        "colorful decorations in a crowded festival street",
+        "people celebrating together at an outdoor festival"
+      ]
+    },
+    {
+      "name": "fireworks",
+      "category": "event",
+      "descriptions": [
+        "colorful fireworks bursting in the night sky",
+        "a fireworks display reflected over water",
+        "sparkling fireworks above a city skyline"
+      ]
+    },
+    {
+      "name": "fishing",
+      "category": "event",
+      "descriptions": [
+        "a person casting a fishing rod at a lake",
+        "an angler holding up a freshly caught fish",
+        "fishing rods set up at the edge of the water"
+      ]
+    },
+    {
+      "name": "ganesh chaturthi",
+      "category": "event",
+      "descriptions": [
+        "a decorated idol of the elephant headed god ganesha",
+        "people carrying a ganesha idol in a street procession",
+        "a ganesha statue adorned with flowers and garlands"
+      ]
+    },
+    {
+      "name": "graduation",
+      "category": "event",
+      "descriptions": [
+        "graduates in caps and gowns at a ceremony",
+        "a student throwing a graduation cap into the air",
+        "a graduate holding a diploma in a gown"
+      ]
+    },
+    {
+      "name": "halloween",
+      "category": "event",
+      "descriptions": [
+        "children in costumes trick or treating at night",
+        "carved jack o lantern pumpkins glowing on a porch",
+        "people dressed in spooky halloween costumes at a party"
+      ]
+    },
+    {
+      "name": "hanukkah",
+      "category": "event",
+      "descriptions": [
+        "a lit menorah with candles in a window",
+        "a family lighting hanukkah candles together",
+        "a nine branched menorah glowing in a dark room"
+      ]
+    },
+    {
+      "name": "hiking",
+      "category": "event",
+      "descriptions": [
+        "hikers with backpacks walking a mountain trail",
+        "a person trekking up a rocky path with poles",
+        "a group hiking along a ridge with views behind them"
+      ]
+    },
+    {
+      "name": "holi",
+      "category": "event",
+      "descriptions": [
+        "people covered in bright colored powder celebrating holi",
+        "clouds of pink and green powder thrown into the air",
+        "faces and clothes smeared with vivid holi colors"
+      ]
+    },
+    {
+      "name": "horseback riding",
+      "category": "event",
+      "descriptions": [
+        "a person riding a horse along a trail",
+        "a rider in a helmet trotting on horseback",
+        "someone galloping on a horse across a field"
+      ]
+    },
+    {
+      "name": "kayaking",
+      "category": "event",
+      "descriptions": [
+        "a person paddling a kayak on a river",
+        "a bright kayak cutting through rapids",
+        "kayakers gliding across calm water"
+      ]
+    },
+    {
+      "name": "lunar new year",
+      "category": "event",
+      "descriptions": [
+        "red paper lanterns strung across a street",
+        "a dragon dance performing through a crowd",
+        "red envelopes and golden new year decorations"
+      ]
+    },
+    {
+      "name": "marathon",
+      "category": "event",
+      "descriptions": [
+        "runners wearing race bibs on a city street",
+        "a dense crowd of runners in a road race",
+        "a runner crossing the finish line with arms raised"
+      ]
+    },
+    {
+      "name": "mehndi",
+      "category": "event",
+      "descriptions": [
+        "intricate henna patterns drawn on a woman's hands",
+        "an artist applying mehndi designs on a bride's palms",
+        "hands and arms decorated with dark henna designs"
+      ]
+    },
+    {
+      "name": "navratri",
+      "category": "event",
+      "descriptions": [
+        "people in colorful traditional dress dancing garba in circles",
+        "dancers striking decorated sticks in a dandiya dance",
+        "a festival ground crowded with garba dancers at night"
+      ]
+    },
+    {
+      "name": "new year",
+      "category": "event",
+      "descriptions": [
+        "fireworks bursting over a city at midnight",
+        "people toasting with champagne and confetti falling",
+        "a countdown celebration with balloons and streamers"
+      ]
+    },
+    {
+      "name": "parade",
+      "category": "event",
+      "descriptions": [
+        "decorated floats moving down a street in a parade",
+        "a marching band in uniform during a parade",
+        "crowds lining a street watching a parade pass"
+      ]
+    },
+    {
+      "name": "party",
+      "category": "event",
+      "descriptions": [
+        "friends celebrating at a party with drinks",
+        "a crowded room with balloons and party decorations",
+        "people dancing and laughing at a house party"
+      ]
+    },
+    {
+      "name": "picnic",
+      "category": "event",
+      "descriptions": [
+        "food spread on a picnic blanket in a park",
+        "a family having a picnic on the grass",
+        "friends sharing food outdoors on a checkered blanket"
+      ]
+    },
+    {
+      "name": "prom",
+      "category": "event",
+      "descriptions": [
+        "teenagers in formal dresses and suits at a school dance",
+        "a young couple posing in formal wear with a corsage",
+        "a decorated hall with students dancing in gowns"
+      ]
+    },
+    {
+      "name": "rock climbing",
+      "category": "event",
+      "descriptions": [
+        "a climber scaling a steep rock face with ropes",
+        "a person bouldering up a climbing wall",
+        "a climber reaching for a hold on a cliff"
+      ]
+    },
+    {
+      "name": "safari",
+      "category": "event",
+      "descriptions": [
+        "tourists in an open safari jeep watching wild animals",
+        "a game drive vehicle near elephants on a savanna",
+        "travelers photographing wildlife from a safari truck"
+      ]
+    },
+    {
+      "name": "scuba diving",
+      "category": "event",
+      "descriptions": [
+        "a scuba diver swimming among coral and fish",
+        "a diver underwater with a tank and bubbles rising",
+        "a person in a wetsuit and mask exploring a reef"
+      ]
+    },
+    {
+      "name": "skiing",
+      "category": "event",
+      "descriptions": [
+        "a skier carving down a snowy slope",
+        "a person on skis kicking up powder snow",
+        "skiers riding a chairlift over white slopes"
+      ]
+    },
+    {
+      "name": "snowboarding",
+      "category": "event",
+      "descriptions": [
+        "a snowboarder carving down a mountain slope",
+        "a person mid jump with a snowboard in the air",
+        "a snowboarder in goggles riding through snow"
+      ]
+    },
+    {
+      "name": "surfing",
+      "category": "event",
+      "descriptions": [
+        "a surfer riding a breaking wave",
+        "a person carrying a surfboard along the beach",
+        "a surfer cutting across a wave with spray flying"
+      ]
+    },
+    {
+      "name": "thanksgiving",
+      "category": "event",
+      "descriptions": [
+        "a family gathered around a table with a roast turkey",
+        "a thanksgiving dinner table with autumn decorations",
+        "a large roasted turkey being carved for dinner"
+      ]
+    },
+    {
+      "name": "valentines day",
+      "category": "event",
+      "descriptions": [
+        "a bouquet of red roses with a heart shaped gift",
+        "a romantic candlelit dinner for two",
+        "heart shaped balloons and chocolates"
+      ]
+    },
+    {
+      "name": "wedding",
+      "category": "event",
+      "descriptions": [
+        "a bride and groom exchanging vows at a wedding ceremony",
+        "a bride in a wedding dress holding a bouquet",
+        "guests celebrating around a newlywed couple",
+        "an indian bride and groom in ornate red and gold wedding attire"
+      ]
+    },
+    {
+      "name": "yoga",
+      "category": "event",
+      "descriptions": [
+        "a person holding a yoga pose on a mat",
+        "a group yoga class stretching in unison",
+        "someone sitting cross legged meditating on a yoga mat"
+      ]
+    },
+    {
+      "name": "aerial view",
+      "category": "attribute",
+      "descriptions": [
+        "an aerial view looking straight down from above",
+        "a landscape photographed from a drone high in the air",
+        "a birds eye view of buildings and roads below"
+      ]
+    },
+    {
+      "name": "autumn",
+      "category": "attribute",
+      "descriptions": [
+        "trees with orange and red autumn leaves",
+        "fallen yellow leaves covering the ground",
+        "a park glowing in warm fall colors"
+      ]
+    },
+    {
+      "name": "clouds",
+      "category": "attribute",
+      "descriptions": [
+        "white fluffy clouds in a blue sky",
+        "dramatic storm clouds filling the sky",
+        "a sky full of scattered clouds"
+      ]
+    },
+    {
+      "name": "fog",
+      "category": "attribute",
+      "descriptions": [
+        "thick fog blanketing the landscape",
+        "trees fading into heavy gray mist",
+        "a foggy morning with low visibility"
+      ]
+    },
+    {
+      "name": "group photo",
+      "category": "attribute",
+      "descriptions": [
+        "a large group of people posing together for a photo",
+        "friends standing in rows smiling at the camera",
+        "a family posed together looking at the camera"
+      ]
+    },
+    {
+      "name": "lightning",
+      "category": "attribute",
+      "descriptions": [
+        "a lightning bolt striking from a dark storm sky",
+        "branched lightning lighting up night clouds"
+      ]
+    },
+    {
+      "name": "moon",
+      "category": "attribute",
+      "descriptions": [
+        "a full moon glowing in the night sky",
+        "the moon rising over a dark landscape",
+        "a bright moon among night clouds"
+      ]
+    },
+    {
+      "name": "night",
+      "category": "attribute",
+      "descriptions": [
+        "a scene photographed at night in the dark",
+        "city lights glowing against the darkness",
+        "a dark sky over dimly lit surroundings"
+      ]
+    },
+    {
+      "name": "rain",
+      "category": "attribute",
+      "descriptions": [
+        "rain falling on a wet street",
+        "raindrops streaking down a window",
+        "people holding umbrellas in the rain"
+      ]
+    },
+    {
+      "name": "rainbow",
+      "category": "attribute",
+      "descriptions": [
+        "a rainbow arching across the sky",
+        "a bright rainbow over a landscape after rain"
+      ]
+    },
+    {
+      "name": "reflection",
+      "category": "attribute",
+      "descriptions": [
+        "a mirror reflection on still water",
+        "mountains reflected in a calm lake",
+        "a building reflected in glass and water"
+      ]
+    },
+    {
+      "name": "selfie",
+      "category": "attribute",
+      "descriptions": [
+        "a person taking a selfie at arm's length",
+        "a close self portrait taken with a phone camera",
+        "friends leaning their heads together for a selfie"
+      ]
+    },
+    {
+      "name": "silhouette",
+      "category": "attribute",
+      "descriptions": [
+        "a dark silhouette of a person against a bright sky",
+        "figures outlined in black against the light",
+        "a tree silhouetted against a glowing sunset"
+      ]
+    },
+    {
+      "name": "snow",
+      "category": "attribute",
+      "descriptions": [
+        "fresh snow covering the ground and trees",
+        "snowflakes falling in a white winter scene",
+        "everything blanketed in deep snow"
+      ]
+    },
+    {
+      "name": "stars",
+      "category": "attribute",
+      "descriptions": [
+        "a night sky filled with stars",
+        "the milky way stretching across a dark sky",
+        "stars glittering above a silhouetted horizon"
+      ]
+    },
+    {
+      "name": "sunrise",
+      "category": "attribute",
+      "descriptions": [
+        "the sun rising over the horizon in soft morning light",
+        "early golden light breaking over the landscape at dawn",
+        "a pale morning sky with the sun just appearing"
+      ]
+    },
+    {
+      "name": "sunset",
+      "category": "attribute",
+      "descriptions": [
+        "an orange sunset glowing over the horizon",
+        "the sun setting behind clouds in pink and orange",
+        "a landscape silhouetted against a sunset sky"
+      ]
+    }
+  ]
+}

--- a/backend/app/database/faces.py
+++ b/backend/app/database/faces.py
@@ -163,7 +163,7 @@ def get_all_face_embeddings():
                 m.name as tag_name
             FROM faces f
             JOIN images i ON f.image_id=i.id
-            LEFT JOIN image_classes ic ON i.id = ic.image_id
+            LEFT JOIN image_classes_display ic ON i.id = ic.image_id
             LEFT JOIN mappings m ON ic.class_id = m.class_id
         """
         )

--- a/backend/app/database/image_embeddings.py
+++ b/backend/app/database/image_embeddings.py
@@ -23,6 +23,14 @@ def db_create_image_embeddings_table():
             "CREATE INDEX IF NOT EXISTS ix_image_embeddings_model_version "
             "ON image_embeddings(model_version)"
         )
+        # scored_signature: which vocabulary/label state this image's semantic
+        # scores were computed against (NULL = never scored). Guarded ALTER
+        # for databases that predate the column.
+        cursor.execute("PRAGMA table_info(image_embeddings)")
+        if "scored_signature" not in {row[1] for row in cursor.fetchall()}:
+            cursor.execute(
+                "ALTER TABLE image_embeddings ADD COLUMN scored_signature TEXT"
+            )
         conn.commit()
     finally:
         if conn:
@@ -88,6 +96,35 @@ def db_get_all_embeddings(model_version: str) -> Tuple[List[str], np.ndarray]:
             embeddings_list.append(np.frombuffer(blob, dtype=np.float32))
 
         matrix = np.vstack(embeddings_list)
+        return image_ids, matrix
+    finally:
+        if conn:
+            conn.close()
+
+
+def db_get_embeddings_needing_scoring(
+    model_version: str, signature: str, limit: int
+) -> Tuple[List[str], np.ndarray]:
+    """Embeddings whose semantic scores are missing or from another
+    vocabulary/label state. Returns up to `limit` (image_ids, matrix)."""
+    conn = None
+    try:
+        conn = _connect()
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT image_id, embedding FROM image_embeddings
+            WHERE model_version = ? AND IFNULL(scored_signature, '') != ?
+            LIMIT ?
+            """,
+            (model_version, signature, limit),
+        )
+        rows = cursor.fetchall()
+        if not rows:
+            return [], np.empty((0, 0), dtype=np.float32)
+
+        image_ids = [image_id for image_id, _ in rows]
+        matrix = np.vstack([np.frombuffer(blob, dtype=np.float32) for _, blob in rows])
         return image_ids, matrix
     finally:
         if conn:

--- a/backend/app/database/images.py
+++ b/backend/app/database/images.py
@@ -100,12 +100,20 @@ def db_create_images_table() -> None:
         CREATE TABLE IF NOT EXISTS image_classes (
             image_id TEXT,
             class_id INTEGER,
+            score REAL,
             PRIMARY KEY (image_id, class_id),
             FOREIGN KEY (image_id) REFERENCES images(id) ON DELETE CASCADE,
             FOREIGN KEY (class_id) REFERENCES mappings(class_id) ON DELETE CASCADE
         )
     """
     )
+
+    # score: semantic-label match score (NULL for YOLO rows). Guarded ALTER
+    # because shipped databases predate the column and CREATE IF NOT EXISTS
+    # won't add it.
+    cursor.execute("PRAGMA table_info(image_classes)")
+    if "score" not in {row[1] for row in cursor.fetchall()}:
+        cursor.execute("ALTER TABLE image_classes ADD COLUMN score REAL")
 
     conn.commit()
     conn.close()
@@ -182,7 +190,7 @@ def db_get_all_images(tagged: Union[bool, None] = None) -> List[dict]:
                 i.captured_at,
                 m.name as tag_name
             FROM images i
-            LEFT JOIN image_classes ic ON i.id = ic.image_id
+            LEFT JOIN image_classes_display ic ON i.id = ic.image_id
             LEFT JOIN mappings m ON ic.class_id = m.class_id
         """
 
@@ -620,7 +628,7 @@ def db_search_images_by_tag(tag_name: str) -> List[dict]:
                 i.captured_at,
                 m.name as tag_name
             FROM images i
-            LEFT JOIN image_classes ic ON i.id = ic.image_id
+            LEFT JOIN image_classes_display ic ON i.id = ic.image_id
             LEFT JOIN mappings m ON ic.class_id = m.class_id
             WHERE i.id IN (
                 SELECT ic2.image_id FROM image_classes ic2
@@ -678,7 +686,7 @@ def db_get_images_by_ids(image_ids: List[str]) -> List[dict]:
                     i.captured_at,
                     m.name as tag_name
                 FROM images i
-                LEFT JOIN image_classes ic ON i.id = ic.image_id
+                LEFT JOIN image_classes_display ic ON i.id = ic.image_id
                 LEFT JOIN mappings m ON ic.class_id = m.class_id
                 WHERE i.id IN ({placeholders})
                 ORDER BY i.path, m.name
@@ -745,7 +753,7 @@ def db_get_images_by_date_range(
                 i.captured_at,
                 GROUP_CONCAT(m.name, ',') as tags
             FROM images i
-            LEFT JOIN image_classes ic ON i.id = ic.image_id
+            LEFT JOIN image_classes_display ic ON i.id = ic.image_id
             LEFT JOIN mappings m ON ic.class_id = m.class_id
             WHERE i.captured_at BETWEEN ? AND ?
         """
@@ -838,7 +846,7 @@ def db_get_images_near_location(
                 i.captured_at,
                 GROUP_CONCAT(m.name, ',') as tags
             FROM images i
-            LEFT JOIN image_classes ic ON i.id = ic.image_id
+            LEFT JOIN image_classes_display ic ON i.id = ic.image_id
             LEFT JOIN mappings m ON ic.class_id = m.class_id
             WHERE i.latitude BETWEEN ? AND ?
               AND i.longitude BETWEEN ? AND ?
@@ -916,7 +924,7 @@ def db_get_images_by_year_month(year: int, month: int) -> List[dict]:
                 i.captured_at,
                 GROUP_CONCAT(m.name, ',') as tags
             FROM images i
-            LEFT JOIN image_classes ic ON i.id = ic.image_id
+            LEFT JOIN image_classes_display ic ON i.id = ic.image_id
             LEFT JOIN mappings m ON ic.class_id = m.class_id
             WHERE strftime('%Y', i.captured_at) = ?
               AND strftime('%m', i.captured_at) = ?
@@ -984,7 +992,7 @@ def db_get_images_with_location() -> List[dict]:
                 i.captured_at,
                 GROUP_CONCAT(m.name, ',') as tags
             FROM images i
-            LEFT JOIN image_classes ic ON i.id = ic.image_id
+            LEFT JOIN image_classes_display ic ON i.id = ic.image_id
             LEFT JOIN mappings m ON ic.class_id = m.class_id
             WHERE i.latitude IS NOT NULL 
               AND i.longitude IS NOT NULL
@@ -1051,7 +1059,7 @@ def db_get_all_images_for_memories() -> List[dict]:
                 i.captured_at,
                 GROUP_CONCAT(m.name, ',') as tags
             FROM images i
-            LEFT JOIN image_classes ic ON i.id = ic.image_id
+            LEFT JOIN image_classes_display ic ON i.id = ic.image_id
             LEFT JOIN mappings m ON ic.class_id = m.class_id
             GROUP BY i.id
             ORDER BY i.captured_at DESC

--- a/backend/app/database/semantic_labels.py
+++ b/backend/app/database/semantic_labels.py
@@ -1,4 +1,15 @@
+import json
+from typing import List, Tuple
+
+import numpy as np
+
 from app.database.images import _connect
+from app.logging.setup_logging import get_logger
+
+logger = get_logger(__name__)
+
+# YOLO owns mappings class_ids 0-79; semantic labels are allocated from here.
+SEMANTIC_CLASS_ID_OFFSET = 1000
 
 
 def db_create_semantic_labels_table():
@@ -7,31 +18,310 @@ def db_create_semantic_labels_table():
         conn = _connect()
         cursor = conn.cursor()
 
+        # Migrate the pre-vocabulary shell schema. It shipped with no writer,
+        # so the table is guaranteed empty: drop-and-recreate instead of
+        # ALTER. image_semantic_labels (also never written) is superseded by
+        # image_classes rows + image_classes.score.
+        cursor.execute("PRAGMA table_info(semantic_labels)")
+        columns = {row[1] for row in cursor.fetchall()}
+        if columns and "descriptions" not in columns:
+            cursor.execute("DROP TABLE semantic_labels")
+        cursor.execute("DROP TABLE IF EXISTS image_semantic_labels")
+
+        # Definition + cache table for the curated vocabulary. class_id is
+        # shared with mappings so tag consumers (image_classes joins) treat
+        # semantic labels exactly like YOLO classes. descriptions (JSON
+        # array) are the source of truth; label_embedding caches their
+        # renormalized mean for embedding_model_version.
         cursor.execute(
             """
             CREATE TABLE IF NOT EXISTS semantic_labels (
-                label_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                class_id INTEGER PRIMARY KEY,
                 name TEXT UNIQUE NOT NULL,
-                prompt_template TEXT,
+                category TEXT NOT NULL,
+                descriptions TEXT NOT NULL,
                 threshold REAL,
-                active BOOLEAN DEFAULT 1
+                active BOOLEAN DEFAULT 1,
+                label_embedding BLOB,
+                embedding_model_version TEXT
             )
             """
         )
+
+        # Display cut: tag-list queries join this view instead of
+        # image_classes, so chips show all YOLO tags but only the
+        # top-SEMANTIC_DISPLAY_TOP_K semantic tags per image. Search
+        # matching still uses the full table (stored top-K). Recreated at
+        # startup so setting changes apply without re-scoring.
+        from app.config.settings import SEMANTIC_DISPLAY_TOP_K
+
+        cursor.execute("DROP VIEW IF EXISTS image_classes_display")
+        cursor.execute(
+            f"""
+            CREATE VIEW image_classes_display AS
+            SELECT image_id, class_id FROM (
+                SELECT image_id, class_id,
+                       ROW_NUMBER() OVER (
+                           PARTITION BY image_id ORDER BY score DESC
+                       ) AS display_rank
+                FROM image_classes WHERE score IS NOT NULL
+            ) WHERE display_rank <= {int(SEMANTIC_DISPLAY_TOP_K)}
+            UNION ALL
+            SELECT image_id, class_id FROM image_classes WHERE score IS NULL
+            """
+        )
+
+        conn.commit()
+    finally:
+        if conn:
+            conn.close()
+
+
+def db_upsert_semantic_vocabulary(labels: List[dict]) -> None:
+    """Idempotently sync the seed vocabulary into mappings + semantic_labels.
+
+    New labels get mappings rows with class_id >= SEMANTIC_CLASS_ID_OFFSET;
+    changed descriptions invalidate the cached label embedding; labels
+    missing from the seed are deactivated (rows kept -- image_classes may
+    reference them).
+    """
+    conn = None
+    try:
+        conn = _connect()
+        cursor = conn.cursor()
+
+        cursor.execute("SELECT class_id, name FROM mappings")
+        mapping_by_name = {name: cid for cid, name in cursor.fetchall()}
 
         cursor.execute(
-            """
-            CREATE TABLE IF NOT EXISTS image_semantic_labels (
-                image_id TEXT,
-                label_id INTEGER,
-                score REAL NOT NULL,
-                PRIMARY KEY (image_id, label_id),
-                FOREIGN KEY (image_id) REFERENCES images(id) ON DELETE CASCADE,
-                FOREIGN KEY (label_id) REFERENCES semantic_labels(label_id) ON DELETE CASCADE
+            "SELECT class_id, name, category, descriptions, threshold, active "
+            "FROM semantic_labels"
+        )
+        existing = {row[1]: row for row in cursor.fetchall()}
+
+        next_id = (
+            max(
+                [SEMANTIC_CLASS_ID_OFFSET - 1]
+                + [
+                    cid
+                    for cid in mapping_by_name.values()
+                    if cid >= SEMANTIC_CLASS_ID_OFFSET
+                ]
             )
-            """
+            + 1
         )
 
+        added = updated = skipped = 0
+        seed_names = set()
+        for label in labels:
+            name = label["name"]
+            seed_names.add(name)
+            category = label["category"]
+            descriptions = json.dumps(label["descriptions"])
+            threshold = label.get("threshold")
+
+            if name in existing:
+                class_id, _, old_cat, old_desc, old_thr, old_active = existing[name]
+                if old_desc != descriptions:
+                    # descriptions changed: cached embedding is stale
+                    cursor.execute(
+                        """
+                        UPDATE semantic_labels
+                        SET category = ?, descriptions = ?, threshold = ?,
+                            active = 1, label_embedding = NULL,
+                            embedding_model_version = NULL
+                        WHERE class_id = ?
+                        """,
+                        (category, descriptions, threshold, class_id),
+                    )
+                    updated += 1
+                elif (old_cat, old_thr, bool(old_active)) != (
+                    category,
+                    threshold,
+                    True,
+                ):
+                    cursor.execute(
+                        "UPDATE semantic_labels "
+                        "SET category = ?, threshold = ?, active = 1 "
+                        "WHERE class_id = ?",
+                        (category, threshold, class_id),
+                    )
+                    updated += 1
+                continue
+
+            mapped_id = mapping_by_name.get(name)
+            if mapped_id is not None and mapped_id < SEMANTIC_CLASS_ID_OFFSET:
+                logger.warning(
+                    f"Skipping semantic label '{name}': name already owned by "
+                    "a YOLO mapping"
+                )
+                skipped += 1
+                continue
+
+            if mapped_id is None:
+                mapped_id = next_id
+                next_id += 1
+                cursor.execute(
+                    "INSERT INTO mappings (class_id, name) VALUES (?, ?)",
+                    (mapped_id, name),
+                )
+                mapping_by_name[name] = mapped_id
+
+            cursor.execute(
+                """
+                INSERT INTO semantic_labels
+                    (class_id, name, category, descriptions, threshold)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (mapped_id, name, category, descriptions, threshold),
+            )
+            added += 1
+
+        deactivated = 0
+        for name in set(existing) - seed_names:
+            if existing[name][5]:
+                cursor.execute(
+                    "UPDATE semantic_labels SET active = 0 WHERE name = ?",
+                    (name,),
+                )
+                deactivated += 1
+
+        conn.commit()
+        if added or updated or skipped or deactivated:
+            logger.info(
+                f"Semantic vocabulary sync: {added} added, {updated} updated, "
+                f"{deactivated} deactivated, {skipped} skipped"
+            )
+    finally:
+        if conn:
+            conn.close()
+
+
+def db_get_labels_needing_embeddings(
+    model_version: str,
+) -> List[Tuple[int, List[str]]]:
+    """Active labels whose cached embedding is missing or belongs to a
+    different checkpoint. Returns (class_id, descriptions) pairs."""
+    conn = None
+    try:
+        conn = _connect()
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT class_id, descriptions FROM semantic_labels
+            WHERE active = 1
+              AND (label_embedding IS NULL
+                   OR IFNULL(embedding_model_version, '') != ?)
+            """,
+            (model_version,),
+        )
+        return [
+            (class_id, json.loads(descriptions))
+            for class_id, descriptions in cursor.fetchall()
+        ]
+    finally:
+        if conn:
+            conn.close()
+
+
+def db_update_label_embeddings(
+    rows: List[Tuple[int, np.ndarray, str]],
+) -> None:
+    """Store computed label embeddings: (class_id, embedding, model_version).
+
+    Same raw-float32 blob format as image_embeddings.embedding.
+    """
+    conn = None
+    try:
+        conn = _connect()
+        cursor = conn.cursor()
+        cursor.executemany(
+            """
+            UPDATE semantic_labels
+            SET label_embedding = ?, embedding_model_version = ?
+            WHERE class_id = ?
+            """,
+            [
+                (
+                    np.ascontiguousarray(embedding, dtype=np.float32).tobytes(),
+                    model_version,
+                    class_id,
+                )
+                for class_id, embedding, model_version in rows
+            ],
+        )
+        conn.commit()
+    finally:
+        if conn:
+            conn.close()
+
+
+def db_get_active_label_embeddings(
+    model_version: str,
+) -> Tuple[List[Tuple[int, str, float]], np.ndarray]:
+    """Cached embeddings for active labels on the given checkpoint.
+
+    Returns ([(class_id, category, threshold), ...], matrix [N, D]) for the
+    scoring pass, ordered by class_id (the scoring signature hashes the
+    matrix, so row order must be deterministic); threshold is None where the
+    label has no per-label override.
+    """
+    conn = None
+    try:
+        conn = _connect()
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT class_id, category, threshold, label_embedding
+            FROM semantic_labels
+            WHERE active = 1
+              AND label_embedding IS NOT NULL
+              AND embedding_model_version = ?
+            ORDER BY class_id
+            """,
+            (model_version,),
+        )
+        rows = cursor.fetchall()
+        if not rows:
+            return [], np.empty((0, 0), dtype=np.float32)
+
+        meta = [
+            (class_id, category, threshold) for class_id, category, threshold, _ in rows
+        ]
+        matrix = np.vstack(
+            [np.frombuffer(blob, dtype=np.float32) for _, _, _, blob in rows]
+        )
+        return meta, matrix
+    finally:
+        if conn:
+            conn.close()
+
+
+def db_write_image_semantic_scores(
+    batch: List[Tuple[str, List[Tuple[int, float]]]], signature: str
+) -> None:
+    """Replace each image's semantic tag rows with the given (class_id, score)
+    pairs and stamp its scored_signature. YOLO rows (class_id below the
+    offset) are never touched."""
+    conn = None
+    try:
+        conn = _connect()
+        cursor = conn.cursor()
+        for image_id, pairs in batch:
+            cursor.execute(
+                "DELETE FROM image_classes " "WHERE image_id = ? AND class_id >= ?",
+                (image_id, SEMANTIC_CLASS_ID_OFFSET),
+            )
+            cursor.executemany(
+                "INSERT OR REPLACE INTO image_classes "
+                "(image_id, class_id, score) VALUES (?, ?, ?)",
+                [(image_id, class_id, score) for class_id, score in pairs],
+            )
+            cursor.execute(
+                "UPDATE image_embeddings SET scored_signature = ? "
+                "WHERE image_id = ?",
+                (signature, image_id),
+            )
         conn.commit()
     finally:
         if conn:

--- a/backend/app/routes/folders.py
+++ b/backend/app/routes/folders.py
@@ -44,6 +44,7 @@ from app.utils.images import (
     image_util_process_unembedded_images,
 )
 from app.utils.model_bootstrap import ensure_ai_tagging_models
+from app.utils.semantic_labels import semantic_util_score_images
 from app.utils.face_clusters import cluster_util_face_clusters_sync
 from app.utils.API import API_util_restart_sync_microservice_watcher
 
@@ -94,6 +95,7 @@ def post_AI_tagging_enabled_sequence():
         image_util_process_untagged_images()
         cluster_util_face_clusters_sync()
         image_util_process_unembedded_images()
+        semantic_util_score_images()
     except Exception as e:
         logger.error(f"Error in post processing after AI tagging was enabled: {e}")
         return False
@@ -123,6 +125,7 @@ def post_sync_folder_sequence(
         image_util_process_untagged_images()
         cluster_util_face_clusters_sync()
         image_util_process_unembedded_images()
+        semantic_util_score_images()
 
         # Restart sync microservice watcher after processing images
         API_util_restart_sync_microservice_watcher()

--- a/backend/app/routes/models.py
+++ b/backend/app/routes/models.py
@@ -18,6 +18,10 @@ from app.models.session_registry import (
 )
 from app.utils.hardware_detect import get_hardware_info
 from app.utils.images import image_util_process_unembedded_images
+from app.utils.semantic_labels import (
+    semantic_util_build_label_embeddings,
+    semantic_util_score_images,
+)
 from app.utils.model_downloader import ensure_model
 from app.database.metadata import db_get_metadata
 import logging
@@ -46,7 +50,12 @@ def submit_embedding_backfill_if_semantic(
     if any(
         MODEL_REGISTRY[key].get("feature") in SEMANTIC_FEATURES for key in model_keys
     ):
+        # The executor is single-worker, so these run in order: label
+        # embeddings, then image embeddings, then the scoring sweep that
+        # depends on both.
+        executor.submit(semantic_util_build_label_embeddings)
         executor.submit(image_util_process_unembedded_images)
+        executor.submit(semantic_util_score_images)
 
 
 # Global dict to track download tasks

--- a/backend/app/utils/semantic_labels.py
+++ b/backend/app/utils/semantic_labels.py
@@ -1,0 +1,209 @@
+from app.logging.setup_logging import get_logger
+
+logger = get_logger(__name__)
+
+SCORING_CHUNK_SIZE = 256
+
+
+def _scoring_signature(model_version, top_k, thresholds, meta, label_matrix):
+    """Fingerprint of everything an image's stored scores depend on. Any
+    change (vocabulary, label embeddings, thresholds, K, checkpoint) makes
+    every image look unscored, and the sweep rewrites it -- re-scoring is one
+    matmul, so wholesale invalidation is cheaper than tracking deltas."""
+    import hashlib
+
+    h = hashlib.sha256()
+    h.update(f"{model_version}|k={top_k}".encode())
+    for (class_id, category, _), threshold in zip(meta, thresholds):
+        h.update(f"|{class_id}:{category}:{threshold:g}".encode())
+    h.update(label_matrix.tobytes())
+    return h.hexdigest()[:16]
+
+
+def semantic_util_sync_vocabulary() -> None:
+    """Sync the shipped seed vocabulary file into the database.
+
+    Runs at startup after the mappings table exists; idempotent and cheap.
+    """
+    import json
+    from pathlib import Path
+    from app.database.semantic_labels import db_upsert_semantic_vocabulary
+
+    seed_path = (
+        Path(__file__).resolve().parents[1] / "data" / "semantic_vocabulary.json"
+    )
+    try:
+        seed = json.loads(seed_path.read_text(encoding="utf-8"))
+        db_upsert_semantic_vocabulary(seed["labels"])
+    except Exception as e:
+        logger.error(f"Failed to sync semantic vocabulary: {e}")
+
+
+def semantic_util_build_label_embeddings() -> None:
+    """Build cached label embeddings for the active checkpoint.
+
+    Self-gating and idempotent: skips when the text model isn't installed,
+    and only encodes labels whose cache is missing or stale (over-triggering
+    is a cheap no-op). A label's embedding is the renormalized mean of its
+    description embeddings (prompt ensembling).
+    """
+    import os
+    import time
+    import numpy as np
+    from app.config.settings import (
+        SIGLIP2_ACTIVE_CHECKPOINT,
+        SIGLIP2_SCORING_METADATA,
+    )
+    from app.models.model_registry import (
+        get_siglip2_registry_keys,
+        get_siglip2_tokenizer_key,
+        get_model_path,
+    )
+    from app.database.semantic_labels import (
+        db_get_labels_needing_embeddings,
+        db_update_label_embeddings,
+    )
+
+    try:
+        _, text_key = get_siglip2_registry_keys(SIGLIP2_ACTIVE_CHECKPOINT)
+        tokenizer_key = get_siglip2_tokenizer_key(SIGLIP2_ACTIVE_CHECKPOINT)
+        text_model_path = get_model_path(text_key)
+        tokenizer_path = get_model_path(tokenizer_key)
+        if not os.path.exists(text_model_path) or not os.path.exists(tokenizer_path):
+            logger.info(
+                "SigLIP2 text model/tokenizer not installed; "
+                "skipping label embedding build"
+            )
+            return
+
+        metadata = SIGLIP2_SCORING_METADATA[SIGLIP2_ACTIVE_CHECKPOINT]
+        model_version = metadata["model_version"]
+
+        stale = db_get_labels_needing_embeddings(model_version)
+        if not stale:
+            return
+
+        from app.utils.SigLIP import (
+            siglip_util_tokenize_query,
+            siglip_util_get_text_model,
+        )
+
+        text_model = siglip_util_get_text_model(text_model_path, text_key)
+        start_time = time.time()
+
+        rows = []
+        for class_id, descriptions in stale:
+            # Descriptions are caption-shaped already; encoded as-is, no
+            # SIGLIP2_QUERY_TEMPLATE wrapping (that template exists to fix
+            # bare-noun live queries).
+            vectors = []
+            for description in descriptions:
+                input_ids, attention_mask = siglip_util_tokenize_query(description)
+                embedding = text_model.get_embedding(input_ids, attention_mask)
+                vectors.append(np.asarray(embedding, dtype=np.float32).flatten())
+            mean = np.mean(vectors, axis=0)
+            norm = np.linalg.norm(mean)
+            rows.append((class_id, mean / norm if norm > 0 else mean, model_version))
+
+        db_update_label_embeddings(rows)
+        elapsed = time.time() - start_time
+        logger.info(
+            f"Label embedding build complete. Labels: {len(rows)}, "
+            f"Elapsed: {elapsed:.2f}s"
+        )
+    except Exception as e:
+        logger.error(f"Error building semantic label embeddings: {e}")
+
+
+def semantic_util_score_images() -> None:
+    """Score embedded images against the cached label matrix and write
+    top-K above-threshold tags as image_classes rows.
+
+    Self-gating and idempotent: needs only cached embeddings (no models),
+    skips images already scored against the current scoring signature. Runs
+    after the embedding pass and whenever the vocabulary or label
+    embeddings change.
+    """
+    import time
+    import numpy as np
+    from app.config.settings import (
+        SIGLIP2_ACTIVE_CHECKPOINT,
+        SIGLIP2_SCORING_METADATA,
+        SEMANTIC_SCORE_TOP_K,
+        SEMANTIC_BUCKET_THRESHOLDS,
+        SEMANTIC_DEFAULT_THRESHOLD,
+    )
+    from app.database.semantic_labels import (
+        db_get_active_label_embeddings,
+        db_write_image_semantic_scores,
+    )
+    from app.database.image_embeddings import db_get_embeddings_needing_scoring
+
+    try:
+        metadata = SIGLIP2_SCORING_METADATA[SIGLIP2_ACTIVE_CHECKPOINT]
+        model_version = metadata["model_version"]
+        logit_scale = np.exp(metadata["logit_scale"])
+        logit_bias = metadata["logit_bias"]
+
+        meta, label_matrix = db_get_active_label_embeddings(model_version)
+        if not meta:
+            logger.info(
+                "No cached label embeddings for the active checkpoint; "
+                "skipping semantic scoring pass"
+            )
+            return
+
+        thresholds = np.array(
+            [
+                (
+                    override
+                    if override is not None
+                    else SEMANTIC_BUCKET_THRESHOLDS.get(
+                        category, SEMANTIC_DEFAULT_THRESHOLD
+                    )
+                )
+                for _, category, override in meta
+            ],
+            dtype=np.float32,
+        )
+        signature = _scoring_signature(
+            model_version, SEMANTIC_SCORE_TOP_K, thresholds, meta, label_matrix
+        )
+
+        total_images = 0
+        start_time = time.time()
+        while True:
+            image_ids, image_matrix = db_get_embeddings_needing_scoring(
+                model_version, signature, SCORING_CHUNK_SIZE
+            )
+            if not image_ids:
+                break
+
+            logits = image_matrix @ label_matrix.T * logit_scale + logit_bias
+            scores = 1.0 / (1.0 + np.exp(-logits))
+
+            batch = []
+            for i, image_id in enumerate(image_ids):
+                row = scores[i]
+                candidates = np.flatnonzero(row >= thresholds)
+                if len(candidates) > SEMANTIC_SCORE_TOP_K:
+                    keep = np.argsort(row[candidates])[::-1][:SEMANTIC_SCORE_TOP_K]
+                    candidates = candidates[keep]
+                batch.append(
+                    (
+                        image_id,
+                        [(meta[j][0], float(row[j])) for j in candidates],
+                    )
+                )
+
+            db_write_image_semantic_scores(batch, signature)
+            total_images += len(image_ids)
+
+        if total_images:
+            elapsed = time.time() - start_time
+            logger.info(
+                f"Semantic scoring pass complete. Images: {total_images}, "
+                f"Labels: {len(meta)}, Elapsed: {elapsed:.2f}s"
+            )
+    except Exception as e:
+        logger.error(f"Error in semantic scoring pass: {e}")

--- a/backend/app/utils/semantic_labels.py
+++ b/backend/app/utils/semantic_labels.py
@@ -1,11 +1,24 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from app.logging.setup_logging import get_logger
+
+if TYPE_CHECKING:
+    import numpy as np
 
 logger = get_logger(__name__)
 
 SCORING_CHUNK_SIZE = 256
 
 
-def _scoring_signature(model_version, top_k, thresholds, meta, label_matrix):
+def _scoring_signature(
+    model_version: str,
+    top_k: int,
+    thresholds: np.ndarray,
+    meta: list[tuple[int, str, float | None]],
+    label_matrix: np.ndarray,
+) -> str:
     """Fingerprint of everything an image's stored scores depend on. Any
     change (vocabulary, label embeddings, thresholds, K, checkpoint) makes
     every image look unscored, and the sweep rewrites it -- re-scoring is one

--- a/backend/main.py
+++ b/backend/main.py
@@ -23,6 +23,11 @@ from app.database.folders import db_create_folders_table
 from app.database.metadata import db_create_metadata_table
 from app.database.semantic_labels import db_create_semantic_labels_table
 from app.database.image_embeddings import db_create_image_embeddings_table
+from app.utils.semantic_labels import (
+    semantic_util_sync_vocabulary,
+    semantic_util_build_label_embeddings,
+    semantic_util_score_images,
+)
 
 from app.routes.folders import router as folders_router
 from app.routes.albums import router as albums_router
@@ -65,8 +70,16 @@ async def lifespan(app: FastAPI):
     db_create_albums_table()
     db_create_album_images_table()
     db_create_metadata_table()
+    # Needs the mappings table (created above): semantic labels register
+    # there as class_ids >= SEMANTIC_CLASS_ID_OFFSET
+    semantic_util_sync_vocabulary()
     # Create ProcessPoolExecutor and attach it to app.state
     app.state.executor = ProcessPoolExecutor(max_workers=1)
+    # Self-gating no-ops unless something is missing/stale (fresh install,
+    # checkpoint swap, edited seed). Single-worker executor runs them in
+    # order: the scoring sweep needs the label embeddings.
+    app.state.executor.submit(semantic_util_build_label_embeddings)
+    app.state.executor.submit(semantic_util_score_images)
 
     # Start the SSE model download cleanup task
     cleanup_task = asyncio.create_task(_cleanup_stale_tasks())

--- a/backend/scripts/build_eval_set.py
+++ b/backend/scripts/build_eval_set.py
@@ -1,0 +1,129 @@
+"""Download the calibration eval set from Wikimedia Commons.
+
+Reads scripts/vocabulary/eval_manifest.json and fetches images_per_label
+images per entry into scripts/vocabulary/eval_images/ (gitignored), named
+<label>__<n>.jpg. Idempotent: existing files are kept. Attribution URLs are
+recorded in eval_images/attribution.json.
+
+Run from the backend directory:  python scripts/build_eval_set.py
+Stdlib-only, like build_semantic_vocabulary.py.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+VOCAB_DIR = Path(__file__).resolve().parent / "vocabulary"
+MANIFEST = VOCAB_DIR / "eval_manifest.json"
+IMAGES_DIR = VOCAB_DIR / "eval_images"
+ATTRIBUTION = IMAGES_DIR / "attribution.json"
+
+API = "https://commons.wikimedia.org/w/api.php"
+USER_AGENT = "PictoPy-eval-builder/0.1 (dev tooling; github.com/AOSSIE-Org/PictoPy)"
+MIN_WIDTH = 500
+THUMB_WIDTH = 640
+
+
+# Commons' robot policy 429s sustained fast bursts; stay comfortably slow.
+REQUEST_DELAY_S = 3.0
+
+
+def _get(url: str) -> bytes:
+    # polite pacing + backoff: Commons 429s on unthrottled request bursts
+    for attempt in range(4):
+        time.sleep(REQUEST_DELAY_S * (1 + attempt * 2))
+        try:
+            req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                return resp.read()
+        except urllib.error.HTTPError as e:
+            if e.code != 429 or attempt == 3:
+                raise
+    raise RuntimeError("unreachable")
+
+
+def search_images(query: str, limit: int) -> list[dict]:
+    """Search Commons bitmaps for query; returns imageinfo dicts by relevance."""
+    params = urllib.parse.urlencode(
+        {
+            "action": "query",
+            "format": "json",
+            "generator": "search",
+            "gsrsearch": f"{query} filetype:bitmap",
+            "gsrnamespace": 6,
+            "gsrlimit": limit,
+            "prop": "imageinfo",
+            "iiprop": "url|size",
+            "iiurlwidth": THUMB_WIDTH,
+        }
+    )
+    data = json.loads(_get(f"{API}?{params}"))
+    pages = data.get("query", {}).get("pages", {})
+    results = sorted(pages.values(), key=lambda p: p.get("index", 999))
+    infos = []
+    for page in results:
+        info = (page.get("imageinfo") or [{}])[0]
+        if info.get("width", 0) >= MIN_WIDTH and info.get("thumburl"):
+            info["descriptionurl"] = info.get("descriptionurl", "")
+            infos.append(info)
+    return infos
+
+
+def main() -> int:
+    manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    per_label = manifest["images_per_label"]
+    IMAGES_DIR.mkdir(parents=True, exist_ok=True)
+    attribution = (
+        json.loads(ATTRIBUTION.read_text(encoding="utf-8"))
+        if ATTRIBUTION.exists()
+        else {}
+    )
+
+    downloaded = skipped = failed = 0
+    for entry in manifest["entries"]:
+        label = entry["label"]
+        targets = [
+            IMAGES_DIR / f"{label.replace(' ', '_')}__{i}.jpg" for i in range(per_label)
+        ]
+        if all(t.exists() for t in targets):
+            skipped += per_label
+            continue
+
+        try:
+            infos = search_images(entry["query"], per_label * 3)
+        except Exception as e:
+            print(f"search failed for {label!r}: {e}")
+            failed += per_label
+            continue
+
+        # index-aligned pairing so a refill run doesn't re-download the
+        # image an existing sibling slot already has
+        for i, target in enumerate(targets):
+            if target.exists() or i >= len(infos):
+                continue
+            info = infos[i]
+            try:
+                target.write_bytes(_get(info["thumburl"]))
+                attribution[target.name] = info["descriptionurl"]
+                downloaded += 1
+                print(f"{target.name}  <-  {info['descriptionurl']}")
+            except Exception as e:
+                print(f"download failed for {label!r}: {e}")
+                failed += 1
+
+    ATTRIBUTION.write_text(
+        json.dumps(attribution, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(f"\ndownloaded: {downloaded}, kept existing: {skipped}, failed: {failed}")
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/scripts/build_semantic_vocabulary.py
+++ b/backend/scripts/build_semantic_vocabulary.py
@@ -1,0 +1,235 @@
+"""Derivation script for the semantic vocabulary seed (curated-vocabulary layer, step 1).
+
+Pulls the Places365 scene categories and Open Images boxable class list,
+applies the mechanical prune rules (COCO-80 exclusion, person/body-part
+exclusion, cross-source dedupe), and emits a raw candidate list for the
+hand-prune pass.
+
+Run from the backend directory:  python scripts/build_semantic_vocabulary.py
+
+Output:  scripts/vocabulary/raw_candidates.json  (committed, reviewable)
+Source downloads are cached in  scripts/vocabulary/sources/  (gitignored).
+
+Stdlib-only on purpose: the COCO class list is read out of app/utils/YOLO.py
+via ast instead of importing it, so this runs without the backend's ML deps.
+"""
+
+from __future__ import annotations
+
+import ast
+import csv
+import io
+import json
+import sys
+import urllib.request
+from pathlib import Path
+
+BACKEND_DIR = Path(__file__).resolve().parent.parent
+YOLO_SOURCE = BACKEND_DIR / "app" / "utils" / "YOLO.py"
+OUTPUT_DIR = Path(__file__).resolve().parent / "vocabulary"
+SOURCES_DIR = OUTPUT_DIR / "sources"
+OUTPUT_FILE = OUTPUT_DIR / "raw_candidates.json"
+
+PLACES365_URL = (
+    "https://raw.githubusercontent.com/CSAILVision/places365/master/"
+    "categories_places365.txt"
+)
+OPEN_IMAGES_URL = (
+    "https://storage.googleapis.com/openimages/v7/"
+    "oidv7-class-descriptions-boxable.csv"
+)
+
+# COCO name -> Open Images display names for the same concept. Exact-name and
+# naive plural matching catch the rest; hand-prune is the backstop for subtypes.
+COCO_TO_OPEN_IMAGES_ALIASES: dict[str, list[str]] = {
+    "tv": ["television"],
+    "cell phone": ["mobile phone"],
+    "remote": ["remote control"],
+    "mouse": ["computer mouse"],
+    "keyboard": ["computer keyboard"],
+    "microwave": ["microwave oven"],
+    "donut": ["doughnut"],
+    "hair drier": ["hair dryer"],
+    "potted plant": ["houseplant"],
+    "couch": ["sofa bed"],
+    "cow": ["cattle"],
+    "frisbee": ["flying disc"],
+    "skis": ["ski"],
+    "sports ball": ["ball"],
+    "dining table": ["kitchen & dining room table"],
+    "airplane": ["aeroplane"],
+    "motorcycle": ["motorbike"],
+}
+
+# Person concepts are owned by YOLO ("person") + the face pipeline. Open Images
+# body-part labels ("Human face", "Human arm", ...) are dropped by prefix below.
+PERSON_LABELS = {"person", "human", "man", "woman", "boy", "girl"}
+
+
+def load_coco_class_names() -> list[str]:
+    """Read class_names from app/utils/YOLO.py without importing it."""
+    tree = ast.parse(YOLO_SOURCE.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "class_names":
+                    names = ast.literal_eval(node.value)
+                    if not (isinstance(names, list) and len(names) == 80):
+                        raise ValueError(
+                            f"class_names in {YOLO_SOURCE} is not the expected "
+                            f"80-entry list (got {len(names)})"
+                        )
+                    return names
+    raise ValueError(f"class_names assignment not found in {YOLO_SOURCE}")
+
+
+def fetch_cached(url: str, cache_path: Path) -> str:
+    """Download url to cache_path unless already cached; return its text."""
+    if cache_path.exists():
+        print(f"using cached {cache_path.name}")
+    else:
+        print(f"downloading {url}")
+        with urllib.request.urlopen(url, timeout=30) as resp:
+            data = resp.read()
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.write_bytes(data)
+    return cache_path.read_text(encoding="utf-8")
+
+
+def normalize(name: str) -> str:
+    return " ".join(name.strip().lower().replace("_", " ").split())
+
+
+def parse_places365(text: str) -> dict[str, list[str]]:
+    """Parse categories_places365.txt into {base name: [qualifiers]}.
+
+    Lines look like '/a/apartment_building/outdoor 0' -- the leading letter is
+    an index bucket, and a trailing path segment ('outdoor', 'sand', ...) is a
+    qualifier of the same base scene, merged here and kept as a variant note.
+    """
+    merged: dict[str, list[str]] = {}
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        path = line.split()[0]
+        parts = [p for p in path.split("/") if p]
+        # parts[0] is the one-letter bucket; parts[1] the category name
+        base = normalize(parts[1])
+        qualifiers = [normalize(p) for p in parts[2:]]
+        merged.setdefault(base, [])
+        for q in qualifiers:
+            if q not in merged[base]:
+                merged[base].append(q)
+    return merged
+
+
+def parse_open_images(text: str) -> list[str]:
+    """Parse oidv7-class-descriptions-boxable.csv into display names."""
+    names = []
+    reader = csv.reader(io.StringIO(text))
+    for row in reader:
+        if len(row) < 2 or not row[0].startswith("/m/"):
+            continue  # header or malformed line
+        names.append(normalize(row[1]))
+    return names
+
+
+def build_exclusion_set(coco_names: list[str]) -> set[str]:
+    excluded = set(PERSON_LABELS)
+    for name in coco_names:
+        norm = normalize(name)
+        excluded.add(norm)
+        for alias in COCO_TO_OPEN_IMAGES_ALIASES.get(norm, []):
+            excluded.add(normalize(alias))
+    return excluded
+
+
+def is_excluded(name: str, exclusion: set[str]) -> bool:
+    if name in exclusion:
+        return True
+    # naive plural/singular bridging: "cars" vs "car", "boxes" vs "box"
+    if name + "s" in exclusion or name + "es" in exclusion:
+        return True
+    if name.endswith("es") and name[:-2] in exclusion:
+        return True
+    if name.endswith("s") and name[:-1] in exclusion:
+        return True
+    # Open Images body-part labels ("human face", "human arm", ...)
+    if name.startswith("human "):
+        return True
+    return False
+
+
+def main() -> int:
+    coco_names = load_coco_class_names()
+    exclusion = build_exclusion_set(coco_names)
+
+    places_raw = parse_places365(
+        fetch_cached(PLACES365_URL, SOURCES_DIR / "categories_places365.txt")
+    )
+    open_images_raw = parse_open_images(
+        fetch_cached(
+            OPEN_IMAGES_URL, SOURCES_DIR / "oidv7-class-descriptions-boxable.csv"
+        )
+    )
+
+    candidates: dict[str, dict] = {}
+    excluded_counts = {"places365": 0, "open_images": 0}
+
+    for name, variants in places_raw.items():
+        if is_excluded(name, exclusion):
+            excluded_counts["places365"] += 1
+            continue
+        entry = {"name": name, "category": "scene", "sources": ["places365"]}
+        if variants:
+            entry["variants"] = variants
+        candidates[name] = entry
+
+    for name in open_images_raw:
+        if is_excluded(name, exclusion):
+            excluded_counts["open_images"] += 1
+            continue
+        if name in candidates:
+            # already present from Places365; scene category wins, record source
+            if "open_images" not in candidates[name]["sources"]:
+                candidates[name]["sources"].append("open_images")
+            continue
+        candidates[name] = {
+            "name": name,
+            "category": "object",
+            "sources": ["open_images"],
+        }
+
+    ordered = sorted(candidates.values(), key=lambda e: e["name"])
+    output = {
+        "generated_by": "scripts/build_semantic_vocabulary.py",
+        "sources": {
+            "places365": PLACES365_URL,
+            "open_images": OPEN_IMAGES_URL,
+            "coco_exclusion": "app/utils/YOLO.py class_names",
+        },
+        "candidate_count": len(ordered),
+        "candidates": ordered,
+    }
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    OUTPUT_FILE.write_text(
+        json.dumps(output, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+
+    both = sum(1 for e in ordered if len(e["sources"]) == 2)
+    print(
+        f"places365: {len(places_raw)} base scenes "
+        f"({excluded_counts['places365']} excluded)"
+    )
+    print(
+        f"open_images: {len(open_images_raw)} boxable classes "
+        f"({excluded_counts['open_images']} excluded)"
+    )
+    print(f"candidates: {len(ordered)} ({both} present in both sources)")
+    print(f"wrote {OUTPUT_FILE.relative_to(BACKEND_DIR)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/scripts/calibrate_semantic_vocabulary.py
+++ b/backend/scripts/calibrate_semantic_vocabulary.py
@@ -23,6 +23,7 @@ import os
 import sys
 import time
 from pathlib import Path
+from typing import Any, Callable
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -46,7 +47,11 @@ THRESHOLDS = [0.00001, 0.00005, 0.0001, 0.0005, 0.001, 0.005, 0.01, 0.02]
 MARGIN_FACTORS = [1.0, 2.0, 5.0, 10.0, 25.0]  # score >= factor * generic baseline
 
 
-def build_label_matrix(labels, text_model, tokenize):
+def build_label_matrix(
+    labels: list[dict],
+    text_model: Any,
+    tokenize: Callable[[str], tuple[np.ndarray, np.ndarray]],
+) -> np.ndarray:
     """Ensembled label vectors: renormalized mean of description embeddings."""
     vectors = []
     for label in labels:

--- a/backend/scripts/calibrate_semantic_vocabulary.py
+++ b/backend/scripts/calibrate_semantic_vocabulary.py
@@ -1,0 +1,232 @@
+"""Bucket calibration for the semantic vocabulary (offline dev script).
+
+Scores the eval set (scripts/vocabulary/eval_images/, built by
+build_eval_set.py) against the full seed vocabulary through the production
+pipeline: siglip_util_preprocess_image -> SigLIP2Vision, descriptions ->
+SigLIP2Text ensembled label vectors, calibrated sigmoid scores.
+
+Reports, per category bucket:
+  - ground-truth (positive) and non-ground-truth (negative) score percentiles
+  - ground-truth rank stats (top-1/5/10/15 over all labels)
+  - a threshold sweep: recall vs mean labels-per-image (tag spam)
+  - null-baseline margin analysis (score minus a generic-prompt baseline)
+
+Writes scripts/vocabulary/calibration_report.json.
+Requires the backend environment + installed SigLIP2 models.
+Run from the backend directory:  python scripts/calibrate_semantic_vocabulary.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import numpy as np
+
+VOCAB_DIR = Path(__file__).resolve().parent / "vocabulary"
+IMAGES_DIR = VOCAB_DIR / "eval_images"
+SEED = (
+    Path(__file__).resolve().parent.parent / "app" / "data" / "semantic_vocabulary.json"
+)
+REPORT = VOCAB_DIR / "calibration_report.json"
+
+GENERIC_PROMPTS = [
+    "a photo",
+    "an image of something",
+    "a picture",
+    "a snapshot of a scene",
+]
+
+THRESHOLDS = [0.00001, 0.00005, 0.0001, 0.0005, 0.001, 0.005, 0.01, 0.02]
+MARGIN_FACTORS = [1.0, 2.0, 5.0, 10.0, 25.0]  # score >= factor * generic baseline
+
+
+def build_label_matrix(labels, text_model, tokenize):
+    """Ensembled label vectors: renormalized mean of description embeddings."""
+    vectors = []
+    for label in labels:
+        per_desc = []
+        for description in label["descriptions"]:
+            input_ids, attention_mask = tokenize(description)
+            emb = text_model.get_embedding(input_ids, attention_mask)
+            per_desc.append(np.asarray(emb, dtype=np.float32).flatten())
+        mean = np.mean(per_desc, axis=0)
+        norm = np.linalg.norm(mean)
+        vectors.append(mean / norm if norm > 0 else mean)
+    return np.vstack(vectors)
+
+
+def main() -> int:
+    from app.config.settings import (
+        SIGLIP2_ACTIVE_CHECKPOINT,
+        SIGLIP2_SCORING_METADATA,
+    )
+    from app.models.model_registry import get_siglip2_registry_keys, get_model_path
+    from app.models.SigLIP2Vision import SigLIP2Vision
+    from app.models.SigLIP2Text import SigLIP2Text
+    from app.utils.SigLIP import (
+        siglip_util_preprocess_image,
+        siglip_util_tokenize_query,
+    )
+
+    metadata = SIGLIP2_SCORING_METADATA[SIGLIP2_ACTIVE_CHECKPOINT]
+    resolution = metadata["input_resolution"]
+    logit_scale = np.exp(metadata["logit_scale"])
+    logit_bias = metadata["logit_bias"]
+
+    seed = json.loads(SEED.read_text(encoding="utf-8"))
+    labels = seed["labels"]
+    name_to_idx = {e["name"]: i for i, e in enumerate(labels)}
+    categories = [e["category"] for e in labels]
+
+    eval_files = sorted(IMAGES_DIR.glob("*__*.jpg"))
+    if not eval_files:
+        print(f"no eval images in {IMAGES_DIR}; run build_eval_set.py first")
+        return 1
+
+    vision_key, text_key = get_siglip2_registry_keys(SIGLIP2_ACTIVE_CHECKPOINT)
+
+    print(f"encoding {len(labels)} labels...")
+    start = time.time()
+    text_model = SigLIP2Text(get_model_path(text_key))
+    try:
+        label_matrix = build_label_matrix(
+            labels, text_model, siglip_util_tokenize_query
+        )
+        generic_vecs = []
+        for prompt in GENERIC_PROMPTS:
+            input_ids, attention_mask = siglip_util_tokenize_query(prompt)
+            emb = text_model.get_embedding(input_ids, attention_mask)
+            generic_vecs.append(np.asarray(emb, dtype=np.float32).flatten())
+        generic_matrix = np.vstack(generic_vecs)
+    finally:
+        text_model.close()
+    print(f"  {time.time() - start:.1f}s")
+
+    print(f"embedding {len(eval_files)} eval images...")
+    start = time.time()
+    vision = SigLIP2Vision(get_model_path(vision_key))
+    image_vecs, gt_indices, kept_files = [], [], []
+    try:
+        for path in eval_files:
+            gt_name = path.stem.split("__")[0].replace("_", " ")
+            if gt_name not in name_to_idx:
+                print(f"  skipping {path.name}: no vocabulary label {gt_name!r}")
+                continue
+            arr = siglip_util_preprocess_image(str(path), resolution)
+            if arr is None:
+                print(f"  skipping {path.name}: unreadable")
+                continue
+            image_vecs.append(vision.get_embedding(np.stack([arr]))[0])
+            gt_indices.append(name_to_idx[gt_name])
+            kept_files.append(path.name)
+    finally:
+        vision.close()
+    print(f"  {time.time() - start:.1f}s")
+
+    images = np.vstack(image_vecs)  # [I, D]
+    gt = np.array(gt_indices)
+
+    def sigmoid_scores(text_matrix):
+        logits = images @ text_matrix.T * logit_scale + logit_bias
+        return 1.0 / (1.0 + np.exp(-logits))
+
+    scores = sigmoid_scores(label_matrix)  # [I, N]
+    generic = sigmoid_scores(generic_matrix).mean(axis=1)  # [I]
+
+    n_images, n_labels = scores.shape
+    gt_scores = scores[np.arange(n_images), gt]
+    ranks = (scores > gt_scores[:, None]).sum(axis=1) + 1  # 1-based GT rank
+
+    report = {"checkpoint": metadata["model_version"], "buckets": {}}
+    pct = [10, 25, 50, 75, 90]
+
+    for bucket in ("scene", "object", "event", "attribute"):
+        mask = np.array([categories[g] == bucket for g in gt])
+        if not mask.any():
+            continue
+        b_scores = scores[mask]
+        b_gt = gt_scores[mask]
+        b_ranks = ranks[mask]
+        neg = b_scores.copy()
+        neg[np.arange(mask.sum()), gt[mask]] = np.nan
+        neg = neg[~np.isnan(neg)]
+
+        sweep = []
+        for t in THRESHOLDS:
+            sweep.append(
+                {
+                    "threshold": t,
+                    "recall": float((b_gt >= t).mean()),
+                    "labels_per_image": float((b_scores >= t).sum(axis=1).mean()),
+                }
+            )
+
+        margin_sweep = []
+        b_generic = generic[mask]
+        for f in MARGIN_FACTORS:
+            above = b_scores >= (b_generic[:, None] * f)
+            margin_sweep.append(
+                {
+                    "factor": f,
+                    "recall": float(above[np.arange(mask.sum()), gt[mask]].mean()),
+                    "labels_per_image": float(above.sum(axis=1).mean()),
+                }
+            )
+
+        report["buckets"][bucket] = {
+            "images": int(mask.sum()),
+            "gt_score_percentiles": {
+                f"p{p}": float(np.percentile(b_gt, p)) for p in pct
+            },
+            "neg_score_percentiles": {
+                f"p{p}": float(np.percentile(neg, p)) for p in [50, 90, 99]
+            },
+            "gt_rank": {
+                "top1": float((b_ranks <= 1).mean()),
+                "top5": float((b_ranks <= 5).mean()),
+                "top10": float((b_ranks <= 10).mean()),
+                "top15": float((b_ranks <= 15).mean()),
+                "median_rank": float(np.median(b_ranks)),
+            },
+            "threshold_sweep": sweep,
+            "generic_baseline_margin_sweep": margin_sweep,
+        }
+
+    # worst-ranked eval images: bad descriptions or bad eval ground truth
+    worst = np.argsort(ranks)[::-1][:15]
+    report["worst_ranked_images"] = [
+        {
+            "file": kept_files[i],
+            "gt_rank": int(ranks[i]),
+            "gt_score": float(gt_scores[i]),
+            "top_labels": [labels[j]["name"] for j in np.argsort(scores[i])[::-1][:5]],
+        }
+        for i in worst
+    ]
+
+    REPORT.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+
+    print(
+        f"\n{'bucket':<10} {'imgs':>4} {'GT p50':>9} {'neg p99':>9} "
+        f"{'top1':>6} {'top5':>6} {'top15':>6} {'med rank':>8}"
+    )
+    for bucket, b in report["buckets"].items():
+        print(
+            f"{bucket:<10} {b['images']:>4} "
+            f"{b['gt_score_percentiles']['p50']:>9.6f} "
+            f"{b['neg_score_percentiles']['p99']:>9.6f} "
+            f"{b['gt_rank']['top1']:>6.2f} {b['gt_rank']['top5']:>6.2f} "
+            f"{b['gt_rank']['top15']:>6.2f} {b['gt_rank']['median_rank']:>8.1f}"
+        )
+    print(f"\nwrote {REPORT}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/scripts/reset_embeddings.py
+++ b/backend/scripts/reset_embeddings.py
@@ -5,6 +5,7 @@ import os
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from app.database.connection import get_db_connection
+from app.database.semantic_labels import SEMANTIC_CLASS_ID_OFFSET
 
 
 def reset_embeddings():
@@ -20,11 +21,19 @@ def reset_embeddings():
         cursor.execute("UPDATE images SET isEmbedded = 0 WHERE isEmbedded = 1")
         updated_images = cursor.rowcount
 
+        print("Deleting semantic tag rows from image_classes...")
+        cursor.execute(
+            "DELETE FROM image_classes WHERE class_id >= ?",
+            (SEMANTIC_CLASS_ID_OFFSET,),
+        )
+        deleted_tags = cursor.rowcount
+
         conn.commit()
 
         print("Done.")
         print(f"Deleted {deleted_embeddings} embeddings.")
         print(f"Reset {updated_images} images to isEmbedded=0.")
+        print(f"Deleted {deleted_tags} semantic tag rows.")
 
 
 if __name__ == "__main__":

--- a/backend/scripts/vocabulary/calibration_report.json
+++ b/backend/scripts/vocabulary/calibration_report.json
@@ -1,0 +1,563 @@
+{
+  "checkpoint": "siglip2-base-patch16-224",
+  "recommendations": {
+    "bucket_thresholds": {
+      "scene": 5e-05,
+      "object": 0.0001,
+      "event": 5e-05,
+      "attribute": 0.0001
+    },
+    "top_k": 15,
+    "display_cut": "top-5 per image (post-hoc, scores stored)",
+    "null_baseline_contrast": "not adopted: margin-vs-generic sweeps matched but never beat absolute thresholds at equal labels-per-image; revisit only if wins-by-default shows up in production",
+    "notes": "Sigmoid scores from ensembled label vectors sit ~2 orders of magnitude below the live-query path (SIGLIP2_MATCH_THRESHOLD=0.01); these thresholds are floors for candidate writes, precision comes from top-k plus the display cut. Eval: 151 Wikimedia Commons images, 9 mislabeled downloads removed after visual review."
+  },
+  "buckets": {
+    "scene": {
+      "images": 46,
+      "gt_score_percentiles": {
+        "p10": 1.922461649428442e-06,
+        "p25": 3.102959817624651e-05,
+        "p50": 0.001402928726747632,
+        "p75": 0.006839083624072373,
+        "p90": 0.03230307810008526
+      },
+      "neg_score_percentiles": {
+        "p50": 2.761727652123014e-10,
+        "p90": 5.771970279511153e-08,
+        "p99": 1.7730037670844496e-05
+      },
+      "gt_rank": {
+        "top1": 0.5217391304347826,
+        "top5": 0.8260869565217391,
+        "top10": 0.8695652173913043,
+        "top15": 0.9130434782608695,
+        "median_rank": 1.0
+      },
+      "threshold_sweep": [
+        {
+          "threshold": 1e-05,
+          "recall": 0.7608695652173914,
+          "labels_per_image": 5.782608695652174
+        },
+        {
+          "threshold": 5e-05,
+          "recall": 0.6956521739130435,
+          "labels_per_image": 3.0869565217391304
+        },
+        {
+          "threshold": 0.0001,
+          "recall": 0.6956521739130435,
+          "labels_per_image": 2.5652173913043477
+        },
+        {
+          "threshold": 0.0005,
+          "recall": 0.5869565217391305,
+          "labels_per_image": 1.2826086956521738
+        },
+        {
+          "threshold": 0.001,
+          "recall": 0.5217391304347826,
+          "labels_per_image": 1.0434782608695652
+        },
+        {
+          "threshold": 0.005,
+          "recall": 0.32608695652173914,
+          "labels_per_image": 0.5869565217391305
+        },
+        {
+          "threshold": 0.01,
+          "recall": 0.2391304347826087,
+          "labels_per_image": 0.41304347826086957
+        },
+        {
+          "threshold": 0.02,
+          "recall": 0.17391304347826086,
+          "labels_per_image": 0.2608695652173913
+        }
+      ],
+      "generic_baseline_margin_sweep": [
+        {
+          "factor": 1.0,
+          "recall": 0.6521739130434783,
+          "labels_per_image": 2.0217391304347827
+        },
+        {
+          "factor": 2.0,
+          "recall": 0.6304347826086957,
+          "labels_per_image": 1.4565217391304348
+        },
+        {
+          "factor": 5.0,
+          "recall": 0.5652173913043478,
+          "labels_per_image": 1.1521739130434783
+        },
+        {
+          "factor": 10.0,
+          "recall": 0.4782608695652174,
+          "labels_per_image": 0.9130434782608695
+        },
+        {
+          "factor": 25.0,
+          "recall": 0.30434782608695654,
+          "labels_per_image": 0.5434782608695652
+        }
+      ]
+    },
+    "object": {
+      "images": 48,
+      "gt_score_percentiles": {
+        "p10": 8.674582313688008e-05,
+        "p25": 0.0006071098032407463,
+        "p50": 0.005635681329295039,
+        "p75": 0.036805637180805206,
+        "p90": 0.07517253085970879
+      },
+      "neg_score_percentiles": {
+        "p50": 5.761034878315474e-11,
+        "p90": 7.285397929379661e-09,
+        "p99": 6.64170863728931e-07
+      },
+      "gt_rank": {
+        "top1": 0.8541666666666666,
+        "top5": 0.9791666666666666,
+        "top10": 1.0,
+        "top15": 1.0,
+        "median_rank": 1.0
+      },
+      "threshold_sweep": [
+        {
+          "threshold": 1e-05,
+          "recall": 0.9583333333333334,
+          "labels_per_image": 2.1041666666666665
+        },
+        {
+          "threshold": 5e-05,
+          "recall": 0.9375,
+          "labels_per_image": 1.4166666666666667
+        },
+        {
+          "threshold": 0.0001,
+          "recall": 0.8958333333333334,
+          "labels_per_image": 1.2708333333333333
+        },
+        {
+          "threshold": 0.0005,
+          "recall": 0.7708333333333334,
+          "labels_per_image": 0.9583333333333334
+        },
+        {
+          "threshold": 0.001,
+          "recall": 0.6875,
+          "labels_per_image": 0.8125
+        },
+        {
+          "threshold": 0.005,
+          "recall": 0.5208333333333334,
+          "labels_per_image": 0.5833333333333334
+        },
+        {
+          "threshold": 0.01,
+          "recall": 0.375,
+          "labels_per_image": 0.4375
+        },
+        {
+          "threshold": 0.02,
+          "recall": 0.375,
+          "labels_per_image": 0.4166666666666667
+        }
+      ],
+      "generic_baseline_margin_sweep": [
+        {
+          "factor": 1.0,
+          "recall": 0.8333333333333334,
+          "labels_per_image": 1.2083333333333333
+        },
+        {
+          "factor": 2.0,
+          "recall": 0.8125,
+          "labels_per_image": 1.0833333333333333
+        },
+        {
+          "factor": 5.0,
+          "recall": 0.75,
+          "labels_per_image": 0.9583333333333334
+        },
+        {
+          "factor": 10.0,
+          "recall": 0.7083333333333334,
+          "labels_per_image": 0.8541666666666666
+        },
+        {
+          "factor": 25.0,
+          "recall": 0.625,
+          "labels_per_image": 0.7083333333333334
+        }
+      ]
+    },
+    "event": {
+      "images": 33,
+      "gt_score_percentiles": {
+        "p10": 1.4697697224619336e-06,
+        "p25": 0.00015250127762556076,
+        "p50": 0.003921407740563154,
+        "p75": 0.016354281455278397,
+        "p90": 0.12086516618728645
+      },
+      "neg_score_percentiles": {
+        "p50": 1.9600323447610535e-10,
+        "p90": 3.2393316118373105e-08,
+        "p99": 8.511004907631993e-06
+      },
+      "gt_rank": {
+        "top1": 0.6363636363636364,
+        "top5": 0.8787878787878788,
+        "top10": 0.9090909090909091,
+        "top15": 0.9090909090909091,
+        "median_rank": 1.0
+      },
+      "threshold_sweep": [
+        {
+          "threshold": 1e-05,
+          "recall": 0.7878787878787878,
+          "labels_per_image": 4.393939393939394
+        },
+        {
+          "threshold": 5e-05,
+          "recall": 0.7878787878787878,
+          "labels_per_image": 2.606060606060606
+        },
+        {
+          "threshold": 0.0001,
+          "recall": 0.7575757575757576,
+          "labels_per_image": 2.0606060606060606
+        },
+        {
+          "threshold": 0.0005,
+          "recall": 0.696969696969697,
+          "labels_per_image": 1.2424242424242424
+        },
+        {
+          "threshold": 0.001,
+          "recall": 0.6666666666666666,
+          "labels_per_image": 1.121212121212121
+        },
+        {
+          "threshold": 0.005,
+          "recall": 0.48484848484848486,
+          "labels_per_image": 0.696969696969697
+        },
+        {
+          "threshold": 0.01,
+          "recall": 0.36363636363636365,
+          "labels_per_image": 0.5151515151515151
+        },
+        {
+          "threshold": 0.02,
+          "recall": 0.21212121212121213,
+          "labels_per_image": 0.36363636363636365
+        }
+      ],
+      "generic_baseline_margin_sweep": [
+        {
+          "factor": 1.0,
+          "recall": 0.7575757575757576,
+          "labels_per_image": 1.4848484848484849
+        },
+        {
+          "factor": 2.0,
+          "recall": 0.7575757575757576,
+          "labels_per_image": 1.4242424242424243
+        },
+        {
+          "factor": 5.0,
+          "recall": 0.696969696969697,
+          "labels_per_image": 1.1515151515151516
+        },
+        {
+          "factor": 10.0,
+          "recall": 0.6363636363636364,
+          "labels_per_image": 1.0
+        },
+        {
+          "factor": 25.0,
+          "recall": 0.48484848484848486,
+          "labels_per_image": 0.7575757575757576
+        }
+      ]
+    },
+    "attribute": {
+      "images": 24,
+      "gt_score_percentiles": {
+        "p10": 0.00022467100498033688,
+        "p25": 0.0019608679285738617,
+        "p50": 0.005120208952575922,
+        "p75": 0.027230489533394575,
+        "p90": 0.11005476191639897
+      },
+      "neg_score_percentiles": {
+        "p50": 3.0255171978854634e-10,
+        "p90": 8.65433342767119e-08,
+        "p99": 5.263684215606205e-05
+      },
+      "gt_rank": {
+        "top1": 0.6666666666666666,
+        "top5": 0.9583333333333334,
+        "top10": 1.0,
+        "top15": 1.0,
+        "median_rank": 1.0
+      },
+      "threshold_sweep": [
+        {
+          "threshold": 1e-05,
+          "recall": 1.0,
+          "labels_per_image": 7.75
+        },
+        {
+          "threshold": 5e-05,
+          "recall": 1.0,
+          "labels_per_image": 5.125
+        },
+        {
+          "threshold": 0.0001,
+          "recall": 1.0,
+          "labels_per_image": 3.6666666666666665
+        },
+        {
+          "threshold": 0.0005,
+          "recall": 0.8333333333333334,
+          "labels_per_image": 2.375
+        },
+        {
+          "threshold": 0.001,
+          "recall": 0.7916666666666666,
+          "labels_per_image": 1.9583333333333333
+        },
+        {
+          "threshold": 0.005,
+          "recall": 0.5,
+          "labels_per_image": 0.8333333333333334
+        },
+        {
+          "threshold": 0.01,
+          "recall": 0.375,
+          "labels_per_image": 0.6666666666666666
+        },
+        {
+          "threshold": 0.02,
+          "recall": 0.2916666666666667,
+          "labels_per_image": 0.4166666666666667
+        }
+      ],
+      "generic_baseline_margin_sweep": [
+        {
+          "factor": 1.0,
+          "recall": 0.875,
+          "labels_per_image": 3.1666666666666665
+        },
+        {
+          "factor": 2.0,
+          "recall": 0.8333333333333334,
+          "labels_per_image": 2.7083333333333335
+        },
+        {
+          "factor": 5.0,
+          "recall": 0.8333333333333334,
+          "labels_per_image": 2.0416666666666665
+        },
+        {
+          "factor": 10.0,
+          "recall": 0.75,
+          "labels_per_image": 1.5
+        },
+        {
+          "factor": 25.0,
+          "recall": 0.625,
+          "labels_per_image": 0.9583333333333334
+        }
+      ]
+    }
+  },
+  "worst_ranked_images": [
+    {
+      "file": "easter__0.jpg",
+      "gt_rank": 20,
+      "gt_score": 3.9649776795158687e-08,
+      "top_labels": [
+        "cheese",
+        "picnic basket",
+        "turkey",
+        "dessert",
+        "egg"
+      ]
+    },
+    {
+      "file": "lake__0.jpg",
+      "gt_rank": 20,
+      "gt_score": 1.549742137285648e-06,
+      "top_labels": [
+        "snowy mountain",
+        "hiking",
+        "glacier",
+        "mountain",
+        "snowfield"
+      ]
+    },
+    {
+      "file": "cricket__0.jpg",
+      "gt_rank": 19,
+      "gt_score": 1.1451775208115578e-06,
+      "top_labels": [
+        "street",
+        "parade",
+        "marathon",
+        "plaza",
+        "night"
+      ]
+    },
+    {
+      "file": "picnic__0.jpg",
+      "gt_rank": 19,
+      "gt_score": 5.164933440937602e-07,
+      "top_labels": [
+        "campsite",
+        "zoo",
+        "creek",
+        "cabin",
+        "porch"
+      ]
+    },
+    {
+      "file": "street__0.jpg",
+      "gt_rank": 16,
+      "gt_score": 5.143172074895119e-06,
+      "top_labels": [
+        "hallway",
+        "airport terminal",
+        "zoo",
+        "shopping mall",
+        "arena"
+      ]
+    },
+    {
+      "file": "street__1.jpg",
+      "gt_rank": 16,
+      "gt_score": 3.794107442445238e-06,
+      "top_labels": [
+        "city",
+        "bridge",
+        "skyscraper",
+        "ice rink",
+        "subway station"
+      ]
+    },
+    {
+      "file": "church__0.jpg",
+      "gt_rank": 16,
+      "gt_score": 1.689114128566871e-06,
+      "top_labels": [
+        "tower",
+        "palace",
+        "skyscraper",
+        "city",
+        "plaza"
+      ]
+    },
+    {
+      "file": "playground__1.jpg",
+      "gt_rank": 13,
+      "gt_score": 9.065108770300867e-07,
+      "top_labels": [
+        "courtyard",
+        "hotel",
+        "apartment building",
+        "parking lot",
+        "phone booth"
+      ]
+    },
+    {
+      "file": "forest__1.jpg",
+      "gt_rank": 11,
+      "gt_score": 3.932223989977501e-06,
+      "top_labels": [
+        "squirrel",
+        "tree",
+        "tree house",
+        "ruins",
+        "lizard"
+      ]
+    },
+    {
+      "file": "kitchen__1.jpg",
+      "gt_rank": 8,
+      "gt_score": 5.929802426862807e-08,
+      "top_labels": [
+        "convenience store",
+        "selfie",
+        "sunglasses",
+        "pantry",
+        "mirror"
+      ]
+    },
+    {
+      "file": "mosque__0.jpg",
+      "gt_rank": 7,
+      "gt_score": 2.155809170290013e-06,
+      "top_labels": [
+        "tower",
+        "lighthouse",
+        "aerial view",
+        "castle",
+        "palace"
+      ]
+    },
+    {
+      "file": "parade__0.jpg",
+      "gt_rank": 7,
+      "gt_score": 6.716193752254185e-07,
+      "top_labels": [
+        "ganesh chaturthi",
+        "durga puja",
+        "palace",
+        "temple",
+        "sculpture"
+      ]
+    },
+    {
+      "file": "tent__1.jpg",
+      "gt_rank": 6,
+      "gt_score": 3.207558734175109e-07,
+      "top_labels": [
+        "group photo",
+        "zoo",
+        "cabin",
+        "campsite",
+        "night"
+      ]
+    },
+    {
+      "file": "silhouette__0.jpg",
+      "gt_rank": 6,
+      "gt_score": 0.0002625813358463347,
+      "top_labels": [
+        "canoe",
+        "sunset",
+        "kayaking",
+        "sunrise",
+        "river"
+      ]
+    },
+    {
+      "file": "butterfly__0.jpg",
+      "gt_rank": 5,
+      "gt_score": 1.216795681102667e-06,
+      "top_labels": [
+        "flower",
+        "snake",
+        "bee",
+        "rainforest",
+        "butterfly"
+      ]
+    }
+  ]
+}

--- a/backend/scripts/vocabulary/eval_manifest.json
+++ b/backend/scripts/vocabulary/eval_manifest.json
@@ -1,0 +1,406 @@
+{
+  "notes": "Stratified eval set for bucket calibration. query is a Wikimedia Commons search; label is the expected ground-truth vocabulary entry.",
+  "images_per_label": 2,
+  "entries": [
+    {
+      "label": "beach",
+      "category": "scene",
+      "query": "sandy beach"
+    },
+    {
+      "label": "forest",
+      "category": "scene",
+      "query": "forest trees"
+    },
+    {
+      "label": "mountain",
+      "category": "scene",
+      "query": "mountain peak"
+    },
+    {
+      "label": "waterfall",
+      "category": "scene",
+      "query": "waterfall"
+    },
+    {
+      "label": "desert",
+      "category": "scene",
+      "query": "desert sand dunes"
+    },
+    {
+      "label": "city",
+      "category": "scene",
+      "query": "city skyline"
+    },
+    {
+      "label": "street",
+      "category": "scene",
+      "query": "city street pedestrians"
+    },
+    {
+      "label": "bridge",
+      "category": "scene",
+      "query": "suspension bridge"
+    },
+    {
+      "label": "castle",
+      "category": "scene",
+      "query": "medieval castle"
+    },
+    {
+      "label": "church",
+      "category": "scene",
+      "query": "church building"
+    },
+    {
+      "label": "temple",
+      "category": "scene",
+      "query": "hindu temple"
+    },
+    {
+      "label": "mosque",
+      "category": "scene",
+      "query": "mosque minaret"
+    },
+    {
+      "label": "library",
+      "category": "scene",
+      "query": "library bookshelves"
+    },
+    {
+      "label": "kitchen",
+      "category": "scene",
+      "query": "home kitchen interior"
+    },
+    {
+      "label": "bedroom",
+      "category": "scene",
+      "query": "bedroom interior"
+    },
+    {
+      "label": "living room",
+      "category": "scene",
+      "query": "living room interior"
+    },
+    {
+      "label": "swimming pool",
+      "category": "scene",
+      "query": "swimming pool"
+    },
+    {
+      "label": "stadium",
+      "category": "scene",
+      "query": "football stadium crowd"
+    },
+    {
+      "label": "market",
+      "category": "scene",
+      "query": "street market vegetables"
+    },
+    {
+      "label": "harbor",
+      "category": "scene",
+      "query": "harbor boats"
+    },
+    {
+      "label": "lake",
+      "category": "scene",
+      "query": "mountain lake"
+    },
+    {
+      "label": "playground",
+      "category": "scene",
+      "query": "children playground"
+    },
+    {
+      "label": "snowy mountain",
+      "category": "scene",
+      "query": "snow covered mountain"
+    },
+    {
+      "label": "vineyard",
+      "category": "scene",
+      "query": "vineyard rows"
+    },
+    {
+      "label": "guitar",
+      "category": "object",
+      "query": "playing acoustic guitar"
+    },
+    {
+      "label": "piano",
+      "category": "object",
+      "query": "grand piano"
+    },
+    {
+      "label": "camera",
+      "category": "object",
+      "query": "dslr camera"
+    },
+    {
+      "label": "balloon",
+      "category": "object",
+      "query": "colorful balloons"
+    },
+    {
+      "label": "candle",
+      "category": "object",
+      "query": "burning candle"
+    },
+    {
+      "label": "butterfly",
+      "category": "object",
+      "query": "butterfly on flower"
+    },
+    {
+      "label": "tiger",
+      "category": "object",
+      "query": "tiger"
+    },
+    {
+      "label": "lion",
+      "category": "object",
+      "query": "male lion"
+    },
+    {
+      "label": "panda",
+      "category": "object",
+      "query": "giant panda"
+    },
+    {
+      "label": "penguin",
+      "category": "object",
+      "query": "penguin"
+    },
+    {
+      "label": "parrot",
+      "category": "object",
+      "query": "parrot bird"
+    },
+    {
+      "label": "dolphin",
+      "category": "object",
+      "query": "dolphin jumping"
+    },
+    {
+      "label": "strawberry",
+      "category": "object",
+      "query": "strawberries"
+    },
+    {
+      "label": "watermelon",
+      "category": "object",
+      "query": "watermelon slices"
+    },
+    {
+      "label": "ice cream",
+      "category": "object",
+      "query": "ice cream cone"
+    },
+    {
+      "label": "hamburger",
+      "category": "object",
+      "query": "hamburger"
+    },
+    {
+      "label": "sushi",
+      "category": "object",
+      "query": "sushi rolls"
+    },
+    {
+      "label": "coffee",
+      "category": "object",
+      "query": "cup of coffee"
+    },
+    {
+      "label": "wine",
+      "category": "object",
+      "query": "glass of red wine"
+    },
+    {
+      "label": "christmas tree",
+      "category": "object",
+      "query": "decorated christmas tree"
+    },
+    {
+      "label": "sunflower",
+      "category": "object",
+      "query": "sunflower field"
+    },
+    {
+      "label": "rose",
+      "category": "object",
+      "query": "red rose flower"
+    },
+    {
+      "label": "tent",
+      "category": "object",
+      "query": "camping tent"
+    },
+    {
+      "label": "watch",
+      "category": "object",
+      "query": "wristwatch"
+    },
+    {
+      "label": "wedding",
+      "category": "event",
+      "query": "wedding ceremony bride groom"
+    },
+    {
+      "label": "birthday",
+      "category": "event",
+      "query": "birthday cake candles party"
+    },
+    {
+      "label": "graduation",
+      "category": "event",
+      "query": "graduation ceremony cap gown"
+    },
+    {
+      "label": "concert",
+      "category": "event",
+      "query": "rock concert crowd stage"
+    },
+    {
+      "label": "parade",
+      "category": "event",
+      "query": "street parade float"
+    },
+    {
+      "label": "fireworks",
+      "category": "event",
+      "query": "fireworks display night"
+    },
+    {
+      "label": "picnic",
+      "category": "event",
+      "query": "picnic blanket park"
+    },
+    {
+      "label": "hiking",
+      "category": "event",
+      "query": "hikers backpack trail"
+    },
+    {
+      "label": "surfing",
+      "category": "event",
+      "query": "surfer riding wave"
+    },
+    {
+      "label": "skiing",
+      "category": "event",
+      "query": "skier slope"
+    },
+    {
+      "label": "marathon",
+      "category": "event",
+      "query": "marathon runners race"
+    },
+    {
+      "label": "yoga",
+      "category": "event",
+      "query": "yoga pose mat"
+    },
+    {
+      "label": "cricket",
+      "category": "event",
+      "query": "cricket match batsman"
+    },
+    {
+      "label": "diwali",
+      "category": "event",
+      "query": "diwali diya oil lamps"
+    },
+    {
+      "label": "holi",
+      "category": "event",
+      "query": "holi festival colored powder"
+    },
+    {
+      "label": "christmas",
+      "category": "event",
+      "query": "christmas presents tree"
+    },
+    {
+      "label": "halloween",
+      "category": "event",
+      "query": "halloween jack o lantern"
+    },
+    {
+      "label": "easter",
+      "category": "event",
+      "query": "easter eggs decorated"
+    },
+    {
+      "label": "safari",
+      "category": "event",
+      "query": "safari jeep wildlife"
+    },
+    {
+      "label": "barbecue",
+      "category": "event",
+      "query": "barbecue grill food"
+    },
+    {
+      "label": "sunset",
+      "category": "attribute",
+      "query": "sunset over sea"
+    },
+    {
+      "label": "sunrise",
+      "category": "attribute",
+      "query": "sunrise landscape"
+    },
+    {
+      "label": "night",
+      "category": "attribute",
+      "query": "city at night"
+    },
+    {
+      "label": "rainbow",
+      "category": "attribute",
+      "query": "rainbow landscape"
+    },
+    {
+      "label": "snow",
+      "category": "attribute",
+      "query": "snow covered trees"
+    },
+    {
+      "label": "rain",
+      "category": "attribute",
+      "query": "rain umbrella street"
+    },
+    {
+      "label": "fog",
+      "category": "attribute",
+      "query": "foggy forest morning"
+    },
+    {
+      "label": "clouds",
+      "category": "attribute",
+      "query": "cumulus clouds sky"
+    },
+    {
+      "label": "autumn",
+      "category": "attribute",
+      "query": "autumn leaves park"
+    },
+    {
+      "label": "silhouette",
+      "category": "attribute",
+      "query": "person silhouette sunset"
+    },
+    {
+      "label": "reflection",
+      "category": "attribute",
+      "query": "mountain reflection lake"
+    },
+    {
+      "label": "aerial view",
+      "category": "attribute",
+      "query": "aerial view drone city"
+    }
+  ]
+}

--- a/backend/scripts/vocabulary/raw_candidates.json
+++ b/backend/scripts/vocabulary/raw_candidates.json
@@ -1,0 +1,6073 @@
+{
+  "generated_by": "scripts/build_semantic_vocabulary.py",
+  "sources": {
+    "places365": "https://raw.githubusercontent.com/CSAILVision/places365/master/categories_places365.txt",
+    "open_images": "https://storage.googleapis.com/openimages/v7/oidv7-class-descriptions-boxable.csv",
+    "coco_exclusion": "app/utils/YOLO.py class_names"
+  },
+  "candidate_count": 838,
+  "candidates": [
+    {
+      "name": "accordion",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "adhesive tape",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "aircraft",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "airfield",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "airplane cabin",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "airport terminal",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "alarm clock",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "alcove",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "alley",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "alpaca",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "ambulance",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "amphitheater",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "amusement arcade",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "amusement park",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "animal",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "ant",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "antelope",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "apartment building",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ],
+      "variants": [
+        "outdoor"
+      ]
+    },
+    {
+      "name": "aquarium",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "aqueduct",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "arcade",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "arch",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "archaelogical excavation",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "archive",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "arena",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ],
+      "variants": [
+        "hockey",
+        "performance",
+        "rodeo"
+      ]
+    },
+    {
+      "name": "armadillo",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "army base",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "art gallery",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "art school",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "art studio",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "artichoke",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "artists loft",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "assembly line",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "athletic field",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ],
+      "variants": [
+        "outdoor"
+      ]
+    },
+    {
+      "name": "atrium",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ],
+      "variants": [
+        "public"
+      ]
+    },
+    {
+      "name": "attic",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "auditorium",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "auto factory",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "auto part",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "auto showroom",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "axe",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "badlands",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "bagel",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "baked goods",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "bakery",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ],
+      "variants": [
+        "shop"
+      ]
+    },
+    {
+      "name": "balance beam",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "balcony",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ],
+      "variants": [
+        "exterior",
+        "interior"
+      ]
+    },
+    {
+      "name": "ball (object)",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "ball pit",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "balloon",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "ballroom",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "bamboo forest",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "band-aid",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "banjo",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "bank vault",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "banquet hall",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "bar",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "barge",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "barn",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "barndoor",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "barrel",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "baseball field",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "basement",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "basketball court",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ],
+      "variants": [
+        "indoor"
+      ]
+    },
+    {
+      "name": "bat (animal)",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "bathroom",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "bathroom accessory",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "bathroom cabinet",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "bathtub",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "bazaar",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ],
+      "variants": [
+        "indoor",
+        "outdoor"
+      ]
+    },
+    {
+      "name": "beach",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "beach house",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "beaker",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "beard",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "beauty salon",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "bedchamber",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "bedroom",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "bee",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "beehive",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "beer",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "beer garden",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "beer hall",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "beetle",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "bell pepper",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "belt",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "berth",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "bicycle helmet",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "bicycle wheel",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "bidet",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "billboard",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "billiard table",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "binoculars",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "biology laboratory",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "blender",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "blue jay",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "boardwalk",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "boat deck",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "boathouse",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "bomb",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "bookcase",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "bookstore",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "boot",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "booth",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ],
+      "variants": [
+        "indoor"
+      ]
+    },
+    {
+      "name": "botanical garden",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "bottle opener",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "bow and arrow",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "bow window",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ],
+      "variants": [
+        "indoor"
+      ]
+    },
+    {
+      "name": "bowling alley",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "bowling equipment",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "box",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "boxing ring",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "brassiere",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "bread",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "bridge",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "briefcase",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "bronze sculpture",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "brown bear",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "building",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "building facade",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "bull",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "bullring",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "burial chamber",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "burrito",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "bus interior",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "bus station",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ],
+      "variants": [
+        "indoor"
+      ]
+    },
+    {
+      "name": "bust",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "butchers shop",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "butte",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "butterfly",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "cabbage",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "cabin",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ],
+      "variants": [
+        "outdoor"
+      ]
+    },
+    {
+      "name": "cabinetry",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "cafeteria",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "cake stand",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "calculator",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "camel",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "camera",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "campsite",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "campus",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "can opener",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "canal",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ],
+      "variants": [
+        "natural",
+        "urban"
+      ]
+    },
+    {
+      "name": "canary",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "candle",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "candy",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "candy store",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "cannon",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "canoe",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "cantaloupe",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "canyon",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "car interior",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "carnivore",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "carrousel",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "cart",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "cassette deck",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "castle",
+      "category": "scene",
+      "sources": [
+        "places365",
+        "open_images"
+      ]
+    },
+    {
+      "name": "cat furniture",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "catacomb",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "caterpillar",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "ceiling fan",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "cello",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "cemetery",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "centipede",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "chainsaw",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "chalet",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "cheese",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "cheetah",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "chemistry lab",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "chest of drawers",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "chicken",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "childs room",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "chime",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "chisel",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "chopsticks",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "christmas tree",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "church",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ],
+      "variants": [
+        "indoor",
+        "outdoor"
+      ]
+    },
+    {
+      "name": "classroom",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "clean room",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "cliff",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "closet",
+      "category": "scene",
+      "sources": [
+        "places365",
+        "open_images"
+      ]
+    },
+    {
+      "name": "clothing",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "clothing store",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "coast",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "coat",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "cockpit",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "cocktail",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "cocktail shaker",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "coconut",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "coffee (drink)",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "coffee cup",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "coffee shop",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "coffee table",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "coffeemaker",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "coin",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "common fig",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "common sunflower",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "computer monitor",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "computer room",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "conference center",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "conference room",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "construction site",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "container",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "convenience store",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "cookie",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "cooking spray",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "corded phone",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "corn field",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "corral",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "corridor",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "cosmetics",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "cottage",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "countertop",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "courthouse",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "courtyard",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "cowboy hat",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "crab",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "cream",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "creek",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "crevasse",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "cricket ball",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "crocodile",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "croissant",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "crosswalk",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "crown",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "crutch",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "cucumber",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "cupboard",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "curtain",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "cutting board",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "dagger",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "dairy product",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "dam",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "deer",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "delicatessen",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "department store",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "desert",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ],
+      "variants": [
+        "sand",
+        "vegetation"
+      ]
+    },
+    {
+      "name": "desert road",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "desk",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "dessert",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "diaper",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "dice",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "digital clock",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "diner",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ],
+      "variants": [
+        "outdoor"
+      ]
+    },
+    {
+      "name": "dining hall",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "dining room",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "dinosaur",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "discotheque",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "dishwasher",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "dog bed",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "doll",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "dolphin",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "door",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "door handle",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "doorway",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ],
+      "variants": [
+        "outdoor"
+      ]
+    },
+    {
+      "name": "dorm room",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "downtown",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "dragonfly",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "drawer",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "dress",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "dressing room",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "drill (tool)",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "drink",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "drinking straw",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "driveway",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "drugstore",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "drum",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "duck",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "dumbbell",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "eagle",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "earring",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "egg",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "elevator",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ],
+      "variants": [
+        "door"
+      ]
+    },
+    {
+      "name": "elevator lobby",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "elevator shaft",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "embassy",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "engine room",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "entrance hall",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "envelope",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "eraser",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "escalator",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ],
+      "variants": [
+        "indoor"
+      ]
+    },
+    {
+      "name": "excavation",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "fabric store",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "face powder",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "facial tissue holder",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "falcon",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "farm",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "fashion accessory",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "fast food",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "fastfood restaurant",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "fax",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "fedora",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "field",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ],
+      "variants": [
+        "cultivated",
+        "wild"
+      ]
+    },
+    {
+      "name": "field road",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "filing cabinet",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "fire escape",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "fire station",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "fireplace",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "fish",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "fishpond",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "fixed-wing aircraft",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "flag",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "flashlight",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "flea market",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ],
+      "variants": [
+        "indoor"
+      ]
+    },
+    {
+      "name": "florist shop",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ],
+      "variants": [
+        "indoor"
+      ]
+    },
+    {
+      "name": "flower",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "flowerpot",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "flute",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "food",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "food court",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "food processor",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "football",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "football field",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "football helmet",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "footwear",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "forest",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ],
+      "variants": [
+        "broadleaf"
+      ]
+    },
+    {
+      "name": "forest path",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "forest road",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "formal garden",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "fountain",
+      "category": "scene",
+      "sources": [
+        "places365",
+        "open_images"
+      ]
+    },
+    {
+      "name": "fox",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "french fries",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "french horn",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "frog",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "fruit",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "frying pan",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "furniture",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "galley",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "garage",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ],
+      "variants": [
+        "indoor",
+        "outdoor"
+      ]
+    },
+    {
+      "name": "garden asparagus",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "gas station",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "gas stove",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "gazebo",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ],
+      "variants": [
+        "exterior"
+      ]
+    },
+    {
+      "name": "general store",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ],
+      "variants": [
+        "indoor",
+        "outdoor"
+      ]
+    },
+    {
+      "name": "gift shop",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "glacier",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "glasses",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "glove",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "goat",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "goggles",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "goldfish",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "golf ball",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "golf cart",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "golf course",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "gondola",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "goose",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "grape",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "grapefruit",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "greenhouse",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ],
+      "variants": [
+        "indoor",
+        "outdoor"
+      ]
+    },
+    {
+      "name": "grinder",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "grotto",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "guacamole",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "guitar",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "gymnasium",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ],
+      "variants": [
+        "indoor"
+      ]
+    },
+    {
+      "name": "hair spray",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "hamburger",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "hammer",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "hamster",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "hand dryer",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "handgun",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "hangar",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ],
+      "variants": [
+        "indoor",
+        "outdoor"
+      ]
+    },
+    {
+      "name": "harbor",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "harbor seal",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "hardware store",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "harmonica",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "harp",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "harpsichord",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "hat",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "hayfield",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "headphones",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "heater",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "hedgehog",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "helicopter",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "heliport",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "helmet",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "high heels",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "highway",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "hiking equipment",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "hippopotamus",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "home appliance",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "home office",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "home theater",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "honeycomb",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "horizontal bar",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "hospital",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "hospital room",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "hot spring",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "hotel",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ],
+      "variants": [
+        "outdoor"
+      ]
+    },
+    {
+      "name": "hotel room",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "house",
+      "category": "scene",
+      "sources": [
+        "places365",
+        "open_images"
+      ]
+    },
+    {
+      "name": "humidifier",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "hunting lodge",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ],
+      "variants": [
+        "outdoor"
+      ]
+    },
+    {
+      "name": "ice cream",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "ice cream parlor",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "ice floe",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "ice shelf",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "ice skating rink",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ],
+      "variants": [
+        "indoor",
+        "outdoor"
+      ]
+    },
+    {
+      "name": "iceberg",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "igloo",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "indoor rower",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "industrial area",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "infant bed",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "inn",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ],
+      "variants": [
+        "outdoor"
+      ]
+    },
+    {
+      "name": "insect",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "invertebrate",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "ipod",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "islet",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "isopod",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "jacket",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "jacuzzi",
+      "category": "scene",
+      "sources": [
+        "places365",
+        "open_images"
+      ],
+      "variants": [
+        "indoor"
+      ]
+    },
+    {
+      "name": "jaguar (animal)",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "jail cell",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "japanese garden",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "jeans",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "jellyfish",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "jet ski",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "jewelry shop",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "jug",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "juice",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "junkyard",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "kangaroo",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "kasbah",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "kennel",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ],
+      "variants": [
+        "outdoor"
+      ]
+    },
+    {
+      "name": "kettle",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "kindergarden classroom",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "kitchen",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "kitchen appliance",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "kitchen knife",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "kitchen utensil",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "kitchenware",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "koala",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "ladder",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "ladle",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "ladybug",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "lagoon",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "lake",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ],
+      "variants": [
+        "natural"
+      ]
+    },
+    {
+      "name": "lamp",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "land vehicle",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "landfill",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "landing deck",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "lantern",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "laundromat",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "lavender (plant)",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "lawn",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "lecture room",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "legislative chamber",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "lemon (plant)",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "leopard",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "library",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ],
+      "variants": [
+        "indoor",
+        "outdoor"
+      ]
+    },
+    {
+      "name": "light bulb",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "light switch",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "lighthouse",
+      "category": "scene",
+      "sources": [
+        "places365",
+        "open_images"
+      ]
+    },
+    {
+      "name": "lily",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "limousine",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "lion",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "lipstick",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "living room",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "lizard",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "loading dock",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "lobby",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "lobster",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "lock chamber",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "locker room",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "loveseat",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "luggage and bags",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "lynx",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "magpie",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "mammal",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "mango",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "mansion",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "manufactured home",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "maple",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "maraca",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "marine invertebrates",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "marine mammal",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "market",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ],
+      "variants": [
+        "indoor",
+        "outdoor"
+      ]
+    },
+    {
+      "name": "marsh",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "martial arts gym",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "mausoleum",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "measuring cup",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "mechanical fan",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "medical equipment",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "medina",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "mezzanine",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "microphone",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "milk",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "miniskirt",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "mirror",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "missile",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "mixer",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "mixing bowl",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "moat",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ],
+      "variants": [
+        "water"
+      ]
+    },
+    {
+      "name": "monkey",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "mosque",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ],
+      "variants": [
+        "outdoor"
+      ]
+    },
+    {
+      "name": "motel",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "moths and butterflies",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "mountain",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "mountain path",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "mountain snowy",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "movie theater",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ],
+      "variants": [
+        "indoor"
+      ]
+    },
+    {
+      "name": "muffin",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "mug",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "mule",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "museum",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ],
+      "variants": [
+        "indoor",
+        "outdoor"
+      ]
+    },
+    {
+      "name": "mushroom",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "music studio",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "musical instrument",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "musical keyboard",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "nail (construction)",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "natural history museum",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "necklace",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "nightstand",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "nursery",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "nursing home",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "oast house",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "oboe",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "ocean",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "office",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "office building",
+      "category": "scene",
+      "sources": [
+        "places365",
+        "open_images"
+      ]
+    },
+    {
+      "name": "office cubicles",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "office supplies",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "oilrig",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "operating room",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "orange (fruit)",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "orchard",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "orchestra pit",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "organ (musical instrument)",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "ostrich",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "otter",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "owl",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "oyster",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "paddle",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "pagoda",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "palace",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "palm tree",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "pancake",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "panda",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "pantry",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "paper cutter",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "paper towel",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "parachute",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "park",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "parking garage",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ],
+      "variants": [
+        "indoor",
+        "outdoor"
+      ]
+    },
+    {
+      "name": "parking lot",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "parrot",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "pasta",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "pastry",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "pasture",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "patio",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "pavilion",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "peach",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "pear",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "pen",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "pencil case",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "pencil sharpener",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "penguin",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "perfume",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "personal care",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "personal flotation device",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "pet shop",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "pharmacy",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "phone booth",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "physics laboratory",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "piano",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "picnic area",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "picnic basket",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "picture frame",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "pier",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "pig",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "pillow",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "pineapple",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "pitcher (container)",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "pizza cutter",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "pizzeria",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "plant",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "plastic bag",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "plate",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "platter",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "playground",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "playroom",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "plaza",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "plumbing fixture",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "polar bear",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "pomegranate",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "pond",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "popcorn",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "porch",
+      "category": "scene",
+      "sources": [
+        "places365",
+        "open_images"
+      ]
+    },
+    {
+      "name": "porcupine",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "poster",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "potato",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "power plugs and sockets",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "pressure cooker",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "pretzel",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "printer",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "promenade",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "pub",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ],
+      "variants": [
+        "indoor"
+      ]
+    },
+    {
+      "name": "pumpkin",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "punching bag",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "rabbit",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "raccoon",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "racecourse",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "raceway",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "racket",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "radish",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "raft",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "railroad track",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "rainforest",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "ratchet (device)",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "raven",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "rays and skates",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "reception",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "recreation room",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "red panda",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "repair shop",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "reptile",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "residential neighborhood",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "restaurant",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "restaurant kitchen",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "restaurant patio",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "rhinoceros",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "rice paddy",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "rifle",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "ring binder",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "river",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "rock arch",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "rocket",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "roller skates",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "roof garden",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "rope bridge",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "rose",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "rugby ball",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "ruin",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "ruler",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "runway",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "salad",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "salt and pepper shakers",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "sandal",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "sandbox",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "saucer",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "sauna",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "saxophone",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "scale",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "scarf",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "schoolhouse",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "science museum",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "scoreboard",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "scorpion",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "screwdriver",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "sculpture",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "sea lion",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "sea turtle",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "seafood",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "seahorse",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "seat belt",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "segway",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "server room",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "serving tray",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "sewing machine",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "shark",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "shed",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "shelf",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "shellfish",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "shirt",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "shoe shop",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "shopfront",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "shopping mall",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ],
+      "variants": [
+        "indoor"
+      ]
+    },
+    {
+      "name": "shorts",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "shotgun",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "shower",
+      "category": "scene",
+      "sources": [
+        "places365",
+        "open_images"
+      ]
+    },
+    {
+      "name": "shrimp",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "ski resort",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "ski slope",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "skirt",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "skull",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "skunk",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "sky",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "skyscraper",
+      "category": "scene",
+      "sources": [
+        "places365",
+        "open_images"
+      ]
+    },
+    {
+      "name": "slow cooker",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "slum",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "snack",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "snail",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "snake",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "snowfield",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "snowman",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "snowmobile",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "snowplow",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "soap dispenser",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "soccer field",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "sock",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "sombrero",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "sparrow",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "spatula",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "spice rack",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "spider",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "sports equipment",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "sports uniform",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "squash (plant)",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "squid",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "squirrel",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "stable",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "stadium",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ],
+      "variants": [
+        "baseball",
+        "football",
+        "soccer"
+      ]
+    },
+    {
+      "name": "stage",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ],
+      "variants": [
+        "indoor",
+        "outdoor"
+      ]
+    },
+    {
+      "name": "staircase",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "stairs",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "stapler",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "starfish",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "stationary bicycle",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "stethoscope",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "stool",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "storage room",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "strawberry",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "street",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "street light",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "stretcher",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "studio couch",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "submarine",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "submarine sandwich",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "subway station",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ],
+      "variants": [
+        "platform"
+      ]
+    },
+    {
+      "name": "suit",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "sun hat",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "sunglasses",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "supermarket",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "sushi",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "sushi bar",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "swamp",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "swan",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "swim cap",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "swimming hole",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "swimming pool",
+      "category": "scene",
+      "sources": [
+        "places365",
+        "open_images"
+      ],
+      "variants": [
+        "indoor",
+        "outdoor"
+      ]
+    },
+    {
+      "name": "swimwear",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "sword",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "synagogue",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ],
+      "variants": [
+        "outdoor"
+      ]
+    },
+    {
+      "name": "syringe",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "table",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "table tennis racket",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "tablet computer",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "tableware",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "taco",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "tank",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "tap",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "tart",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "taxi",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "tea",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "teapot",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "telephone",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "television room",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "television studio",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "temple",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ],
+      "variants": [
+        "asia"
+      ]
+    },
+    {
+      "name": "tennis ball",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "tent",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "throne room",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "tiara",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "tick",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "ticket booth",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "tiger",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "tin can",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "tire",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "toilet paper",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "tomato",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "tool",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "topiary garden",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "torch",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "tortoise",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "towel",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "tower",
+      "category": "scene",
+      "sources": [
+        "places365",
+        "open_images"
+      ]
+    },
+    {
+      "name": "toy",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "toyshop",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "traffic sign",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "train interior",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "train station",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ],
+      "variants": [
+        "platform"
+      ]
+    },
+    {
+      "name": "training bench",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "treadmill",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "tree",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "tree farm",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "tree house",
+      "category": "scene",
+      "sources": [
+        "places365",
+        "open_images"
+      ]
+    },
+    {
+      "name": "trench",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "tripod",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "trombone",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "trousers",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "trumpet",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "tundra",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "turkey",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "turtle",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "underwater",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ],
+      "variants": [
+        "ocean deep"
+      ]
+    },
+    {
+      "name": "unicycle",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "utility room",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "valley",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "van",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "vegetable",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "vegetable garden",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "vehicle",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "vehicle registration plate",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "veterinarians office",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "viaduct",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "village",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "vineyard",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "violin",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "volcano",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "volleyball (ball)",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "volleyball court",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ],
+      "variants": [
+        "outdoor"
+      ]
+    },
+    {
+      "name": "waffle",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "waffle iron",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "waiting room",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "wall clock",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "wardrobe",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "washing machine",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "waste container",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "watch",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "water park",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "water tower",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "watercraft",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "waterfall",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "watering hole",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "watermelon",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "wave",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "weapon",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "wet bar",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "whale",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "wheat field",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "wheel",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "wheelchair",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "whisk",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "whiteboard",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "willow",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "wind farm",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "windmill",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "window",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "window blind",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "wine",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "wine rack",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "winter melon",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "wok",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "wood-burning stove",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "woodpecker",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "worm",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "wrench",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    },
+    {
+      "name": "yard",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "youth hostel",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "zen garden",
+      "category": "scene",
+      "sources": [
+        "places365"
+      ]
+    },
+    {
+      "name": "zucchini",
+      "category": "object",
+      "sources": [
+        "open_images"
+      ]
+    }
+  ]
+}

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -9,6 +9,8 @@ from app.database.yolo_mapping import db_create_YOLO_classes_table
 from app.database.albums import db_create_albums_table, db_create_album_images_table
 from app.database.folders import db_create_folders_table
 from app.database.metadata import db_create_metadata_table
+from app.database.semantic_labels import db_create_semantic_labels_table
+from app.database.image_embeddings import db_create_image_embeddings_table
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -28,6 +30,8 @@ def setup_before_all_tests():
         db_create_albums_table()
         db_create_album_images_table()
         db_create_images_table()
+        db_create_semantic_labels_table()
+        db_create_image_embeddings_table()
         db_create_metadata_table()
         print("All database tables created successfully")
     except Exception as e:

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -1,5 +1,5 @@
 import json
-from unittest.mock import patch, AsyncMock, MagicMock
+from unittest.mock import patch, AsyncMock, MagicMock, call
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from app.routes.models import (
@@ -7,6 +7,10 @@ from app.routes.models import (
     submit_embedding_backfill_if_semantic,
 )
 from app.utils.images import image_util_process_unembedded_images
+from app.utils.semantic_labels import (
+    semantic_util_build_label_embeddings,
+    semantic_util_score_images,
+)
 
 app = FastAPI()
 app.include_router(models_router, prefix="/models")
@@ -119,7 +123,13 @@ class TestEmbeddingBackfillTrigger:
         submit_embedding_backfill_if_semantic(
             ["siglip2_base_vision", "siglip2_base_text", "facenet"], executor
         )
-        executor.submit.assert_called_once_with(image_util_process_unembedded_images)
+        executor.submit.assert_has_calls(
+            [
+                call(semantic_util_build_label_embeddings),
+                call(image_util_process_unembedded_images),
+                call(semantic_util_score_images),
+            ]
+        )
 
     def test_helper_ignores_non_semantic_keys(self):
         executor = MagicMock()
@@ -154,7 +164,13 @@ class TestEmbeddingBackfillTrigger:
 
     def test_setup_semantic_tier_triggers_backfill(self):
         executor = self._run_setup("semantic")
-        executor.submit.assert_called_once_with(image_util_process_unembedded_images)
+        executor.submit.assert_has_calls(
+            [
+                call(semantic_util_build_label_embeddings),
+                call(image_util_process_unembedded_images),
+                call(semantic_util_score_images),
+            ]
+        )
 
     def test_setup_yolo_tier_does_not_trigger_backfill(self):
         executor = self._run_setup("nano")
@@ -169,4 +185,10 @@ class TestEmbeddingBackfillTrigger:
                 response = local_client.post("/models/download/siglip2_base_vision")
                 assert response.status_code == 200
                 self._drain_until_complete(local_client, response.json()["task_id"])
-        executor.submit.assert_called_once_with(image_util_process_unembedded_images)
+        executor.submit.assert_has_calls(
+            [
+                call(semantic_util_build_label_embeddings),
+                call(image_util_process_unembedded_images),
+                call(semantic_util_score_images),
+            ]
+        )

--- a/backend/tests/test_semantic_labels.py
+++ b/backend/tests/test_semantic_labels.py
@@ -1,0 +1,396 @@
+import numpy as np
+import pytest
+
+import app.database.images as images_module
+import app.database.folders as folders_module
+import app.database.yolo_mapping as yolo_mapping_module
+from app.database.images import _connect, db_create_images_table
+from app.database.folders import db_create_folders_table
+from app.database.yolo_mapping import db_create_YOLO_classes_table
+from app.database.semantic_labels import (
+    SEMANTIC_CLASS_ID_OFFSET,
+    db_create_semantic_labels_table,
+    db_upsert_semantic_vocabulary,
+    db_get_labels_needing_embeddings,
+    db_update_label_embeddings,
+    db_get_active_label_embeddings,
+)
+from app.database.image_embeddings import (
+    db_create_image_embeddings_table,
+    db_upsert_image_embeddings,
+)
+from app.utils.semantic_labels import semantic_util_score_images
+
+MODEL_VERSION = "siglip2-base-patch16-224"
+
+
+@pytest.fixture(autouse=True)
+def _isolated_db(tmp_path, monkeypatch):
+    """Same isolation pattern as test_image_embeddings.py: every module that
+    opens a connection needs its own DATABASE_PATH attribute patched."""
+    db_path = str(tmp_path / "test_semantic_labels.sqlite3")
+    monkeypatch.setattr(images_module, "DATABASE_PATH", db_path)
+    monkeypatch.setattr(folders_module, "DATABASE_PATH", db_path)
+    monkeypatch.setattr(yolo_mapping_module, "DATABASE_PATH", db_path)
+
+    db_create_YOLO_classes_table()
+    db_create_folders_table()
+    db_create_images_table()
+    db_create_semantic_labels_table()
+    db_create_image_embeddings_table()
+    yield
+
+
+def _label(name, category="scene", descriptions=None, threshold=None):
+    entry = {
+        "name": name,
+        "category": category,
+        "descriptions": descriptions or [f"a photo of a {name}"],
+    }
+    if threshold is not None:
+        entry["threshold"] = threshold
+    return entry
+
+
+def _fetch(sql, params=()):
+    conn = _connect()
+    try:
+        return conn.execute(sql, params).fetchall()
+    finally:
+        conn.close()
+
+
+class TestSchemaMigration:
+    def test_old_shell_schema_is_dropped_and_recreated(self):
+        conn = _connect()
+        conn.execute("DROP TABLE semantic_labels")
+        conn.execute(
+            """
+            CREATE TABLE semantic_labels (
+                label_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT UNIQUE NOT NULL,
+                prompt_template TEXT,
+                threshold REAL,
+                active BOOLEAN DEFAULT 1
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE image_semantic_labels (
+                image_id TEXT,
+                label_id INTEGER,
+                score REAL NOT NULL,
+                PRIMARY KEY (image_id, label_id)
+            )
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        db_create_semantic_labels_table()
+
+        columns = {row[1] for row in _fetch("PRAGMA table_info(semantic_labels)")}
+        assert "descriptions" in columns
+        assert "label_embedding" in columns
+        assert "prompt_template" not in columns
+        tables = {
+            row[0]
+            for row in _fetch("SELECT name FROM sqlite_master WHERE type='table'")
+        }
+        assert "image_semantic_labels" not in tables
+
+    def test_new_schema_is_left_untouched(self):
+        db_upsert_semantic_vocabulary([_label("beach")])
+        db_create_semantic_labels_table()
+        assert _fetch("SELECT name FROM semantic_labels") == [("beach",)]
+
+    def test_image_classes_gains_score_column(self):
+        columns = {row[1] for row in _fetch("PRAGMA table_info(image_classes)")}
+        assert "score" in columns
+
+
+class TestVocabularyUpsert:
+    def test_new_labels_registered_in_mappings_above_offset(self):
+        db_upsert_semantic_vocabulary([_label("beach"), _label("diwali", "event")])
+
+        rows = _fetch(
+            "SELECT m.class_id, m.name FROM mappings m "
+            "JOIN semantic_labels s ON s.class_id = m.class_id ORDER BY m.class_id"
+        )
+        assert [name for _, name in rows] == ["beach", "diwali"]
+        assert all(cid >= SEMANTIC_CLASS_ID_OFFSET for cid, _ in rows)
+
+    def test_upsert_is_idempotent(self):
+        labels = [_label("beach"), _label("diwali", "event")]
+        db_upsert_semantic_vocabulary(labels)
+        first = _fetch("SELECT class_id, name FROM semantic_labels ORDER BY name")
+        db_upsert_semantic_vocabulary(labels)
+        assert (
+            _fetch("SELECT class_id, name FROM semantic_labels ORDER BY name") == first
+        )
+
+    def test_description_change_invalidates_cached_embedding(self):
+        db_upsert_semantic_vocabulary([_label("beach")])
+        class_id = _fetch("SELECT class_id FROM semantic_labels")[0][0]
+        db_update_label_embeddings(
+            [(class_id, np.ones(4, dtype=np.float32), MODEL_VERSION)]
+        )
+
+        # unchanged descriptions keep the cache
+        db_upsert_semantic_vocabulary([_label("beach")])
+        assert _fetch("SELECT label_embedding FROM semantic_labels")[0][0] is not None
+
+        db_upsert_semantic_vocabulary(
+            [_label("beach", descriptions=["waves on a sandy shore"])]
+        )
+        row = _fetch(
+            "SELECT label_embedding, embedding_model_version FROM semantic_labels"
+        )[0]
+        assert row == (None, None)
+
+    def test_label_missing_from_seed_is_deactivated_and_reactivated(self):
+        db_upsert_semantic_vocabulary([_label("beach"), _label("diwali", "event")])
+        db_upsert_semantic_vocabulary([_label("beach")])
+        assert _fetch("SELECT active FROM semantic_labels WHERE name = 'diwali'") == [
+            (0,)
+        ]
+
+        db_upsert_semantic_vocabulary([_label("beach"), _label("diwali", "event")])
+        assert _fetch("SELECT active FROM semantic_labels WHERE name = 'diwali'") == [
+            (1,)
+        ]
+
+    def test_yolo_owned_name_is_skipped(self):
+        db_upsert_semantic_vocabulary([_label("person"), _label("beach")])
+        assert _fetch("SELECT name FROM semantic_labels") == [("beach",)]
+
+    def test_orphan_mapping_row_is_reused(self):
+        # a semantic mapping surviving a semantic_labels drop keeps its id,
+        # so existing image_classes rows stay linked
+        orphan_id = SEMANTIC_CLASS_ID_OFFSET + 7
+        conn = _connect()
+        conn.execute(
+            "INSERT INTO mappings (class_id, name) VALUES (?, 'beach')",
+            (orphan_id,),
+        )
+        conn.commit()
+        conn.close()
+
+        db_upsert_semantic_vocabulary([_label("beach")])
+        assert _fetch("SELECT class_id FROM semantic_labels") == [(orphan_id,)]
+        assert len(_fetch("SELECT class_id FROM mappings WHERE name = 'beach'")) == 1
+
+
+class TestLabelEmbeddings:
+    def test_needing_embeddings_tracks_staleness(self):
+        db_upsert_semantic_vocabulary(
+            [_label("beach", descriptions=["a", "b"]), _label("diwali", "event")]
+        )
+        stale = db_get_labels_needing_embeddings(MODEL_VERSION)
+        assert sorted(descs for _, descs in stale) == [
+            ["a", "b"],
+            ["a photo of a diwali"],
+        ]
+
+        for class_id, _ in stale:
+            db_update_label_embeddings(
+                [(class_id, np.ones(4, dtype=np.float32), MODEL_VERSION)]
+            )
+        assert db_get_labels_needing_embeddings(MODEL_VERSION) == []
+        # a checkpoint swap makes every cached embedding stale again
+        assert len(db_get_labels_needing_embeddings("other-checkpoint")) == 2
+
+    def test_active_label_embeddings_round_trip(self):
+        db_upsert_semantic_vocabulary(
+            [_label("beach", threshold=0.05), _label("diwali", "event")]
+        )
+        rows = _fetch("SELECT class_id, name FROM semantic_labels ORDER BY name")
+        beach_id = rows[0][0]
+
+        beach_vec = np.array([1.0, 0.0, 0.0], dtype=np.float32)
+        db_update_label_embeddings([(beach_id, beach_vec, MODEL_VERSION)])
+
+        meta, matrix = db_get_active_label_embeddings(MODEL_VERSION)
+        # diwali has no cached embedding yet, so only beach comes back
+        assert meta == [(beach_id, "scene", 0.05)]
+        np.testing.assert_array_equal(matrix, beach_vec.reshape(1, -1))
+        assert matrix.dtype == np.float32
+
+        # wrong checkpoint returns nothing
+        meta, matrix = db_get_active_label_embeddings("other-checkpoint")
+        assert meta == [] and matrix.size == 0
+
+
+def _insert_image_with_embedding(image_id: str, vec: np.ndarray):
+    conn = _connect()
+    conn.execute(
+        "INSERT INTO images (id, path, folder_id, thumbnailPath, metadata, "
+        "isTagged, isEmbedded) VALUES (?, ?, NULL, ?, '{}', 0, 1)",
+        (image_id, f"/tmp/{image_id}.jpg", f"/tmp/{image_id}_thumb.jpg"),
+    )
+    conn.commit()
+    conn.close()
+    db_upsert_image_embeddings([(image_id, MODEL_VERSION, vec)])
+
+
+def _unit(dim: int, size: int = 8) -> np.ndarray:
+    v = np.zeros(size, dtype=np.float32)
+    v[dim] = 1.0
+    return v
+
+
+class TestScoringPass:
+    def _seed_labels(self):
+        """Three scene labels with one-hot embeddings on dims 0, 1, 2."""
+        db_upsert_semantic_vocabulary(
+            [_label("beach"), _label("forest"), _label("desert")]
+        )
+        ids = dict(_fetch("SELECT name, class_id FROM semantic_labels"))
+        db_update_label_embeddings(
+            [
+                (ids["beach"], _unit(0), MODEL_VERSION),
+                (ids["forest"], _unit(1), MODEL_VERSION),
+                (ids["desert"], _unit(2), MODEL_VERSION),
+            ]
+        )
+        return ids
+
+    def _image_tags(self, image_id):
+        return dict(
+            _fetch(
+                "SELECT class_id, score FROM image_classes "
+                "WHERE image_id = ? AND class_id >= ?",
+                (image_id, SEMANTIC_CLASS_ID_OFFSET),
+            )
+        )
+
+    def test_writes_above_threshold_topk_rows(self):
+        ids = self._seed_labels()
+        # strong beach (score saturates ~1), mid-range forest (cosine 0.13
+        # -> sigmoid ~0.13, above threshold but unsaturated), zero desert
+        vec = np.zeros(8, dtype=np.float32)
+        vec[0], vec[1] = 0.9, 0.12
+        _insert_image_with_embedding("img1", vec / np.linalg.norm(vec))
+
+        semantic_util_score_images()
+
+        tags = self._image_tags("img1")
+        assert set(tags) == {ids["beach"], ids["forest"]}
+        assert tags[ids["beach"]] > tags[ids["forest"]] > 0
+        sig = _fetch(
+            "SELECT scored_signature FROM image_embeddings WHERE image_id='img1'"
+        )[0][0]
+        assert sig
+
+    def test_top_k_caps_writes(self, monkeypatch):
+        import app.config.settings as settings
+
+        monkeypatch.setattr(settings, "SEMANTIC_SCORE_TOP_K", 1)
+        ids = self._seed_labels()
+        vec = np.zeros(8, dtype=np.float32)
+        vec[0], vec[1] = 0.9, 0.12
+        _insert_image_with_embedding("img1", vec / np.linalg.norm(vec))
+
+        semantic_util_score_images()
+
+        assert set(self._image_tags("img1")) == {ids["beach"]}
+
+    def test_idempotent_and_rescore_on_label_change(self):
+        ids = self._seed_labels()
+        _insert_image_with_embedding("img1", _unit(0))
+        semantic_util_score_images()
+
+        # simulate manual row loss: an unchanged signature must NOT rewrite
+        conn = _connect()
+        conn.execute(
+            "DELETE FROM image_classes WHERE image_id='img1' AND class_id >= ?",
+            (SEMANTIC_CLASS_ID_OFFSET,),
+        )
+        conn.commit()
+        conn.close()
+        semantic_util_score_images()
+        assert self._image_tags("img1") == {}
+
+        # a label embedding CONTENT change alters the signature -> re-score
+        db_update_label_embeddings([(ids["forest"], _unit(3), MODEL_VERSION)])
+        semantic_util_score_images()
+        assert ids["beach"] in self._image_tags("img1")
+
+    def test_deactivated_label_rows_removed_on_rescore(self):
+        ids = self._seed_labels()
+        _insert_image_with_embedding("img1", _unit(2))
+        semantic_util_score_images()
+        assert set(self._image_tags("img1")) == {ids["desert"]}
+
+        # desert missing from the new seed -> deactivated -> new signature
+        db_upsert_semantic_vocabulary([_label("beach"), _label("forest")])
+        semantic_util_score_images()
+        assert self._image_tags("img1") == {}
+
+    def test_yolo_rows_survive_scoring(self):
+        ids = self._seed_labels()
+        _insert_image_with_embedding("img1", _unit(0))
+        conn = _connect()
+        conn.execute(
+            "INSERT INTO image_classes (image_id, class_id) VALUES ('img1', 0)"
+        )
+        conn.commit()
+        conn.close()
+
+        semantic_util_score_images()
+
+        rows = _fetch(
+            "SELECT class_id, score FROM image_classes "
+            "WHERE image_id='img1' ORDER BY class_id"
+        )
+        assert rows[0] == (0, None)  # YOLO row intact, no score
+        assert rows[1][0] == ids["beach"]
+
+    def test_no_label_embeddings_is_a_noop(self):
+        db_upsert_semantic_vocabulary([_label("beach")])  # no embeddings built
+        _insert_image_with_embedding("img1", _unit(0))
+        semantic_util_score_images()
+        assert self._image_tags("img1") == {}
+        sig = _fetch(
+            "SELECT scored_signature FROM image_embeddings WHERE image_id='img1'"
+        )[0][0]
+        assert sig is None
+
+
+class TestDisplayCut:
+    def test_view_cuts_semantic_tags_but_keeps_yolo_and_search_matching(self):
+        from app.database.images import db_search_images_by_tag
+
+        names = [f"label{i}" for i in range(7)]
+        db_upsert_semantic_vocabulary([_label(n) for n in names])
+        ids = dict(_fetch("SELECT name, class_id FROM semantic_labels"))
+        _insert_image_with_embedding("img1", _unit(0))
+
+        conn = _connect()
+        # 7 semantic rows with descending scores + one YOLO row
+        for rank, name in enumerate(names):
+            conn.execute(
+                "INSERT INTO image_classes (image_id, class_id, score) "
+                "VALUES ('img1', ?, ?)",
+                (ids[name], 0.9 - rank * 0.1),
+            )
+        conn.execute(
+            "INSERT INTO image_classes (image_id, class_id) VALUES ('img1', 0)"
+        )
+        conn.commit()
+        conn.close()
+
+        shown = _fetch(
+            "SELECT class_id FROM image_classes_display WHERE image_id='img1'"
+        )
+        shown_ids = {c for (c,) in shown}
+        # all 5 top-scored semantic labels + the YOLO row, ranks 6-7 cut
+        assert shown_ids == {0} | {ids[n] for n in names[:5]}
+
+        # a below-the-cut tag still matches in search (full table)...
+        hits = db_search_images_by_tag("label6")
+        assert [h["id"] for h in hits] == ["img1"]
+        # ...but the returned display tag list respects the cut
+        assert "label6" not in hits[0]["tags"]
+        assert "label0" in hits[0]["tags"]

--- a/docs/backend/backend_python/database.md
+++ b/docs/backend/backend_python/database.md
@@ -7,9 +7,7 @@ PictoPy uses several SQLite databases to manage various aspects of the applicati
 ## Database Schema
 
 <!-- markdownlint-disable MD033 -->
-<p align="center">
-  <img src="../../assets/database_architecture.svg" alt="PictoPy Banner" width="100%"/>
-</p>
+<iframe width="560" height="315" src='https://dbdiagram.io/e/6a593dd1c3a90dd98d55554d/6a5b4a02067336e1dea2347a'> </iframe>
 <!-- markdownlint-enable MD033 -->
 
-Alternatively, [click here to view the interactive DB schema diagram in a new tab](https://dbdiagram.io/d/PictoPy-685704c4f039ec6d364647e1).
+Alternatively, [click here to view the interactive DB schema diagram in a new tab](https://dbdiagram.io/d/PictoPy-6a593dd1c3a90dd98d55554d).

--- a/docs/backend/backend_python/semantic-search.md
+++ b/docs/backend/backend_python/semantic-search.md
@@ -80,7 +80,7 @@ semantic search when nothing matches — this keeps the existing tag-search
 path completely untouched and adds semantic search as a fallback, not a
 replacement. Since the curated-vocabulary layer landed, tag search also
 matches the ~395 precomputed semantic labels (see
-[the vocabulary section](#semantic_labels-curated-vocabulary-active)), so
+[the vocabulary section](#curated-vocabulary-layer-semantic_labels)), so
 common words like "beach" or "sunset" get instant cache hits and never
 reach the live-scoring fallback.
 
@@ -284,7 +284,7 @@ CREATE INDEX IF NOT EXISTS ix_image_embeddings_model_version
   contract, and renormalizing would silently double-apply the normalization
   math.
 
-### `semantic_labels` — curated vocabulary (active)
+### Curated vocabulary layer (semantic_labels)
 
 The curated-vocabulary layer scores every embedded image against ~395
 predefined labels (scenes, objects, events, attributes) and stores the

--- a/docs/backend/backend_python/semantic-search.md
+++ b/docs/backend/backend_python/semantic-search.md
@@ -78,7 +78,11 @@ graph TB
 Instead, the frontend tries exact tag search first and only falls back to
 semantic search when nothing matches — this keeps the existing tag-search
 path completely untouched and adds semantic search as a fallback, not a
-replacement.
+replacement. Since the curated-vocabulary layer landed, tag search also
+matches the ~395 precomputed semantic labels (see
+[the vocabulary section](#semantic_labels-curated-vocabulary-active)), so
+common words like "beach" or "sunset" get instant cache hits and never
+reach the live-scoring fallback.
 
 ```mermaid
 sequenceDiagram
@@ -204,8 +208,9 @@ called out explicitly:
 ```mermaid
 erDiagram
     images ||--o| image_embeddings : "has at most one, per model_version"
-    images ||--o{ image_semantic_labels : "scored against (dormant)"
-    semantic_labels ||--o{ image_semantic_labels : "scores images for (dormant)"
+    images ||--o{ image_classes : "tagged with (YOLO + semantic)"
+    mappings ||--o{ image_classes : ""
+    mappings ||--o| semantic_labels : "class_id >= 1000"
 
     images {
         TEXT id PK
@@ -215,19 +220,23 @@ erDiagram
         TEXT image_id PK, FK "ON DELETE CASCADE from images"
         TEXT model_version "e.g. siglip2-base-patch16-224; indexed"
         BLOB embedding "raw float32 bytes, unit-norm, via .tobytes()"
+        TEXT scored_signature "vocab/label state scored against; NULL = unscored"
         DATETIME created_at
     }
-    semantic_labels {
-        INTEGER label_id PK
-        TEXT name UK
-        TEXT prompt_template
-        REAL threshold
-        BOOLEAN active "default 1"
-    }
-    image_semantic_labels {
+    image_classes {
         TEXT image_id PK, FK
-        INTEGER label_id PK, FK
-        REAL score
+        INTEGER class_id PK, FK
+        REAL score "NULL for YOLO rows"
+    }
+    semantic_labels {
+        INTEGER class_id PK "same id as mappings row"
+        TEXT name UK
+        TEXT category "scene | object | event | attribute"
+        TEXT descriptions "JSON array; source of truth"
+        REAL threshold "NULL = bucket default"
+        BOOLEAN active "default 1"
+        BLOB label_embedding "ensembled description embedding"
+        TEXT embedding_model_version
     }
 ```
 
@@ -239,6 +248,7 @@ CREATE TABLE IF NOT EXISTS image_embeddings (
     model_version TEXT NOT NULL,
     embedding BLOB NOT NULL,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    scored_signature TEXT,  -- added via guarded ALTER; see vocabulary layer
     FOREIGN KEY (image_id) REFERENCES images(id) ON DELETE CASCADE
 );
 CREATE INDEX IF NOT EXISTS ix_image_embeddings_model_version
@@ -274,47 +284,63 @@ CREATE INDEX IF NOT EXISTS ix_image_embeddings_model_version
   contract, and renormalizing would silently double-apply the normalization
   math.
 
-### `semantic_labels` / `image_semantic_labels` — created, not yet used
+### `semantic_labels` — curated vocabulary (active)
 
-Both tables exist (`backend/app/database/semantic_labels.py`,
-`db_create_semantic_labels_table()`, wired into `main.py` startup) but no
-code writes to or reads from them yet. They're reserved for a planned
-future feature: a curated, precomputed label set for **browsing/display**
-(e.g. showing "AI tags: Christmas, celebration" on a photo nobody searched
-for, or populating a filter-chip list) — a job live query-time scoring can't
-do, since it only runs in response to an actual typed query. This is
-deliberately **not** a search gatekeeper; arbitrary free-text search already
-works without any row existing in these tables.
+The curated-vocabulary layer scores every embedded image against ~395
+predefined labels (scenes, objects, events, attributes) and stores the
+results as **regular tags**: labels register as `mappings` rows at
+`class_id >= 1000` (`SEMANTIC_CLASS_ID_OFFSET`; YOLO owns 0–79), and the
+scoring pass writes plain `image_classes` rows with a `score`. Tag search,
+tag chips, and person-view tag lists pick them up with no consumer changes.
+The planned `image_semantic_labels` table was dropped in favor of this
+reuse. Free-text search is unaffected — this layer is a cache/browse
+feature, not a search gatekeeper.
+
+`semantic_labels` itself is a definition + cache table:
 
 ```sql
 CREATE TABLE IF NOT EXISTS semantic_labels (
-    label_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    class_id INTEGER PRIMARY KEY,    -- same id as the mappings row
     name TEXT UNIQUE NOT NULL,
-    prompt_template TEXT,
-    threshold REAL,
-    active BOOLEAN DEFAULT 1
-);
-
-CREATE TABLE IF NOT EXISTS image_semantic_labels (
-    image_id TEXT,
-    label_id INTEGER,
-    score REAL NOT NULL,
-    PRIMARY KEY (image_id, label_id),
-    FOREIGN KEY (image_id) REFERENCES images(id) ON DELETE CASCADE,
-    FOREIGN KEY (label_id) REFERENCES semantic_labels(label_id) ON DELETE CASCADE
+    category TEXT NOT NULL,          -- scene | object | event | attribute
+    descriptions TEXT NOT NULL,      -- JSON array; source of truth
+    threshold REAL,                  -- per-label override, NULL = bucket default
+    active BOOLEAN DEFAULT 1,
+    label_embedding BLOB,            -- renormalized mean of description embeddings
+    embedding_model_version TEXT
 );
 ```
 
+Key behaviors (all in `backend/app/utils/semantic_labels.py` and
+`backend/app/database/semantic_labels.py`):
+
+- **Seed**: `backend/app/data/semantic_vocabulary.json` is idempotently
+  upserted at startup. Description edits null the cached label embedding;
+  labels removed from the seed deactivate; YOLO-name collisions are skipped.
+- **Label embeddings**: each label's 2–4 caption-shaped descriptions are
+  encoded through the text tower and averaged (prompt ensembling) — this is
+  the fix for SigLIP2's bare-noun weakness on the curated path.
+- **Scoring**: one matmul per image against the label matrix, bucket
+  thresholds (`SEMANTIC_BUCKET_THRESHOLDS` — calibrated, ~2 orders of
+  magnitude below `SIGLIP2_MATCH_THRESHOLD`, never interchangeable), top-15
+  stored (`SEMANTIC_SCORE_TOP_K`).
+- **Invalidation**: a scoring signature (checkpoint + vocab + thresholds +
+  K + label-matrix bytes) is stamped per image in
+  `image_embeddings.scored_signature`; any change re-scores wholesale.
+- **Display cut**: the `image_classes_display` view (recreated each
+  startup) caps chips at the top-5 semantic tags per image
+  (`SEMANTIC_DISPLAY_TOP_K`); search matching uses the full table.
+- Calibration data: `backend/scripts/vocabulary/calibration_report.json`.
+
 !!! note "Schema migrations"
-    This project has no `ALTER TABLE` / migration tooling anywhere —
-    `CREATE TABLE IF NOT EXISTS` is a no-op against a table that already
-    exists, so a new column on an *existing* table never reaches an
-    already-created user database, only fresh installs. This is why
-    `isEmbedded` (a new column on the pre-existing `images` table) needed
-    the same scrutiny as a schema change, and why `image_embeddings` /
-    `semantic_labels` / `image_semantic_labels`, being wholly new tables,
-    don't have this problem — `CREATE TABLE IF NOT EXISTS` does add a new
-    table to an existing database correctly.
+    This project has no migration tooling — `CREATE TABLE IF NOT EXISTS`
+    is a no-op against an existing table. The vocabulary layer handled
+    this two ways: the old `semantic_labels`/`image_semantic_labels`
+    shells shipped with **no writers** (guaranteed empty), so they are
+    detected via `PRAGMA table_info` and drop-recreated; the populated
+    tables got **guarded ALTERs** (`image_classes.score`,
+    `image_embeddings.scored_signature`) that check column presence
+    before altering.
 
 ## Model distribution and checkpoints
 
@@ -526,13 +552,14 @@ Summary of behavior not obvious from the schema alone:
 ```python
 DELETE FROM image_embeddings;
 UPDATE images SET isEmbedded = 0 WHERE isEmbedded = 1;
+DELETE FROM image_classes WHERE class_id >= 1000;  -- semantic tag rows
 ```
 
 Run this any time the embedding or preprocessing pipeline changes in a way
 that invalidates already-stored embeddings (checkpoint swap, preprocessing
 fix, threshold recalibration against a different pipeline). It forces every
 image back through `image_util_process_unembedded_images()` on the next
-sync/tagging pass. There is no automatic detection of "preprocessing
+sync/tagging pass; the semantic scoring sweep then re-tags them. There is no automatic detection of "preprocessing
 changed, invalidate stored embeddings" — this script is a manual step a
 developer runs deliberately.
 
@@ -572,9 +599,9 @@ developer runs deliberately.
   `onnxconverter_common.float16.convert_float_to_float16`, which otherwise
   crashes on >2GB in-memory models) but wasn't finished, since `base`-only
   is the current long-term plan.
-- **The curated `semantic_labels` layer is dormant** (see above) — a
-  reasonable follow-up once free-text search has been in the hands of users
-  for a while.
+- **EXIF tag write-back is deferred** — the curated vocabulary layer (see
+  above) produces the stable, versioned tags it needs, but writing them
+  into image files is its own later PR.
 - **Persistent text-session caching is per-process, in-memory** — it does
   not survive a server restart, and there's no size/TTL bound (a single
   cached session is the whole point, so this is intentional, not an


### PR DESCRIPTION
Closes #1388 

## Summary

Adds a curated, precomputed vocabulary of semantic labels (beach, diwali, sunset, …) on top of the existing SigLIP2 embedding pipeline. Photos get searchable, browsable AI tags beyond YOLO's 80 classes, with common-word searches served from an instant SQL cache instead of a live matmul.

### Design

Semantic labels **reuse the existing YOLO tag flow** instead of a parallel path:

- Labels register as `mappings` rows at `class_id >= 1000` (YOLO keeps 0–79); scoring writes plain `image_classes` rows with a new nullable `score` column. Tag search, chips, and person-view tag lists work with **zero consumer changes**.
- `semantic_labels` is a definition + cache table: per-label category, 2–4 caption-shaped descriptions (source of truth), and a cached label embedding (renormalized mean of description embeddings — attacks SigLIP2's bare-noun weakness text-side).
- Scoring: one matmul per image against the label matrix → bucket threshold → top-15 stored with scores. Invalidation via a content signature (checkpoint + vocab + thresholds + K); any change re-scores wholesale, which is cheaper than delta tracking.
- Display cut: an `image_classes_display` view caps chips at the top-5 semantic tags per image; search matching keeps the full stored set.
- All passes are self-gating and idempotent, triggered at startup, folder sync, and semantic model install.

### Vocabulary

395 labels (194 scene / 139 object / 45 event / 17 attribute), derived from Places365 + Open Images, hand-pruned (COCO-80/person exclusion, synonym collapse, junk removal), plus hand-written events (incl. diwali, holi, ganesh chaturthi, durga puja, navratri, mehndi, eid) and attributes (sunset, night, selfie, …). 1,085 authored descriptions.

### Calibration (measured, not guessed)

151-image stratified eval set (Wikimedia Commons, attribution recorded), scored through the production preprocessing pipeline:

| bucket | top-1 | top-5 | threshold |
|---|---|---|---|
| scene | 0.52 | 0.83 | 5e-5 |
| object | 0.85 | 0.98 | 1e-4 |
| event | 0.64 | 0.88 | 5e-5 |
| attribute | 0.67 | 0.96 | 1e-4 |

Ensembled label scores sit ~2 orders of magnitude below the live-query path, so these floors are deliberately not `SIGLIP2_MATCH_THRESHOLD`. Null-baseline contrast was evaluated and rejected (never beat absolute thresholds). Full report: `backend/scripts/vocabulary/calibration_report.json`.

### Migration

The old `semantic_labels`/`image_semantic_labels` shells shipped with no writers (guaranteed empty) → detected and drop-recreated. Populated tables get guarded ALTERs (`image_classes.score`, `image_embeddings.scored_signature`).

### Testing

- 155 backend tests passing; 18 new (migration, upsert idempotency, embedding-cache staleness, scoring/top-K/signature invalidation, display cut).
- Verified end-to-end with real models: eval images produce correct tags (`beach__1` → coast, beach, island, ocean) and `search?tag=beach` / `balloon` / case-insensitive queries hit the cache.

### Out of scope

EXIF write-back (later PR, reads the same rows with a stricter cut); score-ordered tag-search results.

### AI Usage Disclosure:

We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact. AI slop is strongly discouraged and may lead to banning and blocking. Do not spam our repos with AI slop.

Check one of the checkboxes below:

- [ ] This PR does not contain AI-generated code at all.
- [x] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools: Claude


## Checklist
<!-- Mark items with [x] to indicate completion -->
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [x] If applicable, I have made corresponding changes or additions to the documentation
- [x] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added curated semantic vocabulary with semantic image tagging/scoring and configurable top‑K display.
  * Semantic vocabulary sync, embedding backfill, and image scoring now run automatically on startup and during folder processing.
* **Bug Fixes**
  * Improved consistency of displayed semantic tags across image views and tag-based queries.
  * Added safer incremental “needs scoring” detection to avoid unnecessary rescoring.
* **Maintenance**
  * Added tooling to build, calibrate, and reset semantic vocab/embeddings; expanded eval-set download support.
* **Documentation & Tests**
  * Updated semantic search and database schema docs; added comprehensive semantic integration tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->