### PR TITLE
fix(frontend): make viewer nav arrows visible in dark theme and disable at edges

### DIFF
--- a/frontend/src/components/Media/MediaView.tsx
+++ b/frontend/src/components/Media/MediaView.tsx
@@ -208,6 +208,8 @@ export function MediaView({
         <NavigationButtons
           onPrevious={handlePreviousImage}
           onNext={handleNextImage}
+          disablePrevious={currentViewIndex <= 0}
+          disableNext={currentViewIndex >= images.length - 1}
         />
       </div>
 

--- a/frontend/src/components/Media/NavigationButtons.tsx
+++ b/frontend/src/components/Media/NavigationButtons.tsx
@@ -10,13 +10,8 @@ interface NavigationButtonsProps {
   disableNext?: boolean;
 }
 
-// Scrim chip so the arrow stays visible over any image. In dark mode we keep a
-// persistent black/50 background to match the other viewer controls, otherwise a
-// white chevron disappears on a fully white image. See PictoPy#1422.
 const chipBase =
   'flex items-center justify-center rounded-full bg-white/80 p-3 shadow-md backdrop-blur-md transition-all duration-200 dark:bg-black/50 dark:shadow-none';
-// Hover only on enabled arrows. Darken the dark scrim on hover rather than
-// lightening it, so the chevron never loses contrast over a bright image.
 const chipHover =
   'group-hover:bg-white group-hover:shadow-lg dark:group-hover:bg-black/70 dark:group-hover:shadow-lg';
 

--- a/frontend/src/components/Media/NavigationButtons.tsx
+++ b/frontend/src/components/Media/NavigationButtons.tsx
@@ -6,32 +6,57 @@ interface NavigationButtonsProps {
   onNext: () => void;
   previousLabel?: string;
   nextLabel?: string;
+  disablePrevious?: boolean;
+  disableNext?: boolean;
 }
+
+// Scrim chip so the arrow stays visible over any image. In dark mode we keep a
+// persistent black/50 background to match the other viewer controls, otherwise a
+// white chevron disappears on a fully white image. See PictoPy#1422.
+const chipBase =
+  'flex items-center justify-center rounded-full bg-white/80 p-3 shadow-md backdrop-blur-md transition-all duration-200 dark:bg-black/50 dark:shadow-none';
+// Hover only on enabled arrows. Darken the dark scrim on hover rather than
+// lightening it, so the chevron never loses contrast over a bright image.
+const chipHover =
+  'group-hover:bg-white group-hover:shadow-lg dark:group-hover:bg-black/70 dark:group-hover:shadow-lg';
 
 export const NavigationButtons: React.FC<NavigationButtonsProps> = ({
   onPrevious,
   onNext,
   previousLabel = 'Previous image',
   nextLabel = 'Next image',
+  disablePrevious = false,
+  disableNext = false,
 }) => {
+  // Full class strings so Tailwind's scanner keeps left-0/right-0 (no dynamic concat).
+  const buttonClasses = (disabled: boolean, position: string) =>
+    `absolute inset-y-0 ${position} z-30 flex w-20 items-center justify-center bg-transparent text-gray-800 dark:text-white ${
+      disabled ? 'cursor-not-allowed opacity-40' : 'group cursor-pointer'
+    }`;
+
+  const chipClasses = (disabled: boolean) =>
+    disabled ? chipBase : `${chipBase} ${chipHover}`;
+
   return (
     <>
       <button
         onClick={onPrevious}
-        className="group absolute inset-y-0 left-0 z-30 flex w-20 cursor-pointer items-center justify-center bg-transparent text-gray-800 dark:text-white"
+        disabled={disablePrevious}
+        className={buttonClasses(disablePrevious, 'left-0')}
         aria-label={previousLabel}
       >
-        <span className="flex items-center justify-center rounded-full bg-white/80 p-3 shadow-md backdrop-blur-md transition-all duration-200 group-hover:bg-white group-hover:shadow-lg dark:bg-transparent dark:shadow-none dark:group-hover:bg-black/80 dark:group-hover:shadow-lg">
+        <span className={chipClasses(disablePrevious)}>
           <ChevronLeft className="h-6 w-6" />
         </span>
       </button>
 
       <button
         onClick={onNext}
-        className="group absolute inset-y-0 right-0 z-30 flex w-20 cursor-pointer items-center justify-center bg-transparent text-gray-800 dark:text-white"
+        disabled={disableNext}
+        className={buttonClasses(disableNext, 'right-0')}
         aria-label={nextLabel}
       >
-        <span className="flex items-center justify-center rounded-full bg-white/80 p-3 shadow-md backdrop-blur-md transition-all duration-200 group-hover:bg-white group-hover:shadow-lg dark:bg-transparent dark:shadow-none dark:group-hover:bg-black/80 dark:group-hover:shadow-lg">
+        <span className={chipClasses(disableNext)}>
           <ChevronRight className="h-6 w-6" />
         </span>
       </button>

--- a/frontend/src/components/VideoPlayer/VideoPlayerOverlay.tsx
+++ b/frontend/src/components/VideoPlayer/VideoPlayerOverlay.tsx
@@ -115,6 +115,8 @@ export function VideoPlayerOverlay({ videos }: VideoPlayerOverlayProps) {
             onNext={handleNext}
             previousLabel="Previous video"
             nextLabel="Next video"
+            disablePrevious={currentIndex <= 0}
+            disableNext={currentIndex >= videos.length - 1}
           />
         )}
       </div>


### PR DESCRIPTION
## Description

Fixes #1422

In dark theme the media viewer navigation arrows were invisible over a fully
white image. The arrow chip used `dark:bg-transparent` (a background only
appeared on hover), so a white chevron over a white photo had nothing to stand
against. The arrows were also still clickable at the first and last item even
though nothing happened, so there was no signal that you had reached an edge.

## Approach

The other viewer controls (info, folder, favourite, close) already use a
persistent `dark:bg-black/50` scrim to stay legible over arbitrary image
content. I applied the same treatment to the arrow chip so it keeps a persistent
dark scrim instead of only showing one on hover, matching the rest of the
controls. Light mode is unchanged (`bg-white/80`).

The hover state darkens the dark scrim (`dark:group-hover:bg-black/70`) rather
than lightening it, so the white chevron never loses contrast over a bright
image. Hover styling and the `group` marker are applied only when the arrow is
enabled, so a disabled arrow gives no hover feedback.

For the boundary behaviour, the arrows now receive `disablePrevious` /
`disableNext` from both viewers. A disabled arrow carries the `disabled`
attribute plus a `cursor-not-allowed` and reduced-opacity style, so it is both
visually and functionally inert at the first and last item.

## Changes

- `NavigationButtons.tsx`: persistent dark-mode scrim on the arrow chip,
  contrast-preserving hover, enabled-only hover styling, and new
  `disablePrevious` / `disableNext` props
- `MediaView.tsx`: pass boundary state for the image viewer
- `VideoPlayerOverlay.tsx`: pass boundary state for the video viewer

## Testing

- `tsc --noEmit`: passes
- `eslint --max-warnings 0`: passes
- `prettier --check`: passes on all changed files
- `vite build`: passes
- Verified live in `tauri dev`: arrows are visible over a fully white image in
  dark mode, hover keeps the chevron legible over bright and dark images, and
  the arrows are disabled at the first and last image and video.

## Screenshots

## Expected behavior

Opening an image or video in dark mode shows the navigation arrows clearly over
any image, including a completely white one. The previous arrow is disabled on
the first item and the next arrow is disabled on the last item, in both the
image and video viewers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Previous/next navigation buttons are now disabled at the start and end of the image carousel, preventing out-of-bound navigation.
  * Video navigation buttons are now disabled at the beginning and end of the video sequence.
  * Disabled navigation now shows clearer feedback (e.g., reduced opacity and a cursor state that reflects the unavailable action).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->