### PR TITLE
feat: add light theme support for Image Viewer and Video Viewer

### DIFF
--- a/frontend/src/components/Media/MediaInfoPanel.tsx
+++ b/frontend/src/components/Media/MediaInfoPanel.tsx
@@ -66,13 +66,15 @@ export const MediaInfoPanel: React.FC<MediaInfoPanelProps> = ({
           animate={{ opacity: 1, x: 0 }}
           exit={{ opacity: 0, x: -20 }}
           transition={{ type: 'spring', stiffness: 260, damping: 25 }}
-          className="absolute top-10 left-6 z-50 w-[350px] rounded-xl border border-white/10 bg-black/60 p-6 shadow-xl backdrop-blur-lg"
+          className="absolute top-10 left-6 z-50 w-[350px] rounded-xl border border-black/10 bg-white/80 p-6 shadow-xl backdrop-blur-lg dark:border-white/10 dark:bg-black/60"
         >
-          <div className="mb-4 flex items-center justify-between border-b border-white/10 pb-3">
-            <h3 className="text-xl font-medium text-white">Image Details</h3>
+          <div className="mb-4 flex items-center justify-between border-b border-black/10 pb-3 dark:border-white/10">
+            <h3 className="text-xl font-medium text-gray-900 dark:text-white">
+              Image Details
+            </h3>
             <button
               onClick={onClose}
-              className="text-white/70 hover:text-white"
+              className="text-gray-500 hover:text-gray-900 dark:text-white/70 dark:hover:text-white"
               aria-label="Close info panel"
             >
               <X className="h-5 w-5" />
@@ -81,13 +83,13 @@ export const MediaInfoPanel: React.FC<MediaInfoPanelProps> = ({
 
           <div className="space-y-4 text-sm">
             <div className="flex items-start gap-3">
-              <div className="rounded-lg bg-white/10 p-2">
-                <ImageLucide className="h-5 w-5 text-blue-400" />
+              <div className="rounded-lg bg-black/5 p-2 dark:bg-white/10">
+                <ImageLucide className="h-5 w-5 text-blue-600 dark:text-blue-400" />
               </div>
               <div className="min-w-0 flex-1">
-                <p className="text-xs text-white/50">Name</p>
+                <p className="text-xs text-gray-500 dark:text-white/50">Name</p>
                 <p
-                  className="truncate font-medium text-white"
+                  className="truncate font-medium text-gray-900 dark:text-white"
                   title={getImageName()}
                 >
                   {getImageName()}
@@ -96,33 +98,37 @@ export const MediaInfoPanel: React.FC<MediaInfoPanelProps> = ({
             </div>
 
             <div className="flex items-start gap-3">
-              <div className="rounded-lg bg-white/10 p-2">
-                <Calendar className="h-5 w-5 text-emerald-400" />
+              <div className="rounded-lg bg-black/5 p-2 dark:bg-white/10">
+                <Calendar className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
               </div>
               <div>
-                <p className="text-xs text-white/50">Date</p>
-                <p className="font-medium text-white">{getFormattedDate()}</p>
+                <p className="text-xs text-gray-500 dark:text-white/50">Date</p>
+                <p className="font-medium text-gray-900 dark:text-white">
+                  {getFormattedDate()}
+                </p>
               </div>
             </div>
 
             <div className="flex items-start gap-3">
-              <div className="rounded-lg bg-white/10 p-2">
-                <MapPin className="h-5 w-5 text-red-400" />
+              <div className="rounded-lg bg-black/5 p-2 dark:bg-white/10">
+                <MapPin className="h-5 w-5 text-red-600 dark:text-red-400" />
               </div>
               <div className="min-w-0 flex-1">
-                <p className="text-xs text-white/50">Location</p>
+                <p className="text-xs text-gray-500 dark:text-white/50">
+                  Location
+                </p>
                 {currentImage?.metadata?.latitude &&
                 currentImage?.metadata?.longitude ? (
                   <button
                     type="button"
                     onClick={handleLocationClick}
-                    className="flex w-full items-center truncate text-left font-medium text-white hover:underline"
+                    className="flex w-full items-center truncate text-left font-medium text-gray-900 hover:underline dark:text-white"
                   >
                     {`Lat: ${currentImage.metadata.latitude.toFixed(4)}, Lon: ${currentImage.metadata.longitude.toFixed(4)}`}
                     <SquareArrowOutUpRight className="ml-1 h-[14px] w-[14px]" />
                   </button>
                 ) : (
-                  <p className="font-medium text-white">
+                  <p className="font-medium text-gray-900 dark:text-white">
                     Location not available
                   </p>
                 )}
@@ -130,43 +136,49 @@ export const MediaInfoPanel: React.FC<MediaInfoPanelProps> = ({
             </div>
 
             <div className="flex items-start gap-3">
-              <div className="rounded-lg bg-white/10 p-2">
-                <Tag className="h-5 w-5 text-purple-400" />
+              <div className="rounded-lg bg-black/5 p-2 dark:bg-white/10">
+                <Tag className="h-5 w-5 text-purple-600 dark:text-purple-400" />
               </div>
               <div className="flex-1">
-                <p className="mb-1 text-xs text-white/50">Tags</p>
+                <p className="mb-1 text-xs text-gray-500 dark:text-white/50">
+                  Tags
+                </p>
                 {currentImage?.tags?.length ? (
                   <div className="flex flex-wrap gap-2">
                     {currentImage.tags.map((tag, i) => (
                       <span
                         key={i}
-                        className="rounded-full border border-blue-500/30 bg-blue-500/20 px-2 py-1 text-xs text-blue-300"
+                        className="rounded-full border border-blue-500/30 bg-blue-500/20 px-2 py-1 text-xs text-blue-600 dark:text-blue-300"
                       >
                         {tag}
                       </span>
                     ))}
                   </div>
                 ) : (
-                  <p className="text-white/60">No tags available</p>
+                  <p className="text-gray-500 dark:text-white/60">
+                    No tags available
+                  </p>
                 )}
               </div>
             </div>
 
             <div className="flex items-start gap-3">
-              <div className="rounded-lg bg-white/10 p-2">
-                <Info className="h-5 w-5 text-amber-400" />
+              <div className="rounded-lg bg-black/5 p-2 dark:bg-white/10">
+                <Info className="h-5 w-5 text-amber-600 dark:text-amber-400" />
               </div>
               <div>
-                <p className="text-xs text-white/50">Position</p>
-                <p className="font-medium text-white">
+                <p className="text-xs text-gray-500 dark:text-white/50">
+                  Position
+                </p>
+                <p className="font-medium text-gray-900 dark:text-white">
                   {currentIndex + 1} of {totalImages}
                 </p>
               </div>
             </div>
 
-            <div className="mt-4 border-t border-white/10 pt-3">
+            <div className="mt-4 border-t border-black/10 pt-3 dark:border-white/10">
               <button
-                className="w-full rounded-lg bg-white/10 py-2 text-white hover:bg-white/20"
+                className="w-full rounded-lg bg-black/5 py-2 text-gray-900 hover:bg-black/10 dark:bg-white/10 dark:text-white dark:hover:bg-white/20"
                 onClick={(e) => {
                   e.preventDefault();
                   // Button disabled - does nothing

--- a/frontend/src/components/Media/MediaThumbnails.tsx
+++ b/frontend/src/components/Media/MediaThumbnails.tsx
@@ -99,7 +99,7 @@ export const MediaThumbnails: React.FC<MediaThumbnailsProps> = ({
     <div className="absolute bottom-0 w-full">
       <div
         ref={scrollContainerRef}
-        className={`flex w-full items-center gap-2 overflow-x-auto bg-black/70 py-3 backdrop-blur-md transition-all duration-300 ${
+        className={`flex w-full items-center gap-2 overflow-x-auto bg-white/60 py-3 backdrop-blur-md transition-all duration-300 dark:bg-black/70 ${
           showThumbnails ? 'opacity-100' : 'opacity-0'
         } px-[calc(50%-3.5rem)]`}
       >
@@ -116,7 +116,7 @@ export const MediaThumbnails: React.FC<MediaThumbnailsProps> = ({
             onClick={() => onThumbnailClick(index)}
             className={`relative h-20 w-28 flex-shrink-0 overflow-hidden rounded-lg ${
               index === currentIndex
-                ? 'ring-2 ring-blue-500 ring-offset-1 ring-offset-black'
+                ? 'ring-2 ring-blue-500 ring-offset-1 ring-offset-white dark:ring-offset-black'
                 : 'opacity-70 hover:opacity-100'
             } cursor-pointer transition-all duration-200 hover:scale-105`}
           >

--- a/frontend/src/components/Media/MediaView.tsx
+++ b/frontend/src/components/Media/MediaView.tsx
@@ -172,7 +172,7 @@ export function MediaView({
   // console.log(currentImage);
   const currentImageAlt = `image-${currentViewIndex}`;
   return (
-    <div className="fixed inset-0 z-50 mt-0 flex flex-col bg-gradient-to-b from-black/95 to-black/98 backdrop-blur-lg">
+    <div className="fixed inset-0 z-50 mt-0 flex flex-col bg-gradient-to-b from-white/95 to-white/98 backdrop-blur-lg dark:from-black/95 dark:to-black/98">
       {/* Controls */}
       <MediaViewControls
         showInfo={showInfo}

--- a/frontend/src/components/Media/MediaViewControls.tsx
+++ b/frontend/src/components/Media/MediaViewControls.tsx
@@ -30,8 +30,10 @@ export const MediaViewControls: React.FC<MediaViewControlsProps> = ({
       <button
         onClick={onToggleInfo}
         className={`cursor-pointer rounded-full ${
-          showInfo ? 'bg-indigo-500/70' : 'bg-black/50'
-        } p-2.5 text-white/90 transition-all duration-200 hover:bg-black/20 hover:text-white hover:shadow-lg`}
+          showInfo
+            ? 'bg-indigo-500/70 text-white hover:bg-indigo-600/80'
+            : 'bg-white/80 text-gray-700 shadow-md hover:bg-white hover:text-black dark:bg-black/50 dark:text-white/90 dark:shadow-none dark:hover:bg-black/20 dark:hover:text-white'
+        } p-2.5 transition-all duration-200 hover:shadow-lg`}
         aria-label="Show Info"
         title="Show Info"
       >
@@ -40,7 +42,7 @@ export const MediaViewControls: React.FC<MediaViewControlsProps> = ({
 
       <button
         onClick={onOpenFolder}
-        className="cursor-pointer rounded-full bg-black/50 p-2.5 text-white/90 transition-all duration-200 hover:bg-black/20 hover:text-white hover:shadow-lg"
+        className="cursor-pointer rounded-full bg-white/80 p-2.5 text-gray-700 shadow-md transition-all duration-200 hover:bg-white hover:text-black hover:shadow-lg dark:bg-black/50 dark:text-white/90 dark:shadow-none dark:hover:bg-black/20 dark:hover:text-white"
         aria-label="Open Folder"
         title="Open Folder"
       >
@@ -49,10 +51,10 @@ export const MediaViewControls: React.FC<MediaViewControlsProps> = ({
 
       <button
         onClick={onToggleFavourite}
-        className={`cursor-pointer rounded-full p-2.5 text-white transition-all duration-300 ${
+        className={`cursor-pointer rounded-full p-2.5 transition-all duration-300 ${
           isFavourite
-            ? 'bg-rose-500/80 hover:bg-rose-600 hover:shadow-lg'
-            : 'bg-black/50 hover:bg-black/20 hover:text-white hover:shadow-lg'
+            ? 'bg-rose-500/80 text-white hover:bg-rose-600 hover:shadow-lg'
+            : 'bg-white/80 text-gray-700 shadow-md hover:bg-white hover:text-black hover:shadow-lg dark:bg-black/50 dark:text-white dark:shadow-none dark:hover:bg-black/20 dark:hover:text-white'
         }`}
         aria-label={
           isFavourite ? 'Remove from favourites' : 'Add to favourites'
@@ -82,7 +84,7 @@ export const MediaViewControls: React.FC<MediaViewControlsProps> = ({
 
       <button
         onClick={onClose}
-        className="ml-2 cursor-pointer rounded-full bg-black/50 p-2.5 text-white/90 transition-all duration-200 hover:bg-black/20 hover:text-white hover:shadow-lg"
+        className="ml-2 cursor-pointer rounded-full bg-white/80 p-2.5 text-gray-700 shadow-md transition-all duration-200 hover:bg-white hover:text-black hover:shadow-lg dark:bg-black/50 dark:text-white/90 dark:shadow-none dark:hover:bg-black/20 dark:hover:text-white"
         aria-label="Close"
         title="Close"
       >

--- a/frontend/src/components/Media/NavigationButtons.tsx
+++ b/frontend/src/components/Media/NavigationButtons.tsx
@@ -18,20 +18,20 @@ export const NavigationButtons: React.FC<NavigationButtonsProps> = ({
     <>
       <button
         onClick={onPrevious}
-        className="group absolute inset-y-0 left-0 z-30 flex w-20 cursor-pointer items-center justify-center bg-transparent text-white"
+        className="group absolute inset-y-0 left-0 z-30 flex w-20 cursor-pointer items-center justify-center bg-transparent text-gray-800 dark:text-white"
         aria-label={previousLabel}
       >
-        <span className="flex items-center justify-center rounded-full p-3 backdrop-blur-md transition-all duration-200 group-hover:bg-black/80 group-hover:shadow-lg">
+        <span className="flex items-center justify-center rounded-full bg-white/80 p-3 shadow-md backdrop-blur-md transition-all duration-200 group-hover:bg-white group-hover:shadow-lg dark:bg-transparent dark:shadow-none dark:group-hover:bg-black/80 dark:group-hover:shadow-lg">
           <ChevronLeft className="h-6 w-6" />
         </span>
       </button>
 
       <button
         onClick={onNext}
-        className="group absolute inset-y-0 right-0 z-30 flex w-20 cursor-pointer items-center justify-center bg-transparent text-white"
+        className="group absolute inset-y-0 right-0 z-30 flex w-20 cursor-pointer items-center justify-center bg-transparent text-gray-800 dark:text-white"
         aria-label={nextLabel}
       >
-        <span className="flex items-center justify-center rounded-full p-3 backdrop-blur-md transition-all duration-200 group-hover:bg-black/80 group-hover:shadow-lg">
+        <span className="flex items-center justify-center rounded-full bg-white/80 p-3 shadow-md backdrop-blur-md transition-all duration-200 group-hover:bg-white group-hover:shadow-lg dark:bg-transparent dark:shadow-none dark:group-hover:bg-black/80 dark:group-hover:shadow-lg">
           <ChevronRight className="h-6 w-6" />
         </span>
       </button>

--- a/frontend/src/components/Media/ZoomControls.tsx
+++ b/frontend/src/components/Media/ZoomControls.tsx
@@ -20,12 +20,12 @@ export const ZoomControls: React.FC<ZoomControlsProps> = ({
     <div
       className={`absolute ${
         showThumbnails ? 'bottom-32' : 'bottom-12'
-      } left-1/2 z-10 flex -translate-x-1/2 transform flex-col gap-4 rounded-xl bg-black/50 p-3 backdrop-blur-md transition-all duration-300`}
+      } left-1/2 z-10 flex -translate-x-1/2 transform flex-col gap-4 rounded-xl bg-white/70 p-3 shadow-lg backdrop-blur-md transition-all duration-300 dark:bg-black/50 dark:shadow-none`}
     >
       <div className="flex gap-2">
         <button
           onClick={onZoomOut}
-          className="cursor-pointer rounded-md bg-white/10 p-2 text-white transition-all duration-200 hover:bg-white/20 hover:shadow-md"
+          className="cursor-pointer rounded-md bg-black/5 p-2 text-gray-700 transition-all duration-200 hover:bg-black/10 hover:text-black hover:shadow-md dark:bg-white/10 dark:text-white dark:hover:bg-white/20 dark:hover:text-white"
           aria-label="Zoom Out"
           title="Zoom Out"
         >
@@ -34,7 +34,7 @@ export const ZoomControls: React.FC<ZoomControlsProps> = ({
 
         <button
           onClick={onReset}
-          className="cursor-pointer rounded-md bg-white/10 px-3 py-2 text-sm font-medium text-white transition-all duration-200 hover:bg-white/20 hover:shadow-md"
+          className="cursor-pointer rounded-md bg-black/5 px-3 py-2 text-sm font-medium text-gray-700 transition-all duration-200 hover:bg-black/10 hover:text-black hover:shadow-md dark:bg-white/10 dark:text-white dark:hover:bg-white/20 dark:hover:text-white"
           aria-label="Reset"
         >
           Reset
@@ -42,7 +42,7 @@ export const ZoomControls: React.FC<ZoomControlsProps> = ({
 
         <button
           onClick={onZoomIn}
-          className="cursor-pointer rounded-md bg-white/10 p-2 text-white transition-all duration-200 hover:bg-white/20 hover:shadow-md"
+          className="cursor-pointer rounded-md bg-black/5 p-2 text-gray-700 transition-all duration-200 hover:bg-black/10 hover:text-black hover:shadow-md dark:bg-white/10 dark:text-white dark:hover:bg-white/20 dark:hover:text-white"
           aria-label="Zoom In"
           title="Zoom In"
         >
@@ -51,7 +51,7 @@ export const ZoomControls: React.FC<ZoomControlsProps> = ({
 
         <button
           onClick={onRotate}
-          className="cursor-pointer rounded-md bg-white/10 p-2 text-white transition-all duration-200 hover:bg-white/20 hover:shadow-md"
+          className="cursor-pointer rounded-md bg-black/5 p-2 text-gray-700 transition-all duration-200 hover:bg-black/10 hover:text-black hover:shadow-md dark:bg-white/10 dark:text-white dark:hover:bg-white/20 dark:hover:text-white"
           aria-label="Rotate"
           title="Rotate"
         >

--- a/frontend/src/components/VideoPlayer/VideoInfoPanel.tsx
+++ b/frontend/src/components/VideoPlayer/VideoInfoPanel.tsx
@@ -51,13 +51,15 @@ export const VideoInfoPanel: React.FC<VideoInfoPanelProps> = ({
           animate={{ opacity: 1, x: 0 }}
           exit={{ opacity: 0, x: -20 }}
           transition={{ type: 'spring', stiffness: 260, damping: 25 }}
-          className="absolute top-20 left-6 z-50 w-[350px] rounded-xl border border-white/10 bg-black/60 p-6 shadow-xl backdrop-blur-lg"
+          className="absolute top-20 left-6 z-50 w-[350px] rounded-xl border border-black/10 bg-white/80 p-6 shadow-xl backdrop-blur-lg dark:border-white/10 dark:bg-black/60"
         >
-          <div className="mb-4 flex items-center justify-between border-b border-white/10 pb-3">
-            <h3 className="text-xl font-medium text-white">Video Details</h3>
+          <div className="mb-4 flex items-center justify-between border-b border-black/10 pb-3 dark:border-white/10">
+            <h3 className="text-xl font-medium text-gray-900 dark:text-white">
+              Video Details
+            </h3>
             <button
               onClick={onClose}
-              className="text-white/70 hover:text-white"
+              className="text-gray-500 hover:text-gray-900 dark:text-white/70 dark:hover:text-white"
               aria-label="Close info panel"
             >
               <X className="h-5 w-5" />
@@ -66,13 +68,13 @@ export const VideoInfoPanel: React.FC<VideoInfoPanelProps> = ({
 
           <div className="space-y-4 text-sm">
             <div className="flex items-start gap-3">
-              <div className="rounded-lg bg-white/10 p-2">
-                <Film className="h-5 w-5 text-blue-400" />
+              <div className="rounded-lg bg-black/5 p-2 dark:bg-white/10">
+                <Film className="h-5 w-5 text-blue-600 dark:text-blue-400" />
               </div>
               <div className="min-w-0 flex-1">
-                <p className="text-xs text-white/50">Name</p>
+                <p className="text-xs text-gray-500 dark:text-white/50">Name</p>
                 <p
-                  className="truncate font-medium text-white"
+                  className="truncate font-medium text-gray-900 dark:text-white"
                   title={getVideoName()}
                 >
                   {getVideoName()}
@@ -81,49 +83,59 @@ export const VideoInfoPanel: React.FC<VideoInfoPanelProps> = ({
             </div>
 
             <div className="flex items-start gap-3">
-              <div className="rounded-lg bg-white/10 p-2">
-                <Calendar className="h-5 w-5 text-emerald-400" />
+              <div className="rounded-lg bg-black/5 p-2 dark:bg-white/10">
+                <Calendar className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
               </div>
               <div>
-                <p className="text-xs text-white/50">Date</p>
-                <p className="font-medium text-white">{getFormattedDate()}</p>
+                <p className="text-xs text-gray-500 dark:text-white/50">Date</p>
+                <p className="font-medium text-gray-900 dark:text-white">
+                  {getFormattedDate()}
+                </p>
               </div>
             </div>
 
             <div className="flex items-start gap-3">
-              <div className="rounded-lg bg-white/10 p-2">
-                <Clock className="h-5 w-5 text-purple-400" />
+              <div className="rounded-lg bg-black/5 p-2 dark:bg-white/10">
+                <Clock className="h-5 w-5 text-purple-600 dark:text-purple-400" />
               </div>
               <div>
-                <p className="text-xs text-white/50">Duration</p>
-                <p className="font-medium text-white">
+                <p className="text-xs text-gray-500 dark:text-white/50">
+                  Duration
+                </p>
+                <p className="font-medium text-gray-900 dark:text-white">
                   {duration ?? 'Not available'}
                 </p>
               </div>
             </div>
 
             <div className="flex items-start gap-3">
-              <div className="rounded-lg bg-white/10 p-2">
-                <Monitor className="h-5 w-5 text-amber-400" />
+              <div className="rounded-lg bg-black/5 p-2 dark:bg-white/10">
+                <Monitor className="h-5 w-5 text-amber-600 dark:text-amber-400" />
               </div>
               <div>
-                <p className="text-xs text-white/50">Resolution</p>
-                <p className="font-medium text-white">{resolution}</p>
+                <p className="text-xs text-gray-500 dark:text-white/50">
+                  Resolution
+                </p>
+                <p className="font-medium text-gray-900 dark:text-white">
+                  {resolution}
+                </p>
               </div>
             </div>
 
             {tags.length > 0 && (
               <div className="flex items-start gap-3">
-                <div className="rounded-lg bg-white/10 p-2">
-                  <Tag className="h-5 w-5 text-rose-400" />
+                <div className="rounded-lg bg-black/5 p-2 dark:bg-white/10">
+                  <Tag className="h-5 w-5 text-rose-600 dark:text-rose-400" />
                 </div>
                 <div className="min-w-0 flex-1">
-                  <p className="text-xs text-white/50">Tags</p>
+                  <p className="text-xs text-gray-500 dark:text-white/50">
+                    Tags
+                  </p>
                   <div className="mt-1 flex flex-wrap gap-1">
                     {tags.map((tag, index) => (
                       <span
                         key={`${tag}-${index}`}
-                        className="rounded-full border border-white/30 px-2 py-0.5 text-xs text-white"
+                        className="rounded-full border border-black/20 px-2 py-0.5 text-xs text-gray-800 dark:border-white/30 dark:text-white"
                       >
                         {tag}
                       </span>
@@ -134,12 +146,14 @@ export const VideoInfoPanel: React.FC<VideoInfoPanelProps> = ({
             )}
 
             <div className="flex items-start gap-3">
-              <div className="rounded-lg bg-white/10 p-2">
-                <Info className="h-5 w-5 text-blue-400" />
+              <div className="rounded-lg bg-black/5 p-2 dark:bg-white/10">
+                <Info className="h-5 w-5 text-blue-600 dark:text-blue-400" />
               </div>
               <div>
-                <p className="text-xs text-white/50">Position</p>
-                <p className="font-medium text-white">
+                <p className="text-xs text-gray-500 dark:text-white/50">
+                  Position
+                </p>
+                <p className="font-medium text-gray-900 dark:text-white">
                   {currentIndex + 1} of {totalVideos}
                 </p>
               </div>

--- a/frontend/src/components/VideoPlayer/VideoPlayerOverlay.tsx
+++ b/frontend/src/components/VideoPlayer/VideoPlayerOverlay.tsx
@@ -77,7 +77,7 @@ export function VideoPlayerOverlay({ videos }: VideoPlayerOverlayProps) {
   if (!currentVideo) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex flex-col bg-black/95 backdrop-blur-lg">
+    <div className="fixed inset-0 z-50 flex flex-col bg-white/95 backdrop-blur-lg dark:bg-black/95">
       <VideoViewerControls
         showInfo={showInfo}
         onToggleInfo={() => setShowInfo((prev) => !prev)}

--- a/frontend/src/components/VideoPlayer/VideoViewerControls.tsx
+++ b/frontend/src/components/VideoPlayer/VideoViewerControls.tsx
@@ -28,8 +28,10 @@ export const VideoViewerControls: React.FC<VideoViewerControlsProps> = ({
       <button
         onClick={onToggleInfo}
         className={`cursor-pointer rounded-full ${
-          showInfo ? 'bg-indigo-500/70' : 'bg-black/50'
-        } p-2.5 text-white/90 transition-all duration-200 hover:bg-black/20 hover:text-white hover:shadow-lg`}
+          showInfo
+            ? 'bg-indigo-500/70 text-white hover:bg-indigo-600/80'
+            : 'bg-white/80 text-gray-700 shadow-md hover:bg-white hover:text-black dark:bg-black/50 dark:text-white/90 dark:shadow-none dark:hover:bg-black/20 dark:hover:text-white'
+        } p-2.5 transition-all duration-200 hover:shadow-lg`}
         aria-pressed={showInfo}
         aria-label={showInfo ? 'Hide Info' : 'Show Info'}
         title={showInfo ? 'Hide Info' : 'Show Info'}
@@ -39,7 +41,7 @@ export const VideoViewerControls: React.FC<VideoViewerControlsProps> = ({
 
       <button
         onClick={onOpenFolder}
-        className="cursor-pointer rounded-full bg-black/50 p-2.5 text-white/90 transition-all duration-200 hover:bg-black/20 hover:text-white hover:shadow-lg"
+        className="cursor-pointer rounded-full bg-white/80 p-2.5 text-gray-700 shadow-md transition-all duration-200 hover:bg-white hover:text-black hover:shadow-lg dark:bg-black/50 dark:text-white/90 dark:shadow-none dark:hover:bg-black/20 dark:hover:text-white"
         aria-label="Open Folder"
         title="Open Folder"
       >
@@ -48,10 +50,10 @@ export const VideoViewerControls: React.FC<VideoViewerControlsProps> = ({
 
       <button
         onClick={onToggleFavourite}
-        className={`cursor-pointer rounded-full p-2.5 text-white transition-all duration-300 ${
+        className={`cursor-pointer rounded-full p-2.5 transition-all duration-300 ${
           isFavourite
-            ? 'bg-rose-500/80 hover:bg-rose-600 hover:shadow-lg'
-            : 'bg-black/50 hover:bg-black/20 hover:text-white hover:shadow-lg'
+            ? 'bg-rose-500/80 text-white hover:bg-rose-600 hover:shadow-lg'
+            : 'bg-white/80 text-gray-700 shadow-md hover:bg-white hover:text-black hover:shadow-lg dark:bg-black/50 dark:text-white dark:shadow-none dark:hover:bg-black/20 dark:hover:text-white'
         }`}
         aria-label={
           isFavourite ? 'Remove from favourites' : 'Add to favourites'
@@ -64,10 +66,10 @@ export const VideoViewerControls: React.FC<VideoViewerControlsProps> = ({
       <button
         onClick={onToggleAutoPlayNext}
         aria-pressed={autoPlayNext}
-        className={`flex cursor-pointer items-center gap-2 rounded-full px-4 py-2 text-white transition-all duration-200 hover:shadow-lg ${
+        className={`flex cursor-pointer items-center gap-2 rounded-full px-4 py-2 transition-all duration-200 hover:shadow-lg ${
           autoPlayNext
-            ? 'bg-indigo-500/70 hover:bg-indigo-600/80'
-            : 'bg-black/50 hover:bg-black/20'
+            ? 'bg-indigo-500/70 text-white hover:bg-indigo-600/80'
+            : 'bg-white/80 text-gray-700 shadow-md hover:bg-white hover:text-black dark:bg-black/50 dark:text-white dark:shadow-none dark:hover:bg-black/20 dark:hover:text-white'
         }`}
         aria-label="Toggle auto-play next"
         title="Auto-play next"
@@ -80,7 +82,7 @@ export const VideoViewerControls: React.FC<VideoViewerControlsProps> = ({
 
       <button
         onClick={onClose}
-        className="ml-2 cursor-pointer rounded-full bg-black/50 p-2.5 text-white/90 transition-all duration-200 hover:bg-black/20 hover:text-white hover:shadow-lg"
+        className="ml-2 cursor-pointer rounded-full bg-white/80 p-2.5 text-gray-700 shadow-md transition-all duration-200 hover:bg-white hover:text-black hover:shadow-lg dark:bg-black/50 dark:text-white/90 dark:shadow-none dark:hover:bg-black/20 dark:hover:text-white"
         aria-label="Close"
         title="Close"
       >


### PR DESCRIPTION
## Description

Fixes #1419

The Image Viewer and Video Viewer did not respect the selected app theme.
They hardcoded dark backgrounds and white-on-dark chrome with no light-mode
fallback, so both viewers stayed dark even when the app was switched to Light
Mode, while the rest of the app followed the theme.

## Approach

The app themes via a `.dark` class on the `<html>` element (set by
`ThemeContext`), so `dark:` Tailwind variants are the idiomatic mechanism. I
added light-mode defaults to the viewer chrome and moved the existing dark
styling behind `dark:` variants.

Dark mode is visually unchanged (every dark style is preserved as a `dark:`
variant); only the new light appearance is added.

Because the controls float over arbitrary image content, the light-mode chrome
uses frosted semi-opaque white chips with a subtle shadow and dark icons, which
mirrors how the dark theme uses a semi-opaque dark scrim. This keeps the
controls, navigation arrows, and icons legible over both light and dark images
instead of vanishing against a dark photo.

## Changes

Image viewer:
- `MediaView.tsx` (backdrop container)
- `MediaViewControls.tsx`
- `MediaInfoPanel.tsx`
- `MediaThumbnails.tsx`
- `ZoomControls.tsx`
- `NavigationButtons.tsx`

Video viewer:
- `VideoPlayerOverlay.tsx` (backdrop container)
- `VideoViewerControls.tsx`
- `VideoInfoPanel.tsx`

Note: the `NetflixStylePlayer` video stage itself is intentionally left dark.
That is the video content surface (matching standard players like YouTube and
Netflix, which stay dark in any theme), not app chrome.

## Testing

- `tsc --noEmit`: passes
- `eslint --max-warnings 0`: passes
- `prettier --check`: passes on all changed files
- `jest`: 78/78 in affected suites
- Verified live in `tauri dev`: viewers render light chrome in Light Mode
  (including over dark images) and the original dark chrome in Dark Mode.

## Screenshots

<!-- Add before/after screenshots of both viewers in Light Mode here -->

## Expected behavior

- Opening an image or video in Light Mode shows the viewer with a light theme.
- Opening an image or video in Dark Mode shows the existing dark theme.
- Theme switching stays consistent across the app, including the media viewers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Refreshed light and dark theme styling across media and video viewers with improved contrast, translucent backgrounds, and updated borders/text colors.
  - Restyled overlays, info panels, navigation, zoom, and playback controls with consistent hover/shadow behavior.
  - Updated thumbnail selection and tag chip visuals to better match the new theme treatment.
  - Preserved existing media details and all control behavior/actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->