### PR TITLE
fix(models): serialize inference on shared SigLIP ONNX sessions

### DIFF
--- a/backend/app/models/ONNXSessionBase.py
+++ b/backend/app/models/ONNXSessionBase.py
@@ -34,6 +34,11 @@ class ONNXSessionBase:
         self._session_registered = False
         self._session: onnxruntime.InferenceSession | None = None
         self._lock = threading.Lock()
+        # Serializes session.run() on the shared session. The DirectML EP
+        # faults (0xC0000005) if two threads run the same session at once,
+        # which the parallel image+video semantic searches do. Separate from
+        # _lock so inference never blocks on session creation/close.
+        self._inference_lock = threading.Lock()
 
     def _create_session(self) -> onnxruntime.InferenceSession:
         """Create and register a new ONNX session. Does not touch

--- a/backend/app/models/SigLIP2Text.py
+++ b/backend/app/models/SigLIP2Text.py
@@ -76,10 +76,11 @@ class SigLIP2Text(ONNXSessionBase):
         the HF tokenizer -- this graph does not tokenize internally.
         Returns an L2-normalized embedding."""
         session, input_ids_name, attention_mask_name, output_name = self.get_session()
-        result = session.run(
-            [output_name],
-            {input_ids_name: input_ids, attention_mask_name: attention_mask},
-        )[0]
+        with self._inference_lock:
+            result = session.run(
+                [output_name],
+                {input_ids_name: input_ids, attention_mask_name: attention_mask},
+            )[0]
         embedding = result[0]
         norm = np.linalg.norm(embedding)
         return embedding / norm if norm > 0 else embedding

--- a/backend/app/models/SigLIP2Vision.py
+++ b/backend/app/models/SigLIP2Vision.py
@@ -51,7 +51,8 @@ class SigLIP2Vision(ONNXSessionBase):
         side. Stored embeddings in image_embeddings are therefore
         unit-norm."""
         session, input_name, output_name = self.get_session()
-        result = session.run([output_name], {input_name: pixel_values})[0]
+        with self._inference_lock:
+            result = session.run([output_name], {input_name: pixel_values})[0]
         norms = np.linalg.norm(result, axis=1, keepdims=True)
         norms = np.where(norms > 0, norms, 1.0)
         return (result / norms).astype(np.float32)


### PR DESCRIPTION
Semantic search fires the image and video queries in parallel, and both call `session.run()` on the same cached SigLIP2 text session. The DirectML execution provider faults with an access violation (`0xC0000005`) when two threads run one session at once, killing the backend worker. `fastapi dev` then keeps the port open with no worker behind it, so every later request hangs until it times out — the search appears permanently broken until a restart.

Adds a dedicated inference lock in `ONNXSessionBase`, held around `session.run()` in `SigLIP2Text` and `SigLIP2Vision`. It is separate from `_lock` so inference never blocks on session creation or close.

Repro: two threads, 15 runs each on one DML session — segfaults immediately before the change, clean after. Verified end to end against the running app; backend suite passes (959).

Related to #1376

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when generating text and image embeddings concurrently.
  * Prevented overlapping inference operations from causing inconsistent or failed results.
  * Preserved existing embedding normalization and output behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->