### PR TITLE
feat: add Arch/Manjaro Linux support to setup.sh

### DIFF
--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -17,12 +17,20 @@ if (os.platform() === 'win32') {
   command = 'powershell.exe';
   args = ['-ExecutionPolicy', 'Bypass', '-File', psScript];
 } else if (os.platform() === 'linux') {
-  // Check if it's Debian-based or Fedora-based Linux
+  // Check if it's Debian-based, Fedora-based, or Arch-based Linux
   const debianVersionPath = '/etc/debian_version';
   const fedoraReleasePath = '/etc/fedora-release';
   const redhatReleasePath = '/etc/redhat-release';
-  if (fs.existsSync(debianVersionPath) || fs.existsSync(fedoraReleasePath) || fs.existsSync(redhatReleasePath)) {
-    // On Debian, Fedora or RedHat Linux, use the bash script
+  const archReleasePath = '/etc/arch-release';
+  const manjaroReleasePath = '/etc/manjaro-release';
+  if (
+    fs.existsSync(debianVersionPath) ||
+    fs.existsSync(fedoraReleasePath) ||
+    fs.existsSync(redhatReleasePath) ||
+    fs.existsSync(archReleasePath) ||
+    fs.existsSync(manjaroReleasePath)
+  ) {
+    // On Debian, Fedora, RedHat or Arch Linux, use the bash script
     command = bashScript;
     args = [];
 
@@ -34,13 +42,13 @@ if (os.platform() === 'win32') {
       fs.chmodSync(bashScript, 0o755);
     }
   } else {
-    console.error('Unsupported Linux distribution. This setup script only supports Debian-based and Fedora/RedHat-based Linux distributions.');
+    console.error('Unsupported Linux distribution. This setup script only supports Debian-based, Fedora/RedHat-based, and Arch-based Linux distributions.');
     console.error('Please install system dependencies manually and run the individual setup commands.');
     process.exit(1);
   }
 } else {
   console.error(`Unsupported operating system: ${os.platform()}`);
-  console.error('This setup script only supports Windows, Debian-based, and Fedora/RedHat-based Linux distributions.');
+  console.error('This setup script only supports Windows, Debian-based, Fedora/RedHat-based, and Arch-based Linux distributions.');
   console.error('Please install system dependencies manually and run the individual setup commands.');
   process.exit(1);
 }

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -52,9 +52,7 @@ elif [ -f "/etc/arch-release" ] || [ -f "/etc/manjaro-release" ] || command -v p
         libayatana-appindicator \
         librsvg \
         nodejs \
-        npm \
-        rustup \
-        pyenv
+        npm
 else
     echo -e "\e[31mUnsupported OS: $(uname). Please install system dependencies manually.\e[0m"
     exit 1

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -39,6 +39,22 @@ elif [ -f "/etc/fedora-release" ] || [ -f "/etc/redhat-release" ]; then
         libxdo-devel \
         libayatana-appindicator-gtk3-devel \
         librsvg2-devel
+elif [ -f "/etc/arch-release" ] || [ -f "/etc/manjaro-release" ] || command -v pacman &> /dev/null; then
+    echo -e "\e[33mDetected Arch-based Linux. Installing dependencies...\e[0m"
+    sudo pacman -Sy --needed --noconfirm \
+        webkit2gtk-4.1 \
+        base-devel \
+        curl \
+        wget \
+        file \
+        xdotool \
+        openssl \
+        libayatana-appindicator \
+        librsvg \
+        nodejs \
+        npm \
+        rustup \
+        pyenv
 else
     echo -e "\e[31mUnsupported OS: $(uname). Please install system dependencies manually.\e[0m"
     exit 1

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -41,7 +41,7 @@ elif [ -f "/etc/fedora-release" ] || [ -f "/etc/redhat-release" ]; then
         librsvg2-devel
 elif [ -f "/etc/arch-release" ] || [ -f "/etc/manjaro-release" ] || command -v pacman &> /dev/null; then
     echo -e "\e[33mDetected Arch-based Linux. Installing dependencies...\e[0m"
-    sudo pacman -Sy --needed --noconfirm \
+    sudo pacman -Syu --needed --noconfirm \
         webkit2gtk-4.1 \
         base-devel \
         curl \


### PR DESCRIPTION
Fixes #1381

## Description
This PR adds a detection and package installation branch for Arch-based Linux distributions (e.g., Arch Linux, Manjaro, Mabox Linux, EndeavourOS) in `scripts/setup.sh`.

### Changes Included:
- Added detection branch for Arch/Manjaro systems (`/etc/arch-release`, `/etc/manjaro-release`, or `pacman` command).
- Added system dependency package installation via `pacman`:
  - `webkit2gtk-4.1` (Tauri WebView engine)
  - `base-devel` (Development build tools)
  - `curl`, `wget`, `file`, `openssl`, `librsvg`
  - `xdotool` (Provides `libxdo` headers/libs)
  - `libayatana-appindicator` (System indicator support)
  - `nodejs` & `npm` (In Arch Linux, `npm` is packaged separately from `nodejs`)
  - `rustup` & `pyenv`

### Verification:
- Verified script syntax using `bash -n scripts/setup.sh`.
- Verified local environment initialization on Arch-based Mabox Linux.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added setup support for Arch Linux and Manjaro systems.
  * The setup process now detects Arch-based Linux distributions and installs required application, build/graphics libraries, Node.js/npm, Rust, and Python tooling using the appropriate package managers.  
* **Bug Fixes**
  * Improved error messaging when the Linux distribution is unsupported, including an updated list of supported platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->