### PR TITLE
Infinite "Searching by meaning..." loading state on back navigation and sequential searches fix

### DIFF
--- a/frontend/src/pages/SearchResults/SearchResults.tsx
+++ b/frontend/src/pages/SearchResults/SearchResults.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { AxiosError } from 'axios';
 import { ImageCard } from '@/components/Media/ImageCard';
@@ -71,6 +71,21 @@ export const SearchResults = () => {
 
   const [searchError, setSearchError] = useState<string | null>(null);
 
+  // react-query only aborts a superseded query's signal from inside a
+  // useEffect (post-commit), so there's a brief window right after a new
+  // search starts where an older, still-running queryFn can reach its
+  // manual dispatch below with signal.aborted still false. This ref is
+  // updated synchronously during render -- no such window -- so it always
+  // reflects the truly current search, even before that effect runs.
+  const searchKey = `${query}::${mode}`;
+  const searchKeyRef = useRef<string | null>(null);
+  const searchGenerationRef = useRef(0);
+  if (searchKeyRef.current !== searchKey) {
+    searchKeyRef.current = searchKey;
+    searchGenerationRef.current += 1;
+  }
+  const currentSearchGeneration = searchGenerationRef.current;
+
   const { data: statusData, isSuccess: isStatusSuccess } = usePictoQuery({
     queryKey: ['models', 'status'],
     queryFn: fetchModelStatus,
@@ -81,41 +96,51 @@ export const SearchResults = () => {
       ? isSemanticSearchAvailable(statusData.data)
       : false;
 
-  const { data, isLoading, isSuccess, isError, errorMessage, error } =
-    usePictoQuery({
-      queryKey: ['search-results', query, mode],
-      queryFn: async (): Promise<SearchQueryResult> => {
-        if (mode === 'semantic') {
-          const res = await semanticSearchImages({ query });
-          return { ...res, resultType: 'semantic' };
-        }
-        if (mode === 'tag') {
-          const res = await searchImagesByTag({ tag: query });
-          return { ...res, resultType: 'tag' };
-        }
+  const {
+    data,
+    isLoading,
+    isFetching,
+    isSuccess,
+    isError,
+    errorMessage,
+    error,
+  } = usePictoQuery({
+    queryKey: ['search-results', query, mode],
+    queryFn: async (): Promise<SearchQueryResult> => {
+      const myGeneration = currentSearchGeneration;
+      if (mode === 'semantic') {
+        const res = await semanticSearchImages({ query });
+        return { ...res, resultType: 'semantic' };
+      }
+      if (mode === 'tag') {
+        const res = await searchImagesByTag({ tag: query });
+        return { ...res, resultType: 'tag' };
+      }
 
-        // auto mode
-        const tagResponse = await searchImagesByTag({ tag: query });
-        if (tagResponse.data && tagResponse.data.length > 0) {
-          return { ...tagResponse, resultType: 'tag' };
-        }
-
-        const statusRes = await fetchModelStatus();
-        const semAvailable =
-          statusRes.success && statusRes.data
-            ? isSemanticSearchAvailable(statusRes.data)
-            : false;
-
-        if (semAvailable) {
-          dispatch(showLoader('Searching by meaning...'));
-          const semResponse = await semanticSearchImages({ query });
-          return { ...semResponse, resultType: 'semantic' };
-        }
-
+      // auto mode
+      const tagResponse = await searchImagesByTag({ tag: query });
+      if (tagResponse.data && tagResponse.data.length > 0) {
         return { ...tagResponse, resultType: 'tag' };
-      },
-      enabled: !!query,
-    });
+      }
+
+      const statusRes = await fetchModelStatus();
+      const semAvailable =
+        statusRes.success && statusRes.data
+          ? isSemanticSearchAvailable(statusRes.data)
+          : false;
+
+      if (semAvailable) {
+        if (myGeneration === searchGenerationRef.current) {
+          dispatch(showLoader('Searching by meaning...'));
+        }
+        const semResponse = await semanticSearchImages({ query });
+        return { ...semResponse, resultType: 'semantic' };
+      }
+
+      return { ...tagResponse, resultType: 'tag' };
+    },
+    enabled: !!query,
+  });
 
   // Videos run as their own query: they share the mode logic but a video
   // failure (e.g. no frames embedded yet) must not blank the image results,
@@ -228,6 +253,7 @@ export const SearchResults = () => {
     isSuccess,
     isError,
     isLoading,
+    isFetching,
     errorMessage,
     error,
     mode,


### PR DESCRIPTION
###  Addressed Issues:

Fixes #1398 : Infinite "Searching by meaning..." loading state on back navigation and sequential searches on searching multiple times.

### Problem Statement:

- The application enters an unrecoverable, infinite loading state displaying the "Searching by meaning...".

- When we search different things more than 3 or 4 times and go back or search again, at one point it crashes o r gets stuck.

###  Screenshots/Recordings:

**PictoPy Before:**

https://github.com/user-attachments/assets/5c5d6e26-d5f6-4fec-b51a-9f621c0e69dd

**PictoPy After:**

https://github.com/user-attachments/assets/bd52c08c-3027-46ff-95eb-964545242247


###  Additional Notes:

Number of Files Changed: 1
File Name: frontend/src/pages/searchResults/searchResults.tsx

### Problems that are Fixed:
**Total Number of bugs present: 2**

****Bug 1:** A stale search re-opens the loader after a newer search already closed it**

In auto mode, the query function falls back to semantic search and dispatches a loading message:
```

if (semAvailable) {
  dispatch(showLoader('Searching by meaning...'));
  const semResponse = await semanticSearchImages({ query });
}
```
- This dispatch call has no awareness of whether the search it belongs to is still the one the user cares about. If you search "human" and then immediately search "motorcycle" before "human" resolves, both run as independent async chains. If "human"'s chain is slightly delayed, it can reach that dispatch(showLoader(...)) call after "motorcycle" has already finished and hidden the loader. Nothing was listening for that — only the currently active search's success/error path calls hideLoader() — so the stale dispatch from the abandoned "human" search leaves the loader stuck on.

****Fix:** :**
Added a generation counter `(searchGenerationRef)` that increments synchronously during render whenever query/mode actually changes (not inside a useEffect, since effects run after render and would leave a timing gap). Each search captures its own generation number when it starts (myGeneration). Before dispatching showLoader, it checks whether its generation is still current — if a newer search has started, the numbers won't match and the dispatch is skipped. This is a plain synchronous comparison, so it can't itself race.

```
// react-query only aborts a superseded query's signal from inside a
// useEffect (post-commit), so there's a brief window right after a new
// search starts where an older, still-running queryFn can reach its
// manual dispatch below with signal.aborted still false. This ref is
// updated synchronously during render -- no such window -- so it always
// reflects the truly current search, even before that effect runs.
const searchKey = `${query}::${mode}`;
const searchKeyRef = useRef<string | null>(null);
const searchGenerationRef = useRef(0);
if (searchKeyRef.current !== searchKey) {
  searchKeyRef.current = searchKey;
  searchGenerationRef.current += 1;
}
const currentSearchGeneration = searchGenerationRef.current;
```

**Bug 2: Repeating an identical search re-fetches silently, and the loader-hiding effect never re-runs:**

- This one only shows up when a search is repeated exactly (e.g. "human" → "motorcycle" → "human" again). React Query caches by query key, so the third search hits the same cache entry as the first: it instantly returns the cached results, then quietly refetches in the background to revalidate.

- The `useEffect` responsible for hiding the loader only re-runs when data, `isSuccess, isError, or isLoading` change. During that background refetch:

1.` isLoading` stays `false` the whole time — it's only `true` when there's no cached data at all.
2. If the refetched results are identical to the cached ones (likely, since the underlying library hasn't changed), React Query reuses the same data reference rather than creating a new one.

- So none of the effect's dependencies change, the effect never re-runs, and `hideLoader()` is never called — even though Bug 1's `showLoader` dispatch already turned it back on for that background refetch.

**Fix:**:
 Added `isFetching `to the effect's dependency array. Unlike `isLoading`, `isFetching` is `true `for the full duration of any fetch — including silent background refetches — and reliably flips back to false when it completes, regardless of whether the data reference changed. This guarantees the effect re-runs and hides the loader once the refetch finishes.

```
const {
   data,
   isLoading,
   isFetching,
   isSuccess,
   isError,
   errorMessage,
   error,
 } = usePictoQuery({
   queryKey: ['search-results', query, mode],
   queryFn: async (): Promise<SearchQueryResult> => {
     const myGeneration = currentSearchGeneration;
     if (mode === 'semantic') {
```

### Improtant:

**- I have tested it for multiple searches multiple times, but on your side please do check it, if it is generating a bug or not.**

### AI Usage Disclosure:

We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact. AI slop is strongly discouraged and may lead to banning and blocking. Do not spam our repos with AI slop.

Check one of the checkboxes below:

- [ ] This PR does not contain AI-generated code at all.
- [ x ] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools: Claude Sonnet - 5


## Checklist
<!-- Mark items with [x] to indicate completion -->
- [ x ] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [ x ] My code follows the project's code style and conventions
- [ x ] If applicable, I have made corresponding changes or additions to the documentation
- [ x ] If applicable, I have made corresponding changes or additions to tests
- [ x ] My changes generate no new warnings or errors
- [ x ] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [ x ] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [ x ] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [ x ] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search result loading behavior when multiple searches are started in quick succession.
  * Prevented outdated searches from displaying incorrect loading states.
  * Ensured image results update reliably as fetching progresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->