### PR TITLE
Feat/unified run script cross platform

### DIFF
--- a/backend/scripts/reset_database.py
+++ b/backend/scripts/reset_database.py
@@ -47,11 +47,12 @@ def delete_db_files():
         print("No database files were found or deleted.")
 
     if has_errors:
-        print("Error: Database reset failed because some files could not be deleted.", file=sys.stderr)
+        print(
+            "Error: Database reset failed because some files could not be deleted.",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
 
 if __name__ == "__main__":
     delete_db_files()
-
-

--- a/scripts/run.js
+++ b/scripts/run.js
@@ -1,0 +1,292 @@
+// Unified dev/prod launcher for PictoPy: backend, sync-microservice, and frontend.
+// Node.js port of run.sh with identical behavior, for native Windows (cmd/PowerShell)
+// support without requiring Git Bash or WSL.
+//
+// On Linux, macOS, Git Bash, or WSL you can also use `bash scripts/run.sh`.
+//
+// Usage:
+//   node scripts/run.js          -> dev mode (default)
+//   node scripts/run.js --prod   -> production mode
+
+import { spawn, spawnSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// --- Colors (matches scripts/run.sh / scripts/setup.sh conventions) ---
+const RED = '\x1b[0;31m';
+const GREEN = '\x1b[0;32m';
+const YELLOW = '\x1b[0;33m';
+const NC = '\x1b[0m';
+
+const MODE = process.argv[2] === '--prod' ? 'prod' : 'dev';
+
+const ROOT_DIR = path.resolve(__dirname, '..');
+const BACKEND_DIR = path.join(ROOT_DIR, 'backend');
+const SYNC_DIR = path.join(ROOT_DIR, 'sync-microservice');
+const FRONTEND_DIR = path.join(ROOT_DIR, 'frontend');
+
+// --- OS detection (same approach as scripts/run.sh and scripts/setup.js) ---
+let OS_TYPE;
+switch (process.platform) {
+  case 'linux':
+    OS_TYPE = 'linux';
+    break;
+  case 'darwin':
+    OS_TYPE = 'macos';
+    break;
+  case 'win32':
+    OS_TYPE = 'windows';
+    break;
+  default:
+    OS_TYPE = 'unknown';
+    console.log(`${YELLOW}Warning: unrecognized platform '${process.platform}'. Assuming Unix-like behavior.${NC}`);
+}
+const IS_WINDOWS = OS_TYPE === 'windows';
+
+const SETUP_HINT = IS_WINDOWS
+  ? "Run 'npm run setup' from the repo root (this launches scripts/setup.ps1 on Windows)."
+  : "Run 'npm run setup' from the repo root to install dependencies.";
+
+// --- Preflight: fail fast with guidance instead of a raw "command not found" ---
+function commandExists(cmd) {
+  const pathEnv = process.env.PATH || process.env.Path || '';
+  const dirs = pathEnv.split(path.delimiter).filter(Boolean);
+  const exts = IS_WINDOWS ? (process.env.PATHEXT || '.EXE;.CMD;.BAT;.COM').split(';') : [''];
+  for (const dir of dirs) {
+    for (const ext of exts) {
+      const candidate = path.join(dir, cmd + ext);
+      try {
+        fs.accessSync(candidate, fs.constants.X_OK);
+        return candidate;
+      } catch {
+        // keep searching
+      }
+    }
+  }
+  return null;
+}
+
+function requireCmd(cmd, guidance) {
+  if (!commandExists(cmd)) {
+    console.error(`${RED}Error: required command '${cmd}' not found.${NC}`);
+    console.error(`${YELLOW}${guidance}${NC}`);
+    process.exit(1);
+  }
+}
+
+function requireDir(dir, label) {
+  if (!fs.existsSync(dir) || !fs.statSync(dir).isDirectory()) {
+    console.error(`${RED}Error: ${label} directory not found at ${dir}${NC}`);
+    console.error(`${YELLOW}Make sure you're running this from a full PictoPy checkout.${NC}`);
+    process.exit(1);
+  }
+}
+
+requireDir(BACKEND_DIR, 'backend');
+requireDir(SYNC_DIR, 'sync-microservice');
+requireDir(FRONTEND_DIR, 'frontend');
+
+requireCmd('node', `Node.js not found. Install it from https://nodejs.org, or ${SETUP_HINT}`);
+requireCmd('npm', `npm not found (usually bundled with Node.js). Install Node.js from https://nodejs.org, or ${SETUP_HINT}`);
+requireCmd('cargo', `Rust/Cargo not found (required by 'npm run tauri dev'). Install it from https://rustup.rs, or ${SETUP_HINT}`);
+
+// --- venv resolution helper ---
+// Tries each candidate venv folder name in order, using the correct
+// bin dir per OS (bin/ on Unix, Scripts/ on Windows). Instead of "sourcing"
+// activate (there's no such thing for a child process spawned from Node),
+// the resolved bin dir is prepended to PATH for that child.
+function resolveVenv(baseDir, candidates) {
+  for (const name of candidates) {
+    const venvDir = path.join(baseDir, name);
+    const binDir = path.join(venvDir, IS_WINDOWS ? 'Scripts' : 'bin');
+    if (fs.existsSync(path.join(binDir, 'activate'))) {
+      return { venvDir, binDir };
+    }
+  }
+  console.error(`${RED}Could not find a venv in ${baseDir} (looked for: ${candidates.join(', ')})${NC}`);
+  console.error(`${YELLOW}${SETUP_HINT}${NC}`);
+  return null;
+}
+
+// Verifies a command exists inside the resolved venv's bin dir, with
+// guidance to reinstall dependencies rather than a bare "command not found".
+function requireVenvCmd(binDir, venvDir, cmd) {
+  const resolved = IS_WINDOWS
+    ? [`${cmd}.exe`, `${cmd}.cmd`].map((f) => path.join(binDir, f)).find((p) => fs.existsSync(p))
+    : (() => {
+        const p = path.join(binDir, cmd);
+        try {
+          fs.accessSync(p, fs.constants.X_OK);
+          return p;
+        } catch {
+          return null;
+        }
+      })();
+
+  if (!resolved) {
+    console.error(`${RED}'${cmd}' not found in venv at ${venvDir}.${NC}`);
+    console.error(`${YELLOW}The venv exists but looks incomplete. Try:${NC}`);
+    const activateHint = IS_WINDOWS
+      ? `${venvDir}\\Scripts\\activate && pip install -r requirements.txt`
+      : `source "${venvDir}/bin/activate" && pip install -r requirements.txt`;
+    console.error(`${YELLOW}  ${activateHint}${NC}`);
+    console.error(`${YELLOW}...or rerun: ${SETUP_HINT}${NC}`);
+  }
+  return resolved;
+}
+
+// --- process orchestration ---
+const children = [];
+let aliveCount = 0;
+let shuttingDown = false;
+
+function prefixStream(stream, prefix, out) {
+  let buffer = '';
+  stream.setEncoding('utf8');
+  stream.on('data', (chunk) => {
+    buffer += chunk;
+    const lines = buffer.split('\n');
+    buffer = lines.pop();
+    for (const line of lines) {
+      out.write(`[${prefix}] ${line}\n`);
+    }
+  });
+  stream.on('end', () => {
+    if (buffer.length > 0) {
+      out.write(`[${prefix}] ${buffer}\n`);
+      buffer = '';
+    }
+  });
+}
+
+function spawnService(prefix, command, args, options) {
+  const child = spawn(command, args, {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    ...options,
+  });
+
+  prefixStream(child.stdout, prefix, process.stdout);
+  prefixStream(child.stderr, prefix, process.stdout); // merged like run.sh's 2>&1
+
+  child.on('error', (err) => {
+    process.stdout.write(`[${prefix}] Failed to start: ${err.message}\n`);
+  });
+
+  aliveCount++;
+  child.on('exit', () => {
+    aliveCount--;
+    if (aliveCount === 0 && !shuttingDown) {
+      process.exit(0);
+    }
+  });
+
+  children.push(child);
+  return child;
+}
+
+function killChild(child) {
+  if (!child.pid || child.exitCode !== null || child.signalCode !== null) return;
+  if (IS_WINDOWS) {
+    spawnSync('taskkill', ['/PID', String(child.pid), '/T', '/F']);
+  } else {
+    try {
+      process.kill(-child.pid, 'SIGTERM');
+    } catch {
+      try {
+        child.kill('SIGTERM');
+      } catch {
+        // process already gone
+      }
+    }
+  }
+}
+
+function cleanup() {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  console.log('');
+  console.log('Shutting down all services...');
+  for (const child of children) {
+    killChild(child);
+  }
+  process.exit(0);
+}
+process.on('SIGINT', cleanup);
+process.on('SIGTERM', cleanup);
+
+function venvEnv(binDir) {
+  return { ...process.env, PATH: `${binDir}${path.delimiter}${process.env.PATH || process.env.Path || ''}` };
+}
+
+function startBackend() {
+  console.log(`[BACKEND] Starting... ${BACKEND_DIR}`);
+  const venv = resolveVenv(BACKEND_DIR, ['.env', 'venv']);
+  if (!venv) process.exit(1);
+  const uvicorn = requireVenvCmd(venv.binDir, venv.venvDir, 'uvicorn');
+  if (!uvicorn) process.exit(1);
+
+  const env = venvEnv(venv.binDir);
+  let args;
+  if (MODE === 'prod') {
+    console.log('[BACKEND] Starting in production mode on port 52123...');
+    args = ['main:app', '--host', '0.0.0.0', '--port', '52123', '--workers', process.env.WORKERS || '1'];
+  } else {
+    console.log('[BACKEND] Starting in dev mode on port 52123...');
+    args = ['main:app', '--host', '0.0.0.0', '--port', '52123', '--reload'];
+  }
+  spawnService('BACKEND', uvicorn, args, {
+    cwd: BACKEND_DIR,
+    env,
+    detached: !IS_WINDOWS,
+  });
+}
+
+function startSync() {
+  const venv = resolveVenv(SYNC_DIR, ['.sync-env', 'venv']);
+  if (!venv) process.exit(1);
+  console.log('[SYNC] Starting sync-microservice on port 52124...');
+
+  const env = venvEnv(venv.binDir);
+  if (MODE === 'prod') {
+    const uvicorn = requireVenvCmd(venv.binDir, venv.venvDir, 'uvicorn');
+    if (!uvicorn) process.exit(1);
+    spawnService('SYNC', uvicorn, ['main:app', '--host', '0.0.0.0', '--port', '52124'], {
+      cwd: SYNC_DIR,
+      env,
+      detached: !IS_WINDOWS,
+    });
+  } else {
+    const fastapi = requireVenvCmd(venv.binDir, venv.venvDir, 'fastapi');
+    if (!fastapi) process.exit(1);
+    spawnService('SYNC', fastapi, ['dev', '--port', '52124'], {
+      cwd: SYNC_DIR,
+      env,
+      detached: !IS_WINDOWS,
+    });
+  }
+}
+
+function startFrontend() {
+  const nodeModules = path.join(FRONTEND_DIR, 'node_modules');
+  if (!fs.existsSync(nodeModules)) {
+    console.error(`${RED}[FRONTEND] node_modules not found.${NC}`);
+    console.error(`${YELLOW}[FRONTEND] ${SETUP_HINT}${NC}`);
+    process.exit(1);
+  }
+  console.log('[FRONTEND] Starting Tauri dev...');
+  spawnService('FRONTEND', 'npm', ['run', 'tauri', 'dev'], {
+    cwd: FRONTEND_DIR,
+    env: process.env,
+    shell: IS_WINDOWS, // npm ships as npm.cmd on Windows, which needs shell resolution
+    detached: !IS_WINDOWS,
+  });
+}
+
+console.log(`Starting PictoPy (mode: ${MODE}, OS: ${OS_TYPE})...`);
+startBackend();
+startSync();
+startFrontend();

--- a/scripts/run.js
+++ b/scripts/run.js
@@ -112,33 +112,6 @@ function resolveVenv(baseDir, candidates) {
   return null;
 }
 
-// Verifies a command exists inside the resolved venv's bin dir, with
-// guidance to reinstall dependencies rather than a bare "command not found".
-function requireVenvCmd(binDir, venvDir, cmd) {
-  const resolved = IS_WINDOWS
-    ? [`${cmd}.exe`, `${cmd}.cmd`].map((f) => path.join(binDir, f)).find((p) => fs.existsSync(p))
-    : (() => {
-        const p = path.join(binDir, cmd);
-        try {
-          fs.accessSync(p, fs.constants.X_OK);
-          return p;
-        } catch {
-          return null;
-        }
-      })();
-
-  if (!resolved) {
-    console.error(`${RED}'${cmd}' not found in venv at ${venvDir}.${NC}`);
-    console.error(`${YELLOW}The venv exists but looks incomplete. Try:${NC}`);
-    const activateHint = IS_WINDOWS
-      ? `${venvDir}\\Scripts\\activate && pip install -r requirements.txt`
-      : `source "${venvDir}/bin/activate" && pip install -r requirements.txt`;
-    console.error(`${YELLOW}  ${activateHint}${NC}`);
-    console.error(`${YELLOW}...or rerun: ${SETUP_HINT}${NC}`);
-  }
-  return resolved;
-}
-
 // --- process orchestration ---
 const children = [];
 let aliveCount = 0;
@@ -219,50 +192,96 @@ process.on('SIGINT', cleanup);
 process.on('SIGTERM', cleanup);
 
 function venvEnv(binDir) {
-  return { ...process.env, PATH: `${binDir}${path.delimiter}${process.env.PATH || process.env.Path || ''}` };
+  return {
+    ...process.env,
+    PATH: `${binDir}${path.delimiter}${process.env.PATH || process.env.Path || ''}`,
+    // Node pipes child stdio, so Python sees a non-tty and fully buffers
+    // stdout instead of line-buffering it. Force unbuffered output so
+    // uvicorn/fastapi logs show up live instead of only on exit.
+    PYTHONUNBUFFERED: '1',
+    // Without a real console attached, rich (used by `fastapi dev`'s banner)
+    // falls back to the legacy Windows console writer, which encodes with
+    // cp1252 and crashes on the emoji in its own startup banner. Forcing
+    // UTF-8 mode avoids that.
+    PYTHONUTF8: '1',
+  };
+}
+
+// pip/uvicorn/fastapi console-script .exe launchers generated inside a venv
+// have turned out to be unreliable on this Windows setup (some fail
+// instantly with no output, e.g. "Fatal error in launcher: Unable to find
+// an appended archive"). Invoking everything as `python -m <module>`
+// sidesteps those launcher stubs entirely and has proven reliable.
+function venvPython(venv) {
+  const python = path.join(venv.binDir, IS_WINDOWS ? 'python.exe' : 'python');
+  if (!fs.existsSync(python)) {
+    console.error(`${RED}'python' not found in venv at ${venv.venvDir}.${NC}`);
+    process.exit(1);
+  }
+  return python;
+}
+
+// Installs a service's Python dependencies before starting it, matching
+// `source <venv>/activate && pip install -r requirements.txt` from the
+// project's README. Blocking by design: the server must not start against
+// a venv with missing/outdated packages.
+function pipInstall(prefix, serviceDir, venv, python) {
+  console.log(`[${prefix}] Installing dependencies from requirements.txt...`);
+  const result = spawnSync(python, ['-m', 'pip', 'install', '-r', 'requirements.txt'], {
+    cwd: serviceDir,
+    env: venvEnv(venv.binDir),
+    stdio: 'inherit',
+  });
+  if (result.status !== 0) {
+    console.error(`${RED}[${prefix}] pip install -r requirements.txt failed.${NC}`);
+    process.exit(1);
+  }
 }
 
 function startBackend() {
   console.log(`[BACKEND] Starting... ${BACKEND_DIR}`);
   const venv = resolveVenv(BACKEND_DIR, ['.env', 'venv']);
   if (!venv) process.exit(1);
-  const uvicorn = requireVenvCmd(venv.binDir, venv.venvDir, 'uvicorn');
-  if (!uvicorn) process.exit(1);
+  const python = venvPython(venv);
+  pipInstall('BACKEND', BACKEND_DIR, venv, python);
 
   const env = venvEnv(venv.binDir);
-  let args;
   if (MODE === 'prod') {
     console.log('[BACKEND] Starting in production mode on port 52123...');
-    args = ['main:app', '--host', '0.0.0.0', '--port', '52123', '--workers', process.env.WORKERS || '1'];
+    spawnService('BACKEND', python, ['-m', 'uvicorn', 'main:app', '--host', '0.0.0.0', '--port', '52123', '--workers', process.env.WORKERS || '1'], {
+      cwd: BACKEND_DIR,
+      env,
+      detached: !IS_WINDOWS,
+    });
   } else {
+    // Backend pins fastapi-cli==0.0.3, which predates `fastapi.__main__`
+    // (no `python -m fastapi` support), unlike sync-microservice's newer
+    // fastapi-cli. Use uvicorn directly here instead.
     console.log('[BACKEND] Starting in dev mode on port 52123...');
-    args = ['main:app', '--host', '0.0.0.0', '--port', '52123', '--reload'];
+    spawnService('BACKEND', python, ['-m', 'uvicorn', 'main:app', '--host', '0.0.0.0', '--port', '52123', '--reload'], {
+      cwd: BACKEND_DIR,
+      env,
+      detached: !IS_WINDOWS,
+    });
   }
-  spawnService('BACKEND', uvicorn, args, {
-    cwd: BACKEND_DIR,
-    env,
-    detached: !IS_WINDOWS,
-  });
 }
 
 function startSync() {
   const venv = resolveVenv(SYNC_DIR, ['.sync-env', 'venv']);
   if (!venv) process.exit(1);
+  const python = venvPython(venv);
+  pipInstall('SYNC', SYNC_DIR, venv, python);
   console.log('[SYNC] Starting sync-microservice on port 52124...');
 
   const env = venvEnv(venv.binDir);
   if (MODE === 'prod') {
-    const uvicorn = requireVenvCmd(venv.binDir, venv.venvDir, 'uvicorn');
-    if (!uvicorn) process.exit(1);
-    spawnService('SYNC', uvicorn, ['main:app', '--host', '0.0.0.0', '--port', '52124'], {
+    spawnService('SYNC', python, ['-m', 'uvicorn', 'main:app', '--host', '0.0.0.0', '--port', '52124'], {
       cwd: SYNC_DIR,
       env,
       detached: !IS_WINDOWS,
     });
   } else {
-    const fastapi = requireVenvCmd(venv.binDir, venv.venvDir, 'fastapi');
-    if (!fastapi) process.exit(1);
-    spawnService('SYNC', fastapi, ['dev', '--port', '52124'], {
+    spawnService('SYNC', python, ['-m', 'fastapi', 'dev', '--port', '52124'], {
       cwd: SYNC_DIR,
       env,
       detached: !IS_WINDOWS,

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -74,48 +74,51 @@ require_cmd "node" "Node.js not found. Install it from https://nodejs.org, or $S
 require_cmd "npm" "npm not found (usually bundled with Node.js). Install Node.js from https://nodejs.org, or $SETUP_HINT"
 require_cmd "cargo" "Rust/Cargo not found (required by 'npm run tauri dev'). Install it from https://rustup.rs, or $SETUP_HINT"
 
-# --- venv activation helper ---
-# Tries each candidate venv folder name in order, using the correct
-# activate path per OS (bin/activate on Unix, Scripts/activate on Windows).
-activate_venv() {
+# --- venv resolution helper ---
+# Tries each candidate venv folder name in order and prepends its bin dir
+# (bin/ on Unix, Scripts/ on Windows) to PATH directly. Deliberately does
+# NOT `source <venv>/activate`: that script bakes in an absolute path at
+# creation time (see its VIRTUAL_ENV= line and pyvenv.cfg), and silently
+# breaks -- falling through to system Python with no error -- if the venv
+# folder is ever renamed or moved after creation, which happens easily
+# since ".env"/".venv" naming is inconsistent across tooling. Resolving
+# the bin dir fresh from its current location every run sidesteps that.
+resolve_venv() {
     local base_dir="$1"
     shift
     local candidates=("$@")
+    local bin_subdir="bin"
+    [[ "$OS_TYPE" == "windows" ]] && bin_subdir="Scripts"
 
     for name in "${candidates[@]}"; do
         local venv_dir="$base_dir/$name"
-        if [[ "$OS_TYPE" == "windows" ]]; then
-            if [[ -f "$venv_dir/Scripts/activate" ]]; then
-                source "$venv_dir/Scripts/activate"
-                return 0
-            fi
-        else
-            if [[ -f "$venv_dir/bin/activate" ]]; then
-                source "$venv_dir/bin/activate"
-                return 0
-            fi
+        if [[ -f "$venv_dir/$bin_subdir/activate" ]]; then
+            echo "$venv_dir/$bin_subdir"
+            return 0
         fi
     done
 
-    echo -e "${RED}Could not find a venv in $base_dir (looked for: ${candidates[*]})${NC}"
-    echo -e "${YELLOW}${SETUP_HINT}${NC}"
+    echo -e "${RED}Could not find a venv in $base_dir (looked for: ${candidates[*]})${NC}" >&2
+    echo -e "${YELLOW}${SETUP_HINT}${NC}" >&2
     return 1
 }
 
-# Verifies a command exists inside the *currently activated* venv, with
-# guidance to reinstall dependencies rather than a bare "command not found".
-require_venv_cmd() {
-    local cmd="$1"
-    local venv_dir="$2"
-    if ! command -v "$cmd" &> /dev/null; then
-        echo -e "${RED}'$cmd' not found in venv at $venv_dir.${NC}"
-        echo -e "${YELLOW}The venv exists but looks incomplete. Try:${NC}"
-        if [[ "$OS_TYPE" == "windows" ]]; then
-            echo -e "${YELLOW}  source \"$venv_dir/Scripts/activate\" && pip install -r requirements.txt${NC}"
-        else
-            echo -e "${YELLOW}  source \"$venv_dir/bin/activate\" && pip install -r requirements.txt${NC}"
-        fi
-        echo -e "${YELLOW}...or rerun: $SETUP_HINT${NC}"
+# pip/uvicorn/fastapi console-script launchers generated inside a venv have
+# proven unreliable on some platforms (see scripts/run.js for the Windows
+# case that motivated this). Invoking everything as `python -m <module>`
+# sidesteps those launcher stubs entirely.
+export PYTHONUNBUFFERED=1
+export PYTHONUTF8=1
+
+# Installs a service's Python dependencies before starting it, matching
+# `source <venv>/activate && pip install -r requirements.txt` from the
+# project's README. Blocking by design: the server must not start against
+# a venv with missing/outdated packages.
+pip_install() {
+    local prefix="$1"
+    echo "[$prefix] Installing dependencies from requirements.txt..."
+    if ! python -m pip install -r requirements.txt; then
+        echo -e "${RED}[$prefix] pip install -r requirements.txt failed.${NC}"
         return 1
     fi
     return 0
@@ -138,14 +141,18 @@ start_backend() {
     (
         echo "[BACKEND] Starting... ${BACKEND_DIR}"
         cd "$BACKEND_DIR"
-        activate_venv "$BACKEND_DIR" ".env" "venv" || exit 1
-        require_venv_cmd "uvicorn" "$BACKEND_DIR/.env" || exit 1
+        bin_dir=$(resolve_venv "$BACKEND_DIR" ".env" "venv") || exit 1
+        export PATH="$bin_dir:$PATH"
+        pip_install "BACKEND" || exit 1
         if [[ "$MODE" == "prod" ]]; then
             echo "[BACKEND] Starting in production mode on port 52123..."
-            uvicorn main:app --host 0.0.0.0 --port 52123 --workers "${WORKERS:-1}"
+            python -m uvicorn main:app --host 0.0.0.0 --port 52123 --workers "${WORKERS:-1}"
         else
+            # Backend pins fastapi-cli==0.0.3, which predates
+            # `fastapi.__main__` (no `python -m fastapi` support), unlike
+            # sync-microservice's newer fastapi-cli. Use uvicorn directly.
             echo "[BACKEND] Starting in dev mode on port 52123..."
-            uvicorn main:app --host 0.0.0.0 --port 52123 --reload
+            python -m uvicorn main:app --host 0.0.0.0 --port 52123 --reload
         fi
     ) 2>&1 | sed -u 's/^/[BACKEND] /' &
     PIDS+=($!)
@@ -154,14 +161,14 @@ start_backend() {
 start_sync() {
     (
         cd "$SYNC_DIR"
-        activate_venv "$SYNC_DIR" ".sync-env" "venv" || exit 1
+        bin_dir=$(resolve_venv "$SYNC_DIR" ".sync-env" "venv") || exit 1
+        export PATH="$bin_dir:$PATH"
+        pip_install "SYNC" || exit 1
         echo "[SYNC] Starting sync-microservice on port 52124..."
         if [[ "$MODE" == "prod" ]]; then
-            require_venv_cmd "uvicorn" "$SYNC_DIR/.sync-env" || exit 1
-            uvicorn main:app --host 0.0.0.0 --port 52124
+            python -m uvicorn main:app --host 0.0.0.0 --port 52124
         else
-            require_venv_cmd "fastapi" "$SYNC_DIR/.sync-env" || exit 1
-            fastapi dev --port 52124
+            python -m fastapi dev --port 52124
         fi
     ) 2>&1 | sed -u 's/^/[SYNC] /' &
     PIDS+=($!)

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,0 +1,189 @@
+#!/bin/bash
+
+# Unified dev/prod launcher for PictoPy: backend, sync-microservice, and frontend
+#
+# Requires bash (Linux, macOS, Git Bash, or WSL on Windows). If you're on
+# Windows without Git Bash/WSL, use `node scripts/run.js` instead.
+#
+# Usage:
+#   ./run.sh          -> dev mode (default)
+#   ./run.sh --test    -> dev mode (kept as an alias for backward compatibility)
+#   ./run.sh --prod    -> production mode
+
+set -e
+
+# --- Colors (matches scripts/setup.sh conventions) ---
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NC='\033[0m'
+
+MODE="dev"
+if [[ "$1" == "--prod" ]]; then
+    MODE="prod"
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+BACKEND_DIR="$ROOT_DIR/backend"
+SYNC_DIR="$ROOT_DIR/sync-microservice"
+FRONTEND_DIR="$ROOT_DIR/frontend"
+
+# --- OS detection (same approach as scripts/setup.sh and scripts/setup.js) ---
+case "$(uname -s)" in
+    Linux*)     OS_TYPE="linux" ;;
+    Darwin*)    OS_TYPE="macos" ;;
+    MINGW*|MSYS*|CYGWIN*) OS_TYPE="windows" ;;
+    *)
+        OS_TYPE="unknown"
+        echo -e "${YELLOW}Warning: unrecognized OS '$(uname -s)'. Assuming Unix-like behavior.${NC}"
+        ;;
+esac
+
+SETUP_HINT="Run 'npm run setup' from the repo root to install dependencies."
+if [[ "$OS_TYPE" == "windows" ]]; then
+    SETUP_HINT="Run 'npm run setup' from the repo root (this launches scripts/setup.ps1 on Windows)."
+fi
+
+# --- Preflight: fail fast with guidance instead of a raw "command not found" ---
+require_cmd() {
+    local cmd="$1"
+    local guidance="$2"
+    if ! command -v "$cmd" &> /dev/null; then
+        echo -e "${RED}Error: required command '$cmd' not found.${NC}"
+        echo -e "${YELLOW}${guidance}${NC}"
+        exit 1
+    fi
+}
+
+require_dir() {
+    local dir="$1"
+    local label="$2"
+    if [[ ! -d "$dir" ]]; then
+        echo -e "${RED}Error: $label directory not found at $dir${NC}"
+        echo -e "${YELLOW}Make sure you're running this from a full PictoPy checkout.${NC}"
+        exit 1
+    fi
+}
+
+require_dir "$BACKEND_DIR" "backend"
+require_dir "$SYNC_DIR" "sync-microservice"
+require_dir "$FRONTEND_DIR" "frontend"
+
+require_cmd "node" "Node.js not found. Install it from https://nodejs.org, or $SETUP_HINT"
+require_cmd "npm" "npm not found (usually bundled with Node.js). Install Node.js from https://nodejs.org, or $SETUP_HINT"
+require_cmd "cargo" "Rust/Cargo not found (required by 'npm run tauri dev'). Install it from https://rustup.rs, or $SETUP_HINT"
+
+# --- venv activation helper ---
+# Tries each candidate venv folder name in order, using the correct
+# activate path per OS (bin/activate on Unix, Scripts/activate on Windows).
+activate_venv() {
+    local base_dir="$1"
+    shift
+    local candidates=("$@")
+
+    for name in "${candidates[@]}"; do
+        local venv_dir="$base_dir/$name"
+        if [[ "$OS_TYPE" == "windows" ]]; then
+            if [[ -f "$venv_dir/Scripts/activate" ]]; then
+                source "$venv_dir/Scripts/activate"
+                return 0
+            fi
+        else
+            if [[ -f "$venv_dir/bin/activate" ]]; then
+                source "$venv_dir/bin/activate"
+                return 0
+            fi
+        fi
+    done
+
+    echo -e "${RED}Could not find a venv in $base_dir (looked for: ${candidates[*]})${NC}"
+    echo -e "${YELLOW}${SETUP_HINT}${NC}"
+    return 1
+}
+
+# Verifies a command exists inside the *currently activated* venv, with
+# guidance to reinstall dependencies rather than a bare "command not found".
+require_venv_cmd() {
+    local cmd="$1"
+    local venv_dir="$2"
+    if ! command -v "$cmd" &> /dev/null; then
+        echo -e "${RED}'$cmd' not found in venv at $venv_dir.${NC}"
+        echo -e "${YELLOW}The venv exists but looks incomplete. Try:${NC}"
+        if [[ "$OS_TYPE" == "windows" ]]; then
+            echo -e "${YELLOW}  source \"$venv_dir/Scripts/activate\" && pip install -r requirements.txt${NC}"
+        else
+            echo -e "${YELLOW}  source \"$venv_dir/bin/activate\" && pip install -r requirements.txt${NC}"
+        fi
+        echo -e "${YELLOW}...or rerun: $SETUP_HINT${NC}"
+        return 1
+    fi
+    return 0
+}
+
+PIDS=()
+
+cleanup() {
+    echo ""
+    echo "Shutting down all services..."
+    for pid in "${PIDS[@]}"; do
+        kill "$pid" 2>/dev/null
+    done
+    wait 2>/dev/null
+    exit 0
+}
+trap cleanup INT TERM
+
+start_backend() {
+    (
+        echo "[BACKEND] Starting... ${BACKEND_DIR}"
+        cd "$BACKEND_DIR"
+        activate_venv "$BACKEND_DIR" ".env" "venv" || exit 1
+        require_venv_cmd "uvicorn" "$BACKEND_DIR/.env" || exit 1
+        if [[ "$MODE" == "prod" ]]; then
+            echo "[BACKEND] Starting in production mode on port 52123..."
+            uvicorn main:app --host 0.0.0.0 --port 52123 --workers "${WORKERS:-1}"
+        else
+            echo "[BACKEND] Starting in dev mode on port 52123..."
+            uvicorn main:app --host 0.0.0.0 --port 52123 --reload
+        fi
+    ) 2>&1 | sed -u 's/^/[BACKEND] /' &
+    PIDS+=($!)
+}
+
+start_sync() {
+    (
+        cd "$SYNC_DIR"
+        activate_venv "$SYNC_DIR" ".sync-env" "venv" || exit 1
+        echo "[SYNC] Starting sync-microservice on port 52124..."
+        if [[ "$MODE" == "prod" ]]; then
+            require_venv_cmd "uvicorn" "$SYNC_DIR/.sync-env" || exit 1
+            uvicorn main:app --host 0.0.0.0 --port 52124
+        else
+            require_venv_cmd "fastapi" "$SYNC_DIR/.sync-env" || exit 1
+            fastapi dev --port 52124
+        fi
+    ) 2>&1 | sed -u 's/^/[SYNC] /' &
+    PIDS+=($!)
+}
+
+start_frontend() {
+    (
+        cd "$FRONTEND_DIR"
+        if [[ ! -d "node_modules" ]]; then
+            echo -e "${RED}[FRONTEND] node_modules not found.${NC}"
+            echo -e "${YELLOW}[FRONTEND] ${SETUP_HINT}${NC}"
+            exit 1
+        fi
+        echo "[FRONTEND] Starting Tauri dev..."
+        npm run tauri dev
+    ) 2>&1 | sed -u 's/^/[FRONTEND] /' &
+    PIDS+=($!)
+}
+
+echo "Starting PictoPy (mode: $MODE, OS: $OS_TYPE)..."
+start_backend
+start_sync
+start_frontend
+
+wait


### PR DESCRIPTION
###  Addressed Issues:

Fixes #1395


###  Screenshots/Recordings:

N/A this PR only touches developer tooling (`scripts/run.js`, `scripts/run.sh`), no UI changes. Verified end-to-end locally instead: `node scripts/run.js` brings up backend (`:52123`), sync-microservice (`:52124`), and the Tauri frontend together in one command, with all three exchanging live requests (`/health`, `/models/status`, `/folders/status`, etc. all returning `200`).


###  Additional Notes:

Adds `scripts/run.js` and `scripts/run.sh` a single command (`node scripts/run.js` or `bash scripts/run.sh`, `--prod` for production mode) that starts the backend, sync-microservice, and frontend together, instead of juggling three terminals and manually activating two different venvs.

While validating this on Windows, a few real bugs surfaced and got fixed along the way:

1. **Buffered/missing output**  Node pipes child stdio, so Python defaulted to full buffering instead of line-buffering, making it look like backend/sync had silently failed to start when they were actually just not flushing yet. Fixed with `PYTHONUNBUFFERED=1`.
2. **Corrupted pip-generated launcher `.exe` stubs** — `uvicorn.exe` / `fastapi.exe` / `pip.exe` console-script launchers can fail instantly with no output at all (`Fatal error in launcher: Unable to find an appended archive`), and the error is invisible when there's no console attached (spawned via Node, or under Git Bash). Fixed by invoking everything as `python -m <module>` instead of relying on the generated launcher stubs.
3. **`fastapi dev`'s startup banner crashing on Windows** — `rich`/`rich_toolkit` falls back to a legacy Windows console writer (hardcoded `cp1252` encoding) when there's no real console attached, and the 🚀 emoji in its own banner can't be encoded, crashing the process before it ever binds to a port. Fixed with `PYTHONUTF8=1`.
4. **Fragile venv activation in `run.sh`** — it used to `source <venv>/activate`, but that script bakes in an absolute path at creation time (see its `VIRTUAL_ENV=` line and `pyvenv.cfg`) and silently breaks — falling through to system Python with *no error* — if the venv folder is ever renamed or moved afterward. Both scripts now resolve each venv's bin dir fresh from its current location every run instead of trusting the stale script contents.

Each service also now runs `python -m pip install -r requirements.txt` before starting, so it never comes up against a stale/incomplete venv.

Backend and sync-microservice intentionally diverge in dev mode: backend uses `python -m uvicorn --reload` (its pinned `fastapi-cli==0.0.3` predates `python -m fastapi` support), while sync-microservice uses `python -m fastapi dev` (its `fastapi-cli==0.0.8` supports it).

### AI Usage Disclosure:

We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact. AI slop is strongly discouraged and may lead to banning and blocking. Do not spam our repos with AI slop.

Check one of the checkboxes below:

- [ ] This PR does not contain AI-generated code at all.
- [x] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools: Claude Code (Claude Sonnet 5) — used to implement and debug `run.js`/`run.sh`, including live end-to-end verification on Windows (backend, sync-microservice, and the Tauri frontend all started successfully and exchanged live requests).


## Checklist
<!-- Mark items with [x] to indicate completion -->
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [ ] If applicable, I have made corresponding changes or additions to the documentation
- [ ] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [x ] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x ] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x ] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.
