### PR TITLE
test(backend): add images DB coverage + lift videos/model tests to 100%

### DIFF
--- a/backend/tests/test_face_quality.py
+++ b/backend/tests/test_face_quality.py
@@ -1,0 +1,104 @@
+import numpy as np
+
+from app.utils.face_quality import face_passes_quality_gate
+
+# ##############################
+# Helpers
+# ##############################
+
+
+def sharp_gray(size=50):
+    """A deterministic high-variance (sharp) grayscale image."""
+    img = np.zeros((size, size), dtype=np.uint8)
+    img[::2] = 255  # alternating rows -> large Laplacian variance
+    return img
+
+
+# ##############################
+# Quality gate
+# ##############################
+
+
+class TestFaceQualityGate:
+    def test_passes_all_gates(self):
+        crop = np.stack([sharp_gray()] * 3, axis=-1)  # 3-channel colour crop
+        assert (
+            face_passes_quality_gate(
+                crop,
+                bbox=(0, 0, 50, 50),
+                conf_score=0.9,
+                conf_threshold=0.5,
+                blur_threshold=10.0,
+                min_face_size=100,
+            )
+            is True
+        )
+
+    def test_rejects_low_confidence(self):
+        crop = np.stack([sharp_gray()] * 3, axis=-1)
+        assert (
+            face_passes_quality_gate(
+                crop,
+                bbox=(0, 0, 50, 50),
+                conf_score=0.1,
+                conf_threshold=0.5,
+                blur_threshold=10.0,
+                min_face_size=100,
+            )
+            is False
+        )
+
+    def test_rejects_small_face(self):
+        crop = np.stack([sharp_gray()] * 3, axis=-1)
+        assert (
+            face_passes_quality_gate(
+                crop,
+                bbox=(0, 0, 50, 50),
+                conf_score=0.9,
+                conf_threshold=0.5,
+                blur_threshold=10.0,
+                min_face_size=10000,  # area 2500 < threshold
+            )
+            is False
+        )
+
+    def test_rejects_empty_crop(self):
+        assert (
+            face_passes_quality_gate(
+                np.empty((0, 0, 3), dtype=np.uint8),
+                bbox=(0, 0, 50, 50),
+                conf_score=0.9,
+                conf_threshold=0.5,
+                blur_threshold=10.0,
+                min_face_size=100,
+            )
+            is False
+        )
+
+    def test_accepts_grayscale_crop(self):
+        # A 2-D crop skips the BGR2GRAY conversion branch
+        assert (
+            face_passes_quality_gate(
+                sharp_gray(),
+                bbox=(0, 0, 50, 50),
+                conf_score=0.9,
+                conf_threshold=0.5,
+                blur_threshold=10.0,
+                min_face_size=100,
+            )
+            is True
+        )
+
+    def test_rejects_blurry_crop(self):
+        flat = np.full((50, 50, 3), 127, dtype=np.uint8)  # zero-variance -> blurry
+        assert (
+            face_passes_quality_gate(
+                flat,
+                bbox=(0, 0, 50, 50),
+                conf_score=0.9,
+                conf_threshold=0.5,
+                blur_threshold=10.0,
+                min_face_size=100,
+            )
+            is False
+        )

--- a/backend/tests/test_face_quality.py
+++ b/backend/tests/test_face_quality.py
@@ -7,7 +7,7 @@ from app.utils.face_quality import face_passes_quality_gate
 # ##############################
 
 
-def sharp_gray(size=50):
+def sharp_gray(size: int = 50) -> np.ndarray:
     """A deterministic high-variance (sharp) grayscale image."""
     img = np.zeros((size, size), dtype=np.uint8)
     img[::2] = 255  # alternating rows -> large Laplacian variance

--- a/backend/tests/test_images_db.py
+++ b/backend/tests/test_images_db.py
@@ -1,0 +1,527 @@
+import os
+import sqlite3
+import tempfile
+from datetime import datetime
+
+import pytest
+
+from app.database.images import (
+    db_create_images_table,
+    db_bulk_insert_images,
+    db_get_all_images,
+    db_get_untagged_images,
+    db_get_unembedded_images,
+    db_update_image_tagged_status,
+    db_insert_image_classes_batch,
+    db_get_images_by_folder_ids,
+    db_delete_images_by_ids,
+    db_toggle_image_favourite_status,
+    db_get_image_by_id,
+    db_search_images_by_tag,
+    db_get_images_by_ids,
+    db_get_images_by_date_range,
+    db_get_images_near_location,
+    db_get_images_by_year_month,
+    db_get_images_with_location,
+    db_get_all_images_for_memories,
+    db_mark_images_embedded,
+)
+from app.database.folders import db_create_folders_table
+from app.database.yolo_mapping import db_create_YOLO_classes_table
+from app.database.semantic_labels import db_create_semantic_labels_table
+
+# ##############################
+# Pytest Fixtures
+# ##############################
+
+
+@pytest.fixture(scope="function")
+def test_db(monkeypatch):
+    """Point the image/folder/mapping DB modules at a fresh tempfile database."""
+    db_fd, db_path = tempfile.mkstemp()
+    os.close(db_fd)
+
+    monkeypatch.setattr("app.config.settings.DATABASE_PATH", db_path)
+    monkeypatch.setattr("app.database.images.DATABASE_PATH", db_path)
+    monkeypatch.setattr("app.database.folders.DATABASE_PATH", db_path)
+    monkeypatch.setattr("app.database.yolo_mapping.DATABASE_PATH", db_path)
+
+    # Build the production schema the image queries depend on. Order matters:
+    # image_classes_display is a view over the image_classes table.
+    db_create_YOLO_classes_table()  # mappings (tag names)
+    db_create_folders_table()  # folders (FK target + AI_Tagging joins)
+    db_create_images_table()  # images + image_classes
+    db_create_semantic_labels_table()  # image_classes_display view
+
+    yield db_path
+
+    os.unlink(db_path)
+
+
+@pytest.fixture
+def folder(test_db):
+    """Insert a folder row (AI_Tagging on) to satisfy the images.folder_id FK."""
+    folder_id = "folder-1"
+    conn = sqlite3.connect(test_db)
+    conn.execute(
+        "INSERT INTO folders (folder_id, folder_path, last_modified_time, AI_Tagging) "
+        "VALUES (?, ?, 0, 1)",
+        (folder_id, "/photos"),
+    )
+    conn.commit()
+    conn.close()
+    return folder_id
+
+
+def make_image_record(image_id, path, folder_id, **overrides):
+    record = {
+        "id": image_id,
+        "path": path,
+        "folder_id": folder_id,
+        "thumbnailPath": f"/thumbs/thumbnail_{image_id}.jpg",
+        "metadata": "{}",
+        "isTagged": False,
+        "isEmbedded": False,
+        "latitude": None,
+        "longitude": None,
+        "captured_at": None,
+    }
+    record.update(overrides)
+    return record
+
+
+def add_tag(db_path, image_id, class_id, name):
+    """Register a mapping name and attach it to an image via image_classes."""
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "INSERT OR REPLACE INTO mappings (class_id, name) VALUES (?, ?)",
+        (class_id, name),
+    )
+    conn.execute(
+        "INSERT OR IGNORE INTO image_classes (image_id, class_id) VALUES (?, ?)",
+        (image_id, class_id),
+    )
+    conn.commit()
+    conn.close()
+
+
+def drop_object(db_path, kind, name):
+    """Drop a table/view so the next query against it raises sqlite3.Error."""
+    conn = sqlite3.connect(db_path)
+    conn.execute(f"DROP {kind} IF EXISTS {name}")
+    conn.commit()
+    conn.close()
+
+
+# ##############################
+# Table creation
+# ##############################
+
+
+class TestCreateImagesTable:
+    def test_creates_images_and_image_classes_tables(self, test_db):
+        conn = sqlite3.connect(test_db)
+        tables = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+        conn.close()
+        assert "images" in tables
+        assert "image_classes" in tables
+
+    def test_is_idempotent(self, test_db):
+        # Calling create again on an existing schema must not raise
+        db_create_images_table()
+
+    def test_adds_score_column_to_legacy_image_classes(self, test_db):
+        # A pre-score image_classes table must gain the column via the guarded ALTER
+        conn = sqlite3.connect(test_db)
+        conn.execute("DROP TABLE image_classes")
+        conn.execute(
+            "CREATE TABLE image_classes (image_id TEXT, class_id INTEGER, "
+            "PRIMARY KEY (image_id, class_id))"
+        )
+        conn.commit()
+        conn.close()
+
+        db_create_images_table()
+
+        conn = sqlite3.connect(test_db)
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(image_classes)")}
+        conn.close()
+        assert "score" in columns
+
+
+# ##############################
+# Bulk insert
+# ##############################
+
+
+class TestBulkInsertImages:
+    def test_empty_list_is_a_noop_success(self, test_db):
+        assert db_bulk_insert_images([]) is True
+
+    def test_inserts_records(self, folder, test_db):
+        records = [
+            make_image_record("img-1", "/photos/a.jpg", folder),
+            make_image_record("img-2", "/photos/b.jpg", folder),
+        ]
+        assert db_bulk_insert_images(records) is True
+        assert len(db_get_all_images()) == 2
+
+    def test_conflict_on_path_upserts(self, folder, test_db):
+        db_bulk_insert_images([make_image_record("img-1", "/photos/a.jpg", folder)])
+        # Same path, now tagged -> row is updated in place, not duplicated
+        db_bulk_insert_images(
+            [make_image_record("img-1", "/photos/a.jpg", folder, isTagged=True)]
+        )
+        images = db_get_all_images()
+        assert len(images) == 1
+        assert images[0]["isTagged"] is True
+
+    def test_foreign_key_violation_returns_false(self, test_db):
+        # folder_id has no matching folders row -> FK failure -> rollback
+        record = make_image_record("img-1", "/photos/a.jpg", "missing-folder")
+        assert db_bulk_insert_images([record]) is False
+        assert db_get_all_images() == []
+
+
+# ##############################
+# Reading images
+# ##############################
+
+
+class TestGetAllImages:
+    def test_returns_empty_when_no_images(self, test_db):
+        assert db_get_all_images() == []
+
+    def test_returns_tags_and_none_when_untagged(self, folder, test_db):
+        db_bulk_insert_images(
+            [
+                make_image_record("img-1", "/photos/a.jpg", folder),
+                make_image_record("img-2", "/photos/b.jpg", folder),
+            ]
+        )
+        add_tag(test_db, "img-1", 9001, "sunset")
+
+        by_id = {img["id"]: img for img in db_get_all_images()}
+        assert by_id["img-1"]["tags"] == ["sunset"]
+        assert by_id["img-2"]["tags"] is None
+
+    def test_tagged_filter(self, folder, test_db):
+        db_bulk_insert_images(
+            [
+                make_image_record("img-1", "/photos/a.jpg", folder, isTagged=True),
+                make_image_record("img-2", "/photos/b.jpg", folder, isTagged=False),
+            ]
+        )
+        tagged = db_get_all_images(tagged=True)
+        assert [img["id"] for img in tagged] == ["img-1"]
+
+
+class TestGetImageById:
+    def test_returns_none_when_missing(self, test_db):
+        assert db_get_image_by_id("nope") is None
+
+    def test_parses_metadata(self, folder, test_db):
+        db_bulk_insert_images(
+            [make_image_record("img-1", "/photos/a.jpg", folder, metadata='{"k": 1}')]
+        )
+        image = db_get_image_by_id("img-1")
+        assert image["metadata"] == {"k": 1}
+        assert image["isFavourite"] is False
+
+    def test_invalid_metadata_falls_back_to_empty(self, folder, test_db):
+        db_bulk_insert_images(
+            [make_image_record("img-1", "/photos/a.jpg", folder, metadata="not json")]
+        )
+        assert db_get_image_by_id("img-1")["metadata"] == {}
+
+
+class TestUntaggedAndUnembedded:
+    def test_untagged_lists_only_untagged_in_ai_folders(self, folder, test_db):
+        db_bulk_insert_images(
+            [
+                make_image_record("img-1", "/photos/a.jpg", folder, isTagged=False),
+                make_image_record("img-2", "/photos/b.jpg", folder, isTagged=True),
+            ]
+        )
+        assert [img["id"] for img in db_get_untagged_images()] == ["img-1"]
+
+    def test_unembedded_lists_only_unembedded_in_ai_folders(self, folder, test_db):
+        db_bulk_insert_images(
+            [
+                make_image_record("img-1", "/photos/a.jpg", folder, isEmbedded=False),
+                make_image_record("img-2", "/photos/b.jpg", folder, isEmbedded=True),
+            ]
+        )
+        assert [img["id"] for img in db_get_unembedded_images()] == ["img-1"]
+
+
+# ##############################
+# Tagging, classes and status
+# ##############################
+
+
+class TestTaggedStatusAndClasses:
+    def test_update_tagged_status(self, folder, test_db):
+        db_bulk_insert_images([make_image_record("img-1", "/photos/a.jpg", folder)])
+        assert db_update_image_tagged_status("img-1", True) is True
+        assert db_get_image_by_id("img-1")["isTagged"] is True
+
+    def test_update_tagged_status_missing_image(self, test_db):
+        assert db_update_image_tagged_status("nope", True) is False
+
+    def test_insert_image_classes_batch_empty(self, test_db):
+        assert db_insert_image_classes_batch([]) is True
+
+    def test_insert_image_classes_batch_ignores_duplicates(self, folder, test_db):
+        db_bulk_insert_images([make_image_record("img-1", "/photos/a.jpg", folder)])
+        assert db_insert_image_classes_batch([("img-1", 0), ("img-1", 0)]) is True
+
+        conn = sqlite3.connect(test_db)
+        count = conn.execute(
+            "SELECT COUNT(*) FROM image_classes WHERE image_id = 'img-1'"
+        ).fetchone()[0]
+        conn.close()
+        assert count == 1
+
+
+class TestFavouriteStatus:
+    def test_toggles_on_then_off(self, folder, test_db):
+        db_bulk_insert_images([make_image_record("img-1", "/photos/a.jpg", folder)])
+        assert db_toggle_image_favourite_status("img-1") is True
+        assert db_get_image_by_id("img-1")["isFavourite"] is True
+        assert db_toggle_image_favourite_status("img-1") is True
+        assert db_get_image_by_id("img-1")["isFavourite"] is False
+
+    def test_missing_image_returns_false(self, test_db):
+        assert db_toggle_image_favourite_status("nope") is False
+
+
+# ##############################
+# Folder queries and deletion
+# ##############################
+
+
+class TestFolderQueriesAndDeletion:
+    def test_get_images_by_folder_ids_empty(self, test_db):
+        assert db_get_images_by_folder_ids([]) == []
+
+    def test_get_images_by_folder_ids(self, folder, test_db):
+        db_bulk_insert_images(
+            [
+                make_image_record("img-1", "/photos/a.jpg", folder),
+                make_image_record("img-2", "/photos/b.jpg", folder),
+            ]
+        )
+        rows = db_get_images_by_folder_ids([folder])
+        assert {row[0] for row in rows} == {"img-1", "img-2"}
+        assert rows[0][1].startswith("/photos/")
+
+    def test_delete_by_ids_empty(self, test_db):
+        assert db_delete_images_by_ids([]) is True
+
+    def test_delete_by_ids_cascades_to_image_classes(self, folder, test_db):
+        db_bulk_insert_images(
+            [
+                make_image_record("img-1", "/photos/a.jpg", folder),
+                make_image_record("img-2", "/photos/b.jpg", folder),
+            ]
+        )
+        db_insert_image_classes_batch([("img-1", 0)])
+
+        assert db_delete_images_by_ids(["img-1"]) is True
+        assert [img["id"] for img in db_get_all_images()] == ["img-2"]
+
+        conn = sqlite3.connect(test_db)
+        remaining = conn.execute(
+            "SELECT COUNT(*) FROM image_classes WHERE image_id = 'img-1'"
+        ).fetchone()[0]
+        conn.close()
+        assert remaining == 0
+
+
+# ##############################
+# Search and lookup by ids
+# ##############################
+
+
+class TestSearchAndGetByIds:
+    def test_search_by_tag_is_case_insensitive(self, folder, test_db):
+        db_bulk_insert_images([make_image_record("img-1", "/photos/a.jpg", folder)])
+        add_tag(test_db, "img-1", 9001, "sunset")
+
+        results = db_search_images_by_tag("SUNSET")
+        assert [img["id"] for img in results] == ["img-1"]
+        assert results[0]["tags"] == ["sunset"]
+
+    def test_search_by_tag_no_match(self, folder, test_db):
+        db_bulk_insert_images([make_image_record("img-1", "/photos/a.jpg", folder)])
+        assert db_search_images_by_tag("nothing") == []
+
+    def test_get_images_by_ids_empty(self, test_db):
+        assert db_get_images_by_ids([]) == []
+
+    def test_get_images_by_ids_preserves_request_order(self, folder, test_db):
+        db_bulk_insert_images(
+            [
+                make_image_record("img-1", "/photos/a.jpg", folder),
+                make_image_record("img-2", "/photos/b.jpg", folder),
+                make_image_record("img-3", "/photos/c.jpg", folder),
+            ]
+        )
+        # Request out of insertion order, with one id that does not exist
+        results = db_get_images_by_ids(["img-3", "img-1", "missing"])
+        assert [img["id"] for img in results] == ["img-3", "img-1"]
+
+
+# ##############################
+# Memories: location and time
+# ##############################
+
+
+class TestMemoriesQueries:
+    def _seed_memory_images(self, folder, test_db):
+        db_bulk_insert_images(
+            [
+                make_image_record(
+                    "img-near",
+                    "/photos/near.jpg",
+                    folder,
+                    latitude=40.001,
+                    longitude=-74.001,
+                    captured_at="2024-06-15 12:00:00",
+                ),
+                make_image_record(
+                    "img-far",
+                    "/photos/far.jpg",
+                    folder,
+                    latitude=41.0,
+                    longitude=-75.0,
+                    captured_at="2024-07-15 12:00:00",
+                ),
+                make_image_record(
+                    "img-nogps",
+                    "/photos/nogps.jpg",
+                    folder,
+                    captured_at="2024-06-20 09:00:00",
+                ),
+            ]
+        )
+
+    def test_by_date_range(self, folder, test_db):
+        self._seed_memory_images(folder, test_db)
+        results = db_get_images_by_date_range(
+            datetime(2024, 6, 1), datetime(2024, 6, 30)
+        )
+        assert {img["id"] for img in results} == {"img-near", "img-nogps"}
+
+    def test_by_date_range_favorites_only(self, folder, test_db):
+        self._seed_memory_images(folder, test_db)
+        db_toggle_image_favourite_status("img-near")
+        results = db_get_images_by_date_range(
+            datetime(2024, 6, 1), datetime(2024, 6, 30), include_favorites_only=True
+        )
+        assert [img["id"] for img in results] == ["img-near"]
+
+    def test_near_location_excludes_far_and_null(self, folder, test_db):
+        self._seed_memory_images(folder, test_db)
+        results = db_get_images_near_location(40.0, -74.0, radius_km=5.0)
+        assert [img["id"] for img in results] == ["img-near"]
+
+    def test_by_year_month(self, folder, test_db):
+        self._seed_memory_images(folder, test_db)
+        results = db_get_images_by_year_month(2024, 6)
+        assert {img["id"] for img in results} == {"img-near", "img-nogps"}
+
+    def test_with_location_only_returns_geotagged(self, folder, test_db):
+        self._seed_memory_images(folder, test_db)
+        results = db_get_images_with_location()
+        assert {img["id"] for img in results} == {"img-near", "img-far"}
+
+    def test_all_for_memories_returns_everything(self, folder, test_db):
+        self._seed_memory_images(folder, test_db)
+        results = db_get_all_images_for_memories()
+        assert {img["id"] for img in results} == {"img-near", "img-far", "img-nogps"}
+
+
+# ##############################
+# Marking embedded
+# ##############################
+
+
+class TestMarkImagesEmbedded:
+    def test_empty_list_is_a_noop_success(self, test_db):
+        assert db_mark_images_embedded([]) is True
+
+    def test_marks_images_embedded(self, folder, test_db):
+        db_bulk_insert_images(
+            [
+                make_image_record("img-1", "/photos/a.jpg", folder, isEmbedded=False),
+                make_image_record("img-2", "/photos/b.jpg", folder, isEmbedded=False),
+            ]
+        )
+        assert db_mark_images_embedded(["img-1", "img-2"]) is True
+        assert db_get_unembedded_images() == []
+
+
+# ##############################
+# Error handling
+# ##############################
+
+
+class TestErrorHandling:
+    @pytest.mark.parametrize(
+        "call",
+        [
+            lambda: db_get_all_images(),
+            lambda: db_get_images_by_date_range(
+                datetime(2024, 1, 1), datetime(2024, 12, 31)
+            ),
+            lambda: db_get_images_near_location(0.0, 0.0),
+            lambda: db_get_images_by_year_month(2024, 1),
+            lambda: db_get_images_with_location(),
+            lambda: db_get_all_images_for_memories(),
+        ],
+    )
+    def test_view_read_errors_return_empty(self, test_db, call):
+        # These queries join image_classes_display; without it they must not crash
+        drop_object(test_db, "VIEW", "image_classes_display")
+        assert call() == []
+
+    def test_search_by_tag_reraises_on_db_error(self, test_db):
+        drop_object(test_db, "VIEW", "image_classes_display")
+        with pytest.raises(sqlite3.Error):
+            db_search_images_by_tag("x")
+
+    def test_get_images_by_ids_reraises_on_db_error(self, test_db):
+        drop_object(test_db, "VIEW", "image_classes_display")
+        with pytest.raises(sqlite3.Error):
+            db_get_images_by_ids(["x"])
+
+    def test_get_by_folder_ids_returns_empty_on_db_error(self, test_db):
+        drop_object(test_db, "TABLE", "images")
+        assert db_get_images_by_folder_ids([1]) == []
+
+    def test_update_tagged_status_returns_false_on_db_error(self, test_db):
+        drop_object(test_db, "TABLE", "images")
+        assert db_update_image_tagged_status("x", True) is False
+
+    def test_delete_by_ids_returns_false_on_db_error(self, test_db):
+        drop_object(test_db, "TABLE", "images")
+        assert db_delete_images_by_ids(["x"]) is False
+
+    def test_toggle_favourite_returns_false_on_db_error(self, test_db):
+        drop_object(test_db, "TABLE", "images")
+        assert db_toggle_image_favourite_status("x") is False
+
+    def test_mark_embedded_returns_false_on_db_error(self, test_db):
+        drop_object(test_db, "TABLE", "images")
+        assert db_mark_images_embedded(["x"]) is False
+
+    def test_insert_image_classes_returns_false_on_db_error(self, test_db):
+        drop_object(test_db, "TABLE", "image_classes")
+        assert db_insert_image_classes_batch([("x", 0)]) is False

--- a/backend/tests/test_images_db.py
+++ b/backend/tests/test_images_db.py
@@ -2,6 +2,7 @@ import os
 import sqlite3
 import tempfile
 from datetime import datetime
+from typing import Any, Dict, Iterator
 
 import pytest
 
@@ -36,7 +37,7 @@ from app.database.semantic_labels import db_create_semantic_labels_table
 
 
 @pytest.fixture(scope="function")
-def test_db(monkeypatch):
+def test_db(monkeypatch: pytest.MonkeyPatch) -> Iterator[str]:
     """Point the image/folder/mapping DB modules at a fresh tempfile database."""
     db_fd, db_path = tempfile.mkstemp()
     os.close(db_fd)
@@ -59,7 +60,7 @@ def test_db(monkeypatch):
 
 
 @pytest.fixture
-def folder(test_db):
+def folder(test_db: str) -> str:
     """Insert a folder row (AI_Tagging on) to satisfy the images.folder_id FK."""
     folder_id = "folder-1"
     conn = sqlite3.connect(test_db)
@@ -73,8 +74,10 @@ def folder(test_db):
     return folder_id
 
 
-def make_image_record(image_id, path, folder_id, **overrides):
-    record = {
+def make_image_record(
+    image_id: str, path: str, folder_id: str, **overrides: Any
+) -> Dict[str, Any]:
+    record: Dict[str, Any] = {
         "id": image_id,
         "path": path,
         "folder_id": folder_id,
@@ -90,7 +93,7 @@ def make_image_record(image_id, path, folder_id, **overrides):
     return record
 
 
-def add_tag(db_path, image_id, class_id, name):
+def add_tag(db_path: str, image_id: str, class_id: int, name: str) -> None:
     """Register a mapping name and attach it to an image via image_classes."""
     conn = sqlite3.connect(db_path)
     conn.execute(
@@ -105,7 +108,7 @@ def add_tag(db_path, image_id, class_id, name):
     conn.close()
 
 
-def drop_object(db_path, kind, name):
+def drop_object(db_path: str, kind: str, name: str) -> None:
     """Drop a table/view so the next query against it raises sqlite3.Error."""
     conn = sqlite3.connect(db_path)
     conn.execute(f"DROP {kind} IF EXISTS {name}")
@@ -332,6 +335,14 @@ class TestFolderQueriesAndDeletion:
             ]
         )
         db_insert_image_classes_batch([("img-1", 0)])
+
+        # The junction row must exist first, or the cascade assertion is vacuous
+        conn = sqlite3.connect(test_db)
+        before = conn.execute(
+            "SELECT COUNT(*) FROM image_classes WHERE image_id = 'img-1'"
+        ).fetchone()[0]
+        conn.close()
+        assert before == 1
 
         assert db_delete_images_by_ids(["img-1"]) is True
         assert [img["id"] for img in db_get_all_images()] == ["img-2"]

--- a/backend/tests/test_onnx_session_base.py
+++ b/backend/tests/test_onnx_session_base.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from app.models.ONNXSessionBase import ONNXSessionBase
 from app.models.SigLIP2Text import SigLIP2Text
 from app.models.session_registry import (
     get_active_session_count,
@@ -102,3 +103,21 @@ class TestONNXSessionBaseClose:
         session.close()
         session.close()  # second call must not raise or double-decrement
         assert get_active_session_count(MODEL_KEY) == 0
+
+
+class TestONNXSessionBaseCreation:
+    @patch("os.path.exists", return_value=False)
+    def test_get_session_raises_when_model_missing(self, mock_exists):
+        session = SigLIP2Text(MODEL_PATH)
+        with pytest.raises(RuntimeError, match="not installed"):
+            session.get_session()
+
+    def test_base_clear_tensor_names_is_abstract(self):
+        base = ONNXSessionBase(MODEL_PATH)
+        with pytest.raises(NotImplementedError):
+            base._clear_tensor_names()
+
+    def test_del_swallows_close_errors(self):
+        base = ONNXSessionBase(MODEL_PATH)
+        base.close = MagicMock(side_effect=RuntimeError("boom"))
+        base.__del__()  # must not raise

--- a/backend/tests/test_siglip2text.py
+++ b/backend/tests/test_siglip2text.py
@@ -1,0 +1,85 @@
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from app.models.SigLIP2Text import SigLIP2Text
+from app.models.session_registry import (
+    get_active_session_count,
+    mark_model_session_inactive,
+)
+
+MODEL_PATH = "app/models/ONNX_Exports/SigLIP2_Base_Text.onnx"
+MODEL_KEY = "siglip2_base_text"
+
+
+class _FakeTensor:
+    def __init__(self, name):
+        self.name = name
+
+
+def _ort_session(input_names, output_name="output"):
+    """Stand-in for onnxruntime.InferenceSession -- no real model file needed."""
+    session = MagicMock()
+    session.get_inputs.return_value = [_FakeTensor(n) for n in input_names]
+    session.get_outputs.return_value = [_FakeTensor(output_name)]
+    return session
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    yield
+    # Don't leak a registered session into other tests sharing this model key
+    while get_active_session_count(MODEL_KEY) > 0:
+        mark_model_session_inactive(MODEL_KEY)
+
+
+class TestGetSession:
+    @patch("onnxruntime.InferenceSession")
+    @patch("os.path.exists", return_value=True)
+    def test_second_call_returns_cached_session(self, mock_exists, mock_cls):
+        mock_cls.return_value = _ort_session(["input_ids", "attention_mask"])
+        model = SigLIP2Text(MODEL_PATH)
+
+        first = model.get_session()
+        second = model.get_session()  # fast path: self._session already set
+        assert second == first
+        model.close()
+
+    def test_raises_if_names_cleared_mid_call(self):
+        # session present but a racing close() has nulled the tensor names
+        model = SigLIP2Text(MODEL_PATH)
+        model._session = MagicMock()
+        model.input_ids_name = None
+        with pytest.raises(RuntimeError, match="was closed"):
+            model.get_session()
+
+    @patch("onnxruntime.InferenceSession")
+    @patch("os.path.exists", return_value=True)
+    def test_raises_when_output_name_missing(self, mock_exists, mock_cls):
+        # Inputs valid, but the graph exposes no usable output tensor name
+        mock_cls.return_value = _ort_session(
+            ["input_ids", "attention_mask"], output_name=None
+        )
+        model = SigLIP2Text(MODEL_PATH)
+        with pytest.raises(RuntimeError, match="was closed"):
+            model.get_session()
+        model.close()
+
+
+class TestGetEmbedding:
+    @patch("onnxruntime.InferenceSession")
+    @patch("os.path.exists", return_value=True)
+    def test_returns_l2_normalized_embedding(self, mock_exists, mock_cls):
+        session = _ort_session(["input_ids", "attention_mask"])
+        session.run.return_value = [np.array([[3.0, 4.0]], dtype=np.float32)]
+        mock_cls.return_value = session
+
+        model = SigLIP2Text(MODEL_PATH)
+        ids = np.zeros((1, 4), dtype=np.int64)
+        mask = np.ones((1, 4), dtype=np.int64)
+
+        embedding = model.get_embedding(ids, mask)
+        assert np.allclose(np.linalg.norm(embedding), 1.0)
+        assert np.allclose(embedding, [0.6, 0.8])
+        model.close()

--- a/backend/tests/test_siglip2text.py
+++ b/backend/tests/test_siglip2text.py
@@ -1,24 +1,24 @@
+from typing import Iterator, List, Optional
 from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
 
 from app.models.SigLIP2Text import SigLIP2Text
-from app.models.session_registry import (
-    get_active_session_count,
-    mark_model_session_inactive,
-)
+from app.models.session_registry import get_active_session_count
 
 MODEL_PATH = "app/models/ONNX_Exports/SigLIP2_Base_Text.onnx"
 MODEL_KEY = "siglip2_base_text"
 
 
 class _FakeTensor:
-    def __init__(self, name):
+    def __init__(self, name: Optional[str]):
         self.name = name
 
 
-def _ort_session(input_names, output_name="output"):
+def _ort_session(
+    input_names: List[str], output_name: Optional[str] = "output"
+) -> MagicMock:
     """Stand-in for onnxruntime.InferenceSession -- no real model file needed."""
     session = MagicMock()
     session.get_inputs.return_value = [_FakeTensor(n) for n in input_names]
@@ -27,23 +27,31 @@ def _ort_session(input_names, output_name="output"):
 
 
 @pytest.fixture(autouse=True)
-def _clean_registry():
+def _clean_registry() -> Iterator[None]:
+    # No session may be registered before or after a test. A nonzero count at
+    # teardown means a test leaked a session that close() should have released;
+    # draining it here instead would mask that bug.
+    assert get_active_session_count(MODEL_KEY) == 0
     yield
-    # Don't leak a registered session into other tests sharing this model key
-    while get_active_session_count(MODEL_KEY) > 0:
-        mark_model_session_inactive(MODEL_KEY)
+    assert get_active_session_count(MODEL_KEY) == 0
 
 
 class TestGetSession:
     @patch("onnxruntime.InferenceSession")
     @patch("os.path.exists", return_value=True)
     def test_second_call_returns_cached_session(self, mock_exists, mock_cls):
-        mock_cls.return_value = _ort_session(["input_ids", "attention_mask"])
+        # Distinct objects per construction so a re-build would be observable
+        mock_cls.side_effect = [
+            _ort_session(["input_ids", "attention_mask"]),
+            _ort_session(["input_ids", "attention_mask"]),
+        ]
         model = SigLIP2Text(MODEL_PATH)
 
         first = model.get_session()
         second = model.get_session()  # fast path: self._session already set
-        assert second == first
+        # Built once and cached -- no second InferenceSession, same object back
+        assert mock_cls.call_count == 1
+        assert second[0] is first[0]
         model.close()
 
     def test_raises_if_names_cleared_mid_call(self):
@@ -82,4 +90,20 @@ class TestGetEmbedding:
         embedding = model.get_embedding(ids, mask)
         assert np.allclose(np.linalg.norm(embedding), 1.0)
         assert np.allclose(embedding, [0.6, 0.8])
+        model.close()
+
+    @patch("onnxruntime.InferenceSession")
+    @patch("os.path.exists", return_value=True)
+    def test_zero_vector_is_returned_unchanged(self, mock_exists, mock_cls):
+        # A zero embedding has norm 0 -- it must pass through, not divide by zero
+        session = _ort_session(["input_ids", "attention_mask"])
+        session.run.return_value = [np.zeros((1, 2), dtype=np.float32)]
+        mock_cls.return_value = session
+
+        model = SigLIP2Text(MODEL_PATH)
+        ids = np.zeros((1, 4), dtype=np.int64)
+        mask = np.ones((1, 4), dtype=np.int64)
+
+        embedding = model.get_embedding(ids, mask)
+        assert np.allclose(embedding, [0.0, 0.0])
         model.close()

--- a/backend/tests/test_videos.py
+++ b/backend/tests/test_videos.py
@@ -2,6 +2,7 @@ import os
 import sqlite3
 import tempfile
 import shutil
+from unittest.mock import MagicMock
 
 import cv2
 import pytest
@@ -23,6 +24,10 @@ from app.utils.videos import (
     video_util_generate_thumbnail,
     video_util_extract_metadata,
     video_util_prepare_video_records,
+    video_util_process_folder_videos,
+    video_util_collect_superseded_thumbnails,
+    video_util_source_is_unchanged,
+    video_util_remove_thumbnail_files,
 )
 from app.routes.videos import router as videos_router
 
@@ -548,3 +553,145 @@ class TestVideosAPI:
         assert response.status_code == 200
         data = response.json()["data"]
         assert [v["id"] for v in data] == ["vid-good"]
+
+    def test_get_all_videos_db_error_returns_500(self, client, monkeypatch):
+        def boom():
+            raise RuntimeError("db down")
+
+        monkeypatch.setattr("app.routes.videos.db_get_all_videos", boom)
+        response = client.get("/videos/")
+        assert response.status_code == 500
+        assert response.json()["detail"]["success"] is False
+
+    def test_toggle_favourite_row_disappears_after_toggle(self, client, monkeypatch):
+        # Toggle reports success, but the row can't be read back -> 404
+        monkeypatch.setattr(
+            "app.routes.videos.db_toggle_video_favourite_status", lambda vid: True
+        )
+        monkeypatch.setattr("app.routes.videos.db_get_video_by_id", lambda vid: None)
+        response = client.post("/videos/toggle-favourite", json={"video_id": "vid-1"})
+        assert response.status_code == 404
+
+    def test_toggle_favourite_db_error_returns_500(self, client, monkeypatch):
+        def boom(vid):
+            raise RuntimeError("db down")
+
+        monkeypatch.setattr("app.routes.videos.db_toggle_video_favourite_status", boom)
+        response = client.post("/videos/toggle-favourite", json={"video_id": "vid-1"})
+        assert response.status_code == 500
+        assert response.json()["detail"]["success"] is False
+
+
+# ##############################
+# Utility edge cases
+# ##############################
+
+
+class TestVideoUtilEdgeCases:
+    def test_collect_superseded_skips_records_without_thumbnail(self):
+        records = [{"path": "/v/a.mp4", "thumbnailPath": None}]
+        already = {"/v/a.mp4": ("/thumbs/old.jpg", {})}
+        assert video_util_collect_superseded_thumbnails(records, already) == []
+
+    def test_source_is_unchanged_missing_file(self):
+        assert video_util_source_is_unchanged("/nope/missing.mp4", {}) is False
+
+    def test_remove_thumbnail_files_tolerates_os_error(
+        self, temp_media_dir, monkeypatch
+    ):
+        thumb = os.path.join(temp_media_dir, "t.jpg")
+        with open(thumb, "wb") as f:
+            f.write(b"x")
+
+        def boom(path):
+            raise OSError("locked")
+
+        monkeypatch.setattr("app.utils.videos.os.remove", boom)
+        # Must swallow the error, not raise
+        video_util_remove_thumbnail_files([thumb])
+
+    def test_get_videos_from_folder_non_recursive_bad_dir(self):
+        assert video_util_get_videos_from_folder("/no/such/dir", recursive=False) == []
+
+    def test_extract_metadata_missing_file(self):
+        metadata = video_util_extract_metadata("/no/such/file.mp4")
+        assert metadata["file_size"] == 0
+        assert metadata["width"] == 0
+
+    def test_prepare_records_skips_when_folder_id_falsy(self, temp_media_dir):
+        video_path = os.path.join(temp_media_dir, "a.mp4")
+        with open(video_path, "wb") as f:
+            f.write(b"data")
+        # Folder resolves to id 0, which the guard treats as "no folder"
+        records = video_util_prepare_video_records(
+            [video_path], {os.path.abspath(temp_media_dir): 0}
+        )
+        assert records == []
+
+    def test_process_folder_inner_exception_is_isolated(
+        self, test_db, test_folder_id, temp_media_dir, monkeypatch
+    ):
+        thumb_dir = os.path.join(temp_media_dir, "thumbs")
+        monkeypatch.setattr("app.utils.videos.THUMBNAIL_IMAGES_PATH", thumb_dir)
+        with open(os.path.join(temp_media_dir, "a.mp4"), "wb") as f:
+            f.write(b"data")
+
+        def boom(folder_ids):
+            raise RuntimeError("index read failed")
+
+        monkeypatch.setattr("app.utils.videos.db_get_video_index_by_folder_ids", boom)
+        # The inner handler swallows the error and continues -> overall success
+        folder_data = [(temp_media_dir, test_folder_id, False)]
+        assert video_util_process_folder_videos(folder_data) is True
+
+    def test_process_folder_outer_exception_returns_false(self, monkeypatch):
+        def boom(path, exist_ok=False):
+            raise RuntimeError("mkdir failed")
+
+        monkeypatch.setattr("app.utils.videos.os.makedirs", boom)
+        assert video_util_process_folder_videos([]) is False
+
+    def test_generate_thumbnail_returns_false_when_frame_unreadable(
+        self, temp_media_dir
+    ):
+        cap = MagicMock()
+        cap.isOpened.return_value = True
+        cap.get.return_value = 0  # fps/frame_count 0 -> target 0
+        cap.read.return_value = (False, None)
+        out = os.path.join(temp_media_dir, "t.jpg")
+        assert video_util_generate_thumbnail("x.mp4", out, capture=cap) is False
+
+    def test_generate_thumbnail_retries_from_first_frame(self, temp_media_dir):
+        import numpy as np
+
+        frame = np.zeros((10, 10, 3), dtype=np.uint8)
+        cap = MagicMock()
+        cap.isOpened.return_value = True
+        cap.get.side_effect = lambda prop: {
+            cv2.CAP_PROP_FPS: 30.0,
+            cv2.CAP_PROP_FRAME_COUNT: 100.0,
+        }.get(prop, 0)
+        # First read at the seeked frame fails; the retry from frame 0 succeeds
+        cap.read.side_effect = [(False, None), (True, frame)]
+        out = os.path.join(temp_media_dir, "t.jpg")
+        assert video_util_generate_thumbnail("x.mp4", out, capture=cap) is True
+        assert os.path.exists(out)
+
+    def test_generate_thumbnail_swallows_exceptions(self, temp_media_dir):
+        cap = MagicMock()
+        cap.isOpened.return_value = True
+        cap.get.return_value = 0
+        cap.read.side_effect = RuntimeError("decode boom")
+        out = os.path.join(temp_media_dir, "t.jpg")
+        assert video_util_generate_thumbnail("x.mp4", out, capture=cap) is False
+
+    def test_extract_metadata_swallows_capture_errors(self, temp_media_dir):
+        real = os.path.join(temp_media_dir, "a.mp4")
+        with open(real, "wb") as f:
+            f.write(b"data")
+        cap = MagicMock()
+        cap.isOpened.return_value = True
+        cap.get.side_effect = RuntimeError("prop boom")
+        metadata = video_util_extract_metadata(real, capture=cap)
+        assert metadata["file_size"] > 0  # os.stat ran before the capture error
+        assert metadata["width"] == 0  # capture error left the defaults

--- a/backend/tests/test_videos.py
+++ b/backend/tests/test_videos.py
@@ -561,7 +561,10 @@ class TestVideosAPI:
         monkeypatch.setattr("app.routes.videos.db_get_all_videos", boom)
         response = client.get("/videos/")
         assert response.status_code == 500
-        assert response.json()["detail"]["success"] is False
+        detail = response.json()["detail"]
+        assert detail["success"] is False
+        assert detail["error"]
+        assert detail["message"]
 
     def test_toggle_favourite_row_disappears_after_toggle(self, client, monkeypatch):
         # Toggle reports success, but the row can't be read back -> 404
@@ -579,7 +582,10 @@ class TestVideosAPI:
         monkeypatch.setattr("app.routes.videos.db_toggle_video_favourite_status", boom)
         response = client.post("/videos/toggle-favourite", json={"video_id": "vid-1"})
         assert response.status_code == 500
-        assert response.json()["detail"]["success"] is False
+        detail = response.json()["detail"]
+        assert detail["success"] is False
+        assert detail["error"]
+        assert detail["message"]
 
 
 # ##############################


### PR DESCRIPTION
### Addressed Issues

Related to #1238 (backend test coverage). The `database/images.py` work directly extends the database-testing effort tracked there.

Scoped to **avoid overlap** with the other in-flight coverage PRs (#1341 connection/folders, #1342 albums/faces, #1343 metadata/yolo_mapping) — none of them touch the modules covered here.

### What this adds

New backend unit tests taking several previously thin modules to **100% line coverage**:

| Module | Before | After |
| --- | --- | --- |
| `app/database/images.py` | 24% | **100%** |
| `app/utils/videos.py` | 87% | **100%** |
| `app/routes/videos.py` | 91% | **100%** |
| `app/models/SigLIP2Text.py` | 80% | **100%** |
| `app/models/ONNXSessionBase.py` | 88% | **100%** |
| `app/utils/face_quality.py` | 94% | **100%** |

Test files:
- `tests/test_images_db.py` (new) — CRUD, path-conflict upsert, case-insensitive tag search, Memories location/time queries, and every `sqlite3.Error` branch exercised by dropping the tables/views the queries depend on.
- `tests/test_videos.py` (extended) — route 404/500 error envelopes plus a `TestVideoUtilEdgeCases` class covering thumbnail retry/decode-failure, OS errors, and metadata capture failures via mocked `cv2.VideoCapture`.
- `tests/test_siglip2text.py` (new) and `tests/test_onnx_session_base.py` (extended) — session lifecycle, missing-model raise, embedding normalization.
- `tests/test_face_quality.py` (new) — all quality-gate branches including the grayscale-crop path.

### Notes
- Every test is isolated via a tempfile SQLite database and mocked ONNX sessions — no real model files, disk state, or network required.
- Full suite: **268 passed**, black + ruff clean.

### AI Usage Disclosure
This PR contains AI-assisted test code. I have reviewed it, run it locally, and take responsibility for it, in line with the project's AI Usage Policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded automated coverage for face-quality validation, including confidence, face-size thresholds, empty crops, grayscale handling, and blur/low-variance scenarios.
  * Added comprehensive coverage for image database operations, including schema creation/upgrades, bulk inserts, queries (including memories), updates, deletions, and robust error handling.
  * Added tests for ONNX session lifecycle, session caching, missing-model behavior, and embedding L2-normalization edge cases.
  * Added video API and processing edge-case coverage, including database error responses, favourite toggling consistency, thumbnail and metadata capture robustness, and resilient file handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->