### PR TITLE
fix(ci): run lint on pull_request so fork PRs are actually linted

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,21 +1,21 @@
 name: Lint Check
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   linting:
     runs-on: ubuntu-latest
     name: Linting
     steps:
-      - name: Checkout PR head
+      - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
 
       - name: Markdown lint


### PR DESCRIPTION
Follow-up to #1442. The `Lint Check` workflow currently fails on **every fork pull request**, at the checkout step, without running a single linter.

## What happens

```
Refusing to check out fork pull request code from a 'pull_request_target'
workflow. This workflow runs with the base repository's GITHUB_TOKEN,
secrets, default-branch cache scope, and runner access. Fetching and
executing a fork's code in that trusted context commonly leads to
"pwn request" vulnerabilities.
```

The job dies in ~3s at step 1 of 8 — before Node, before Python, before eslint/prettier/black/ruff/`cargo fmt`. Nothing is linted, and the red X is indistinguishable from a genuine lint failure.

Example run: https://github.com/AOSSIE-Org/PictoPy/actions/runs/30756159484/job/91518560396

## Why the config can't work as written

The workflow triggers on `pull_request_target` and then checks out `github.event.pull_request.head.sha`. Those two are incompatible by design: `pull_request_target` exists to run in the *base* repository's trusted context, which is precisely why untrusted fork code must not be checked out into it. `actions/checkout@v4` now blocks the combination outright.

I understand why the trigger was chosen — #1441 wanted lint to run without waiting on maintainer approval, and `pull_request_target` bypasses the first-time-contributor gate. But that benefit and "check out the contributor's code" are mutually exclusive.

## Why not `allow-unsafe-pr-checkout: true`

The error message offers that opt-out. It would make the failure disappear and reintroduce the exact vulnerability the guard exists to prevent. Two arbitrary-code-execution paths already exist in this workflow:

- `npm run lint:check` loads the fork's `.eslintrc.json`, which can `require()` any file the PR adds
- `pre-commit run --all-files` executes hook definitions from the fork's `.pre-commit-config.yaml`, which can name arbitrary repos and entry points

`npm ci --ignore-scripts` on line 42 shows the supply-chain risk was considered, but the lint steps themselves bypass it.

`permissions: {}` limits the token, but not cache scope — `pull_request_target` grants default-branch cache access, and this workflow enables `cache: npm` and `cache: pip`, so a malicious PR could poison caches that `main` builds later consume.

## The change

Switch to `pull_request` and drop the explicit `ref:` so checkout uses the PR merge ref.

This is what `pr-check-tests.yml` already does, and it's why **Frontend Tests** and **Backend Tests** run fine on fork PRs while **Linting** does not. The job uses no secrets and needs no write access, so it loses nothing by running in the untrusted context — that context is the correct one for it.

`permissions` becomes `contents: read` rather than `{}`, because `actions/checkout` needs that scope to authenticate; an empty map leaves the token with none. It remains minimal and read-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the reliability and security of automated pull request checks.
  * Validation now runs against the correct proposed changes with read-only repository access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->