### PR TITLE
Feat/themed-scrollbar-and-tag-toggle

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -206,6 +206,29 @@
   scrollbar-width: none; /* Firefox */
 }
 
+.thin-scrollbar {
+  scrollbar-width: thin; /* Firefox */
+  scrollbar-color: var(--border) transparent; /* Firefox: */
+}
+
+.thin-scrollbar::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+.thin-scrollbar::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.thin-scrollbar::-webkit-scrollbar-thumb {
+  background-color: var(--border);
+  border-radius: 9999px;
+}
+
+.thin-scrollbar::-webkit-scrollbar-thumb:hover {
+  background-color: var(--muted-foreground); 
+}
+
 .no-select {
   -webkit-user-select: none; /* Safari */
   -moz-user-select: none; /* Firefox */

--- a/frontend/src/components/Media/ImageTags.tsx
+++ b/frontend/src/components/Media/ImageTags.tsx
@@ -69,11 +69,11 @@ export function ImageTags({
       )}
 
       {shouldShowTags && showTags && (
-        <div className="absolute bottom-0 left-0 z-10 flex max-h-24 max-w-[200px] flex-wrap gap-1 overflow-y-auto rounded-md bg-black/80 p-2 shadow-lg">
+        <div className="thin-scrollbar absolute bottom-0 left-0 z-10 flex max-h-24 max-w-[200px] flex-wrap gap-1 overflow-x-hidden overflow-y-auto rounded-md bg-black/80 p-2 shadow-lg">
           {tags.map((tag: any, index: number) => (
             <Badge
               key={tag.id || index}
-              className="border border-white/40 bg-transparent whitespace-nowrap text-white hover:bg-white/10"
+              className="border border-white/40 bg-transparent text-white hover:bg-white/10"
             >
               {tag.name || tag}
             </Badge>

--- a/frontend/src/components/Media/MediaInfoPanel.tsx
+++ b/frontend/src/components/Media/MediaInfoPanel.tsx
@@ -155,14 +155,14 @@ export const MediaInfoPanel: React.FC<MediaInfoPanelProps> = ({
                   Tags
                 </p>
                 {currentImage?.tags?.length ? (
-                  <div className="flex flex-wrap gap-2">
+                  <div className="flex flex-wrap gap-1">
                     {(showAllTags
                       ? currentImage.tags
                       : currentImage.tags.slice(0, 3)
                     ).map((tag, i) => (
                       <span
                         key={i}
-                        className="rounded-full border border-blue-500/30 bg-blue-500/20 px-2 py-1 text-xs text-blue-600 dark:text-blue-300"
+                        className="rounded-full border border-black/20 px-2 py-0.5 text-xs text-gray-800 dark:border-white/30 dark:text-white"
                       >
                         {tag}
                       </span>
@@ -171,7 +171,7 @@ export const MediaInfoPanel: React.FC<MediaInfoPanelProps> = ({
                       <button
                         type="button"
                         onClick={() => setShowAllTags((prev) => !prev)}
-                        className="focus-visible:ring-ring/50 inline-flex items-center gap-1.5 rounded-md bg-blue-500/20 px-2 py-1 text-xs font-medium whitespace-nowrap text-blue-600 shadow-xs transition-all outline-none hover:bg-blue-500/30 focus-visible:ring-[3px] dark:text-blue-300 dark:hover:bg-blue-500/30"
+                        className="focus-visible:ring-ring/50 inline-flex items-center gap-1.5 rounded-full bg-black/10 px-2 py-0.5 text-xs font-medium whitespace-nowrap text-gray-800 shadow-xs transition-all outline-none hover:bg-black/15 focus-visible:ring-[3px] dark:bg-white/15 dark:text-white dark:hover:bg-white/20"
                       >
                         {showAllTags ? (
                           <Minus

--- a/frontend/src/components/Media/MediaInfoPanel.tsx
+++ b/frontend/src/components/Media/MediaInfoPanel.tsx
@@ -9,6 +9,8 @@ import {
   Tag,
   Info,
   SquareArrowOutUpRight,
+  Plus,
+  Minus,
 } from 'lucide-react';
 import { Image } from '@/types/Media';
 
@@ -27,6 +29,8 @@ export const MediaInfoPanel: React.FC<MediaInfoPanelProps> = ({
   currentIndex,
   totalImages,
 }) => {
+  const [showAllTags, setShowAllTags] = React.useState(false);
+
   const getFormattedDate = () => {
     if (currentImage?.metadata?.date_created) {
       return new Date(currentImage.metadata.date_created).toLocaleDateString(
@@ -145,7 +149,10 @@ export const MediaInfoPanel: React.FC<MediaInfoPanelProps> = ({
                 </p>
                 {currentImage?.tags?.length ? (
                   <div className="flex flex-wrap gap-2">
-                    {currentImage.tags.map((tag, i) => (
+                    {(showAllTags
+                      ? currentImage.tags
+                      : currentImage.tags.slice(0, 3)
+                    ).map((tag, i) => (
                       <span
                         key={i}
                         className="rounded-full border border-blue-500/30 bg-blue-500/20 px-2 py-1 text-xs text-blue-600 dark:text-blue-300"
@@ -153,6 +160,26 @@ export const MediaInfoPanel: React.FC<MediaInfoPanelProps> = ({
                         {tag}
                       </span>
                     ))}
+                    {currentImage.tags.length > 3 && (
+                      <button
+                        type="button"
+                        onClick={() => setShowAllTags((prev) => !prev)}
+                        className="focus-visible:ring-ring/50 inline-flex items-center gap-1.5 rounded-md bg-blue-500/20 px-2 py-1 text-xs font-medium whitespace-nowrap text-blue-600 shadow-xs transition-all outline-none hover:bg-blue-500/30 focus-visible:ring-[3px] dark:text-blue-300 dark:hover:bg-blue-500/30"
+                      >
+                        {showAllTags ? (
+                          <Minus
+                            className="h-2.5 w-2.5 shrink-0"
+                            strokeWidth={2.5}
+                          />
+                        ) : (
+                          <Plus
+                            className="h-2.5 w-2.5 shrink-0"
+                            strokeWidth={2.5}
+                          />
+                        )}
+                        <span>{showAllTags ? 'show less' : 'show more'}</span>
+                      </button>
+                    )}
                   </div>
                 ) : (
                   <p className="text-gray-500 dark:text-white/60">

--- a/frontend/src/components/Media/MediaInfoPanel.tsx
+++ b/frontend/src/components/Media/MediaInfoPanel.tsx
@@ -31,6 +31,13 @@ export const MediaInfoPanel: React.FC<MediaInfoPanelProps> = ({
 }) => {
   const [showAllTags, setShowAllTags] = React.useState(false);
 
+  const tagResetKey = `${show}:${currentImage?.id ?? ''}`;
+  const [prevTagResetKey, setPrevTagResetKey] = React.useState(tagResetKey);
+  if (tagResetKey !== prevTagResetKey) {
+    setPrevTagResetKey(tagResetKey);
+    setShowAllTags(false);
+  }
+
   const getFormattedDate = () => {
     if (currentImage?.metadata?.date_created) {
       return new Date(currentImage.metadata.date_created).toLocaleDateString(

--- a/frontend/src/components/Media/__tests__/MediaInfoPanel.test.tsx
+++ b/frontend/src/components/Media/__tests__/MediaInfoPanel.test.tsx
@@ -87,4 +87,41 @@ describe('MediaInfoPanel tag list', () => {
       screen.getByRole('button', { name: /show more/i }),
     ).toBeInTheDocument();
   });
+
+  test('resets to the compact default when a different image is shown', () => {
+    const first = makeImage(['alpha', 'beta', 'gamma', 'delta', 'epsilon']);
+    const second: Image = {
+      ...makeImage(['one', 'two', 'three', 'four']),
+      id: 'img2',
+    };
+    const { rerender } = render(
+      <MediaInfoPanel
+        show
+        onClose={jest.fn()}
+        currentImage={first}
+        currentIndex={0}
+        totalImages={2}
+      />,
+    );
+
+    // Expand on the first image.
+    fireEvent.click(screen.getByRole('button', { name: /show more/i }));
+    expect(screen.getByText('epsilon')).toBeInTheDocument();
+
+    // Navigating to a different image collapses the list again.
+    rerender(
+      <MediaInfoPanel
+        show
+        onClose={jest.fn()}
+        currentImage={second}
+        currentIndex={1}
+        totalImages={2}
+      />,
+    );
+
+    expect(screen.queryByText('four')).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /show more/i }),
+    ).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/Media/__tests__/MediaInfoPanel.test.tsx
+++ b/frontend/src/components/Media/__tests__/MediaInfoPanel.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MediaInfoPanel } from '../MediaInfoPanel';
+import { Image } from '@/types/Media';
+
+jest.mock('@tauri-apps/plugin-shell', () => ({
+  open: jest.fn().mockResolvedValue(undefined),
+}));
+
+const makeImage = (tags: string[]): Image => ({
+  id: 'img1',
+  path: 'C:\\pics\\img1.jpg',
+  thumbnailPath: 'C:\\pics\\thumb\\img1.jpg',
+  folder_id: 'folder-1',
+  isTagged: true,
+  metadata: {
+    name: 'img1.jpg',
+    date_created: '2026-01-01T00:00:00',
+    width: 1920,
+    height: 1080,
+    file_location: 'C:\\pics\\img1.jpg',
+    file_size: 1024,
+    item_type: 'image/jpeg',
+  },
+  isFavourite: false,
+  tags,
+});
+
+const renderPanel = (tags: string[]) =>
+  render(
+    <MediaInfoPanel
+      show
+      onClose={jest.fn()}
+      currentImage={makeImage(tags)}
+      currentIndex={0}
+      totalImages={1}
+    />,
+  );
+
+describe('MediaInfoPanel tag list', () => {
+  test('shows all tags and no toggle when there are 3 or fewer', () => {
+    renderPanel(['alpha', 'beta', 'gamma']);
+
+    expect(screen.getByText('alpha')).toBeInTheDocument();
+    expect(screen.getByText('beta')).toBeInTheDocument();
+    expect(screen.getByText('gamma')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /show more/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('truncates to the first 3 tags and shows a "show more" toggle when there are more than 3', () => {
+    renderPanel(['alpha', 'beta', 'gamma', 'delta', 'epsilon']);
+
+    expect(screen.getByText('alpha')).toBeInTheDocument();
+    expect(screen.getByText('gamma')).toBeInTheDocument();
+    expect(screen.queryByText('delta')).not.toBeInTheDocument();
+    expect(screen.queryByText('epsilon')).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /show more/i }),
+    ).toBeInTheDocument();
+  });
+
+  test('"show more" reveals all tags and flips the toggle to "show less"', () => {
+    renderPanel(['alpha', 'beta', 'gamma', 'delta', 'epsilon']);
+
+    fireEvent.click(screen.getByRole('button', { name: /show more/i }));
+
+    expect(screen.getByText('delta')).toBeInTheDocument();
+    expect(screen.getByText('epsilon')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /show less/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /show more/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('"show less" collapses back to the first 3 tags', () => {
+    renderPanel(['alpha', 'beta', 'gamma', 'delta', 'epsilon']);
+
+    fireEvent.click(screen.getByRole('button', { name: /show more/i }));
+    fireEvent.click(screen.getByRole('button', { name: /show less/i }));
+
+    expect(screen.queryByText('delta')).not.toBeInTheDocument();
+    expect(screen.queryByText('epsilon')).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /show more/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/VideoPlayer/VideoInfoPanel.tsx
+++ b/frontend/src/components/VideoPlayer/VideoInfoPanel.tsx
@@ -54,6 +54,13 @@ export const VideoInfoPanel: React.FC<VideoInfoPanelProps> = ({
   const tags = video?.tags ?? [];
   const [showAllTags, setShowAllTags] = React.useState(false);
 
+  const tagResetKey = `${show}:${video?.id ?? ''}`;
+  const [prevTagResetKey, setPrevTagResetKey] = React.useState(tagResetKey);
+  if (tagResetKey !== prevTagResetKey) {
+    setPrevTagResetKey(tagResetKey);
+    setShowAllTags(false);
+  }
+
   return (
     <AnimatePresence>
       {show && (

--- a/frontend/src/components/VideoPlayer/VideoInfoPanel.tsx
+++ b/frontend/src/components/VideoPlayer/VideoInfoPanel.tsx
@@ -164,7 +164,7 @@ export const VideoInfoPanel: React.FC<VideoInfoPanelProps> = ({
                       <button
                         type="button"
                         onClick={() => setShowAllTags((prev) => !prev)}
-                        className="focus-visible:ring-ring/50 inline-flex items-center gap-1.5 rounded-md bg-black/10 px-2 py-0.5 text-xs font-medium whitespace-nowrap text-gray-800 shadow-xs transition-all outline-none hover:bg-black/15 focus-visible:ring-[3px] dark:bg-white/15 dark:text-white dark:hover:bg-white/20"
+                        className="focus-visible:ring-ring/50 inline-flex items-center gap-1.5 rounded-full bg-black/10 px-2 py-0.5 text-xs font-medium whitespace-nowrap text-gray-800 shadow-xs transition-all outline-none hover:bg-black/15 focus-visible:ring-[3px] dark:bg-white/15 dark:text-white dark:hover:bg-white/20"
                       >
                         {showAllTags ? (
                           <Minus

--- a/frontend/src/components/VideoPlayer/VideoInfoPanel.tsx
+++ b/frontend/src/components/VideoPlayer/VideoInfoPanel.tsx
@@ -1,6 +1,16 @@
 import React from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { X, Film, Calendar, Clock, Monitor, Info, Tag } from 'lucide-react';
+import {
+  X,
+  Film,
+  Calendar,
+  Clock,
+  Monitor,
+  Info,
+  Tag,
+  Plus,
+  Minus,
+} from 'lucide-react';
 import { Video } from '@/types/Media';
 import { formatDurationLabel } from '@/utils/durationUtils';
 
@@ -42,6 +52,7 @@ export const VideoInfoPanel: React.FC<VideoInfoPanelProps> = ({
   const resolution =
     width > 0 && height > 0 ? `${width} × ${height}` : 'Not available';
   const tags = video?.tags ?? [];
+  const [showAllTags, setShowAllTags] = React.useState(false);
 
   return (
     <AnimatePresence>
@@ -132,14 +143,36 @@ export const VideoInfoPanel: React.FC<VideoInfoPanelProps> = ({
                     Tags
                   </p>
                   <div className="mt-1 flex flex-wrap gap-1">
-                    {tags.map((tag, index) => (
-                      <span
-                        key={`${tag}-${index}`}
-                        className="rounded-full border border-black/20 px-2 py-0.5 text-xs text-gray-800 dark:border-white/30 dark:text-white"
+                    {(showAllTags ? tags : tags.slice(0, 3)).map(
+                      (tag, index) => (
+                        <span
+                          key={`${tag}-${index}`}
+                          className="rounded-full border border-black/20 px-2 py-0.5 text-xs text-gray-800 dark:border-white/30 dark:text-white"
+                        >
+                          {tag}
+                        </span>
+                      ),
+                    )}
+                    {tags.length > 3 && (
+                      <button
+                        type="button"
+                        onClick={() => setShowAllTags((prev) => !prev)}
+                        className="focus-visible:ring-ring/50 inline-flex items-center gap-1.5 rounded-md bg-black/10 px-2 py-0.5 text-xs font-medium whitespace-nowrap text-gray-800 shadow-xs transition-all outline-none hover:bg-black/15 focus-visible:ring-[3px] dark:bg-white/15 dark:text-white dark:hover:bg-white/20"
                       >
-                        {tag}
-                      </span>
-                    ))}
+                        {showAllTags ? (
+                          <Minus
+                            className="h-2.5 w-2.5 shrink-0"
+                            strokeWidth={2.5}
+                          />
+                        ) : (
+                          <Plus
+                            className="h-2.5 w-2.5 shrink-0"
+                            strokeWidth={2.5}
+                          />
+                        )}
+                        <span>{showAllTags ? 'show less' : 'show more'}</span>
+                      </button>
+                    )}
                   </div>
                 </div>
               </div>

--- a/frontend/src/components/VideoPlayer/__tests__/VideoInfoPanel.test.tsx
+++ b/frontend/src/components/VideoPlayer/__tests__/VideoInfoPanel.test.tsx
@@ -86,4 +86,41 @@ describe('VideoInfoPanel tag list', () => {
       screen.getByRole('button', { name: /show more/i }),
     ).toBeInTheDocument();
   });
+
+  test('resets to the compact default when a different video is shown', () => {
+    const first = makeVideo(['alpha', 'beta', 'gamma', 'delta', 'epsilon']);
+    const second: Video = {
+      ...makeVideo(['one', 'two', 'three', 'four']),
+      id: 'v2',
+    };
+    const { rerender } = render(
+      <VideoInfoPanel
+        show
+        onClose={jest.fn()}
+        video={first}
+        currentIndex={0}
+        totalVideos={2}
+      />,
+    );
+
+    // Expand on the first video.
+    fireEvent.click(screen.getByRole('button', { name: /show more/i }));
+    expect(screen.getByText('epsilon')).toBeInTheDocument();
+
+    // Navigating to a different video collapses the list again.
+    rerender(
+      <VideoInfoPanel
+        show
+        onClose={jest.fn()}
+        video={second}
+        currentIndex={1}
+        totalVideos={2}
+      />,
+    );
+
+    expect(screen.queryByText('four')).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /show more/i }),
+    ).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/VideoPlayer/__tests__/VideoInfoPanel.test.tsx
+++ b/frontend/src/components/VideoPlayer/__tests__/VideoInfoPanel.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { VideoInfoPanel } from '../VideoInfoPanel';
+import { Video } from '@/types/Media';
+
+const makeVideo = (tags: string[]): Video => ({
+  id: 'v1',
+  path: 'C:\\videos\\v1.mp4',
+  thumbnailPath: null,
+  folder_id: 'folder-1',
+  metadata: {
+    name: 'v1.mp4',
+    date_created: '2026-01-01T00:00:00',
+    width: 1920,
+    height: 1080,
+    duration: 60,
+    fps: 30,
+    file_location: 'C:\\videos\\v1.mp4',
+    file_size: 1024,
+    item_type: 'video/mp4',
+  },
+  isFavourite: false,
+  tags,
+});
+
+const renderPanel = (tags: string[]) =>
+  render(
+    <VideoInfoPanel
+      show
+      onClose={jest.fn()}
+      video={makeVideo(tags)}
+      currentIndex={0}
+      totalVideos={1}
+    />,
+  );
+
+describe('VideoInfoPanel tag list', () => {
+  test('shows all tags and no toggle when there are 3 or fewer', () => {
+    renderPanel(['alpha', 'beta', 'gamma']);
+
+    expect(screen.getByText('alpha')).toBeInTheDocument();
+    expect(screen.getByText('beta')).toBeInTheDocument();
+    expect(screen.getByText('gamma')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /show more/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('truncates to the first 3 tags and shows a "show more" toggle when there are more than 3', () => {
+    renderPanel(['alpha', 'beta', 'gamma', 'delta', 'epsilon']);
+
+    expect(screen.getByText('alpha')).toBeInTheDocument();
+    expect(screen.getByText('beta')).toBeInTheDocument();
+    expect(screen.getByText('gamma')).toBeInTheDocument();
+    // Beyond the first 3 are hidden until expanded.
+    expect(screen.queryByText('delta')).not.toBeInTheDocument();
+    expect(screen.queryByText('epsilon')).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /show more/i }),
+    ).toBeInTheDocument();
+  });
+
+  test('"show more" reveals all tags and flips the toggle to "show less"', () => {
+    renderPanel(['alpha', 'beta', 'gamma', 'delta', 'epsilon']);
+
+    fireEvent.click(screen.getByRole('button', { name: /show more/i }));
+
+    expect(screen.getByText('delta')).toBeInTheDocument();
+    expect(screen.getByText('epsilon')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /show less/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /show more/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('"show less" collapses back to the first 3 tags', () => {
+    renderPanel(['alpha', 'beta', 'gamma', 'delta', 'epsilon']);
+
+    fireEvent.click(screen.getByRole('button', { name: /show more/i }));
+    fireEvent.click(screen.getByRole('button', { name: /show less/i }));
+
+    expect(screen.queryByText('delta')).not.toBeInTheDocument();
+    expect(screen.queryByText('epsilon')).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /show more/i }),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
###  Addressed Issues:

Fixes #1417 

###  Screenshots/Recordings:

#### Tags before 
<img width="331" height="89" alt="tags-before" src="https://github.com/user-attachments/assets/bffb80df-b62d-442e-993f-531845c16331" />
<img width="328" height="81" alt="tags-before-light" src="https://github.com/user-attachments/assets/cea81a53-7e10-421f-ac08-331f1fde755f" />

#### Tags after
<img width="323" height="81" alt="tags-after-hidden" src="https://github.com/user-attachments/assets/cf8df632-430e-4373-b1fc-c08e8d589923" />
<img width="333" height="84" alt="tags-after-hidden-light" src="https://github.com/user-attachments/assets/4f89dc2a-1569-4a8c-b35a-8f86ee29b2f7" />
<img width="321" height="107" alt="tags-after-shown" src="https://github.com/user-attachments/assets/23b7ecc0-bdcb-4004-90cc-38ee76210315" />
<img width="340" height="116" alt="tags-after-shown-light" src="https://github.com/user-attachments/assets/3f70cbd9-917d-4175-8980-a1bc77ff5ba1" />

#### Scrollbar before 
<img width="84" height="87" alt="scrollbar-before" src="https://github.com/user-attachments/assets/ecc4e4c2-4f33-442b-ba08-08f10ceecdfb" />
<img width="78" height="89" alt="scrollbar-before-light" src="https://github.com/user-attachments/assets/4541b523-de46-4a47-b037-852d46f8b802" />

#### Scrollbar after
<img width="111" height="105" alt="scrollbar-after-dark" src="https://github.com/user-attachments/assets/65e20433-7372-4e85-8059-0307d005a8e3" />
<img width="106" height="101" alt="scrollbar-after-light" src="https://github.com/user-attachments/assets/38b61b73-582c-4a7c-8dc5-71aef8081d33" />


###  Additional Notes:
Split into three focused commits:
  - `feat(frontend): collapsible tag list in video info panel` — shows the
    first 3 tags with a show more/less toggle when a video has more than 3.
  - `feat(frontend): themed thin scrollbar for tag lists` — reusable
    `.thin-scrollbar` utility (WebKit + Firefox) built on the app's `--border`
    token, so it adapts to light/dark automatically, applied to the `ImageTags`
    overflow list.
  - `feat(frontend): collapsible tag list in image info panel` — applies the
    same toggle to the image details panel, so long tag lists stay compact in
    both the video and image metadata panels.

  **Button label choice:** I used symmetric "show more" / "show less" labels
  with a +/− icon instead of the issue's "+More tags" / "Show less". This keeps
  the two states parallel and lets the icon carry the +/− affordance, which
  reads cleaner than mixing "+More" with "Show less". Happy to switch to the
  exact wording from the issue if preferred.

  **Testing** — added `VideoInfoPanel.test.tsx` and `MediaInfoPanel.test.tsx`
  covering tag truncation and the toggle (collapsed → expanded → collapsed, and
  no button when ≤ 3 tags). Verified locally:
  - `npm run format:check` — clean
  - `npm run lint:check` — 0 warnings
  - `npm test` — 25 suites / 208 tests pass

### AI Usage Disclosure:

We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact. AI slop is strongly discouraged and may lead to banning and blocking. Do not spam our repos with AI slop.

Check one of the checkboxes below:

- [ ] This PR does not contain AI-generated code at all.
- [x] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools: Claude Code Opus 4.8

## Checklist
<!-- Mark items with [x] to indicate completion -->
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [x] If applicable, I have made corresponding changes or additions to the documentation
- [x] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image and video detail panels now truncate tag lists to the first three items by default.
  * Added “Show more” / “Show less” controls to reveal or collapse additional tags (shown only when more than three tags exist).
  * Improved tag-list scroll experience with a slimmer, styled scrollbar.
* **Bug Fixes**
  * Expanded/collapsed state now resets correctly when switching the current image or video.
* **Tests**
  * Expanded test coverage for tag truncation, expansion/collapse toggling, and state reset for both image and video panels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->