### PR TITLE
Fix review findings in the agent instructions

### DIFF
--- a/agent-kit/README.md
+++ b/agent-kit/README.md
@@ -69,9 +69,14 @@ mechanically.
 ## Adopting a third-party skill
 
 ```bash
-npx skills add <owner>/<repo>
+npx skills@1.5.21 add <owner>/<repo>#<reviewed-tag-or-commit>
 ```
 
+Pin both halves. `npx skills` without a version runs whatever was published most recently,
+and a skill installed from a moving branch can change the instructions an agent follows
+after you reviewed them. Install from a tag or commit you have actually read.
+
 This installs into `.claude/skills/` or `.agents/skills/` and stays updatable with
-`npx skills update`. Leave it where the installer put it — moving it here breaks updates —
-and record what you adopted and why in `references/third-party-skills.md`.
+`npx skills@1.5.21 update`. Leave it where the installer put it — moving it here breaks
+updates — and record what you adopted, at which revision, and why in
+`references/third-party-skills.md`.

--- a/agent-kit/providers/codex.md
+++ b/agent-kit/providers/codex.md
@@ -15,13 +15,15 @@ root file applying everywhere else. Explicit instructions in chat override both.
 stubs there are byte-identical to the ones in `.claude/skills/`; both point at
 `agent-kit/skills/`.
 
-`npx skills add <owner>/<repo>` installs into this directory. See
-`agent-kit/references/third-party-skills.md` before adopting anything.
+`npx skills@1.5.21 add <owner>/<repo>#<reviewed-tag-or-commit>` installs into this
+directory. See `agent-kit/references/third-party-skills.md` before adopting anything.
 
 ## Notes
 
-- Codex has no equivalent of Claude Code's hooks, so the automatic formatting does not
-  apply. Run the checks in `agent-kit/skills/pre-pr-check/SKILL.md` manually before
-  pushing — especially `pre-commit`, since nothing will have reformatted Python for you.
+- Codex supports hooks of its own, through `hooks.json` or an inline `[hooks]` table in
+  `config.toml`, but this repository does not wire any up. Only Claude Code gets the
+  automatic formatting here, so unless you add equivalent hooks yourself, run the checks in
+  `agent-kit/skills/pre-pr-check/SKILL.md` manually before pushing — especially
+  `pre-commit`, since nothing will have reformatted Python for you.
 - `disable-model-invocation` and `allowed-tools` in the stub frontmatter are Claude Code
   extensions. Codex ignores them harmlessly.

--- a/agent-kit/references/ci-gates.md
+++ b/agent-kit/references/ci-gates.md
@@ -11,12 +11,19 @@ Both workflows trigger on `pull_request` against `main`.
 
 | Check | Local command |
 | --- | --- |
-| Markdown | `npx markdownlint-cli2 --config .github/.markdownlint-cli2.jsonc` |
-| Frontend lint | `cd frontend && npm run lint:check` |
-| Frontend format | `cd frontend && npm run format:check` |
+| Markdown | `npx markdownlint-cli2@0.22.1 --config .github/.markdownlint-cli2.jsonc` |
+| Frontend lint | `(cd frontend && npm run lint:check)` |
+| Frontend format | `(cd frontend && npm run format:check)` |
 | Python lint + format | `pre-commit run --config .pre-commit-config.yaml --all-files` |
 | Agent hook tests | `node scripts/agent-format-hook.test.mjs` |
-| Rust format | `cd frontend/src-tauri && cargo fmt -- --check` |
+| Rust format | `(cd frontend/src-tauri && cargo fmt -- --check)` |
+
+Every command above runs from the repository root, and each `cd` is wrapped in a subshell so
+it does not leak into the next one.
+
+The markdownlint version is pinned to match `markdownlint-cli2-action@v23`, which CI uses.
+Bare `npx markdownlint-cli2` resolves to the latest release instead, so it can disagree with
+CI over rules that changed between versions.
 
 CI installs the linters from `backend/requirements-lint.txt`, which pins `pre-commit`,
 `ruff`, and `black` — install from that file locally so your versions match the runner's.

--- a/agent-kit/references/third-party-skills.md
+++ b/agent-kit/references/third-party-skills.md
@@ -6,12 +6,16 @@ this file documents the process so the first adoption follows it.
 ## How to adopt one
 
 ```bash
-npx skills add <owner>/<repo>
+npx skills@1.5.21 add <owner>/<repo>#<reviewed-tag-or-commit>
 ```
+
+Both halves are pinned on purpose. `npx skills` on its own runs the latest published
+release, and installing from a moving branch means the instructions an agent follows can
+change after you reviewed them. Record the exact revision in the table below.
 
 The installer writes into `.claude/skills/` (Claude Code) or `.agents/skills/` (Codex,
 Cursor, Gemini CLI). **Leave it there.** Moving it into `agent-kit/skills/` breaks
-`npx skills update`, which matches on the install path.
+`npx skills@1.5.21 update`, which matches on the install path.
 
 That is the one exception to the rule that `agent-kit/` holds the canonical copy: vendored
 skills stay where their installer manages them, and this file records what they are.
@@ -25,6 +29,9 @@ first.
   or note the conflict below.
 - Does it run commands? Check what they do.
 - Is it maintained? An abandoned skill encoding an old API is worse than none.
+- Which exact revision did you read? Install that tag or commit, not the default branch,
+  and put it in the table. Re-reading is the only way to know an update is safe, so an
+  update is a fresh review, not a version bump.
 
 ## Adopted skills
 
@@ -38,6 +45,7 @@ When you add one, record it here:
 
 ## Candidates
 
-- **shadcn/ui** (`npx skills add shadcn/ui`) — component generation guidance. Relevant
+- **shadcn/ui** (`npx skills@1.5.21 add shadcn/ui#<reviewed-tag>`) — component generation
+  guidance. Relevant
   because `frontend/src/components/ui/` is shadcn-generated and must not be hand-edited.
   Check it agrees with our Tailwind v4 setup before adopting.

--- a/agent-kit/skills/add-backend-endpoint/SKILL.md
+++ b/agent-kit/skills/add-backend-endpoint/SKILL.md
@@ -84,6 +84,15 @@ pre-commit run --config .pre-commit-config.yaml --all-files
 (cd frontend && npm run lint:check && npm run format:check && npm test)
 ```
 
+A new endpoint usually means a new import, and CI freezes both services with PyInstaller
+before it runs the tests. An import that only happens at runtime passes `pytest` and fails
+there, so build them too:
+
+```bash
+(cd backend && pyinstaller main.py --name PictoPy_Server --onedir --distpath dist)
+(cd sync-microservice && pyinstaller main.py --name PictoPy_Sync_Microservice --onedir --distpath dist)
+```
+
 Or run `/pre-pr-check`, which covers every area and is the single place the gate list is
 maintained.
 

--- a/agent-kit/skills/pre-pr-check/SKILL.md
+++ b/agent-kit/skills/pre-pr-check/SKILL.md
@@ -7,9 +7,14 @@ allowed-tools: Bash Read Grep Glob
 
 # Pre-PR check
 
-Run the same checks CI runs, in the same order, and report each one. Do not stop at the
-first failure — run everything, then summarise, so the contributor sees the full picture in
-one pass.
+Run every check CI runs, in the same order, and report each one. Do not stop at the first
+failure — run everything, then summarise, so the contributor sees the full picture in one
+pass.
+
+Two things here are deliberately not a mirror of CI. `cargo test` is **extra**: no PR
+workflow runs it, but `CONTRIBUTING.md` asks for it on Rust changes. Everything else below
+is a gate CI will fail you on, including the two PyInstaller builds, which catch imports
+that work in development and break once frozen.
 
 `agent-kit/references/ci-gates.md` documents which workflow job each gate comes from. If
 you change this list, change that file too.
@@ -30,16 +35,19 @@ docs-only change does not need `cargo test`.
 Runs on every `.md` in the repository regardless of what changed.
 
 ```bash
-npx markdownlint-cli2 --config .github/.markdownlint-cli2.jsonc
+npx markdownlint-cli2@0.22.1 --config .github/.markdownlint-cli2.jsonc
 ```
+
+The version matches the action CI uses. Leave it pinned, or you will be linting against a
+different release than the one that decides your build.
 
 Errors from paths inside local virtualenvs (`.env/`, `.docs-env/`, `.sync-env/`,
 `site-packages/`) are pre-existing noise, not caused by the change. Ignore them and say so.
 
 ## 3. Agent hook tests
 
-Only needed if the diff touches `scripts/agent-format-hook*.mjs`, but it is fast and needs
-no dependencies.
+CI runs this on every PR, so run it on every PR too, whatever the diff touches. It needs no
+dependencies and finishes in under a second.
 
 ```bash
 node scripts/agent-format-hook.test.mjs
@@ -76,7 +84,20 @@ If the black hook reformats files, that is a pass with changes — re-stage them
 resolve a formatting disagreement by running `ruff format`; Ruff is configured at 300
 columns here and would reflow the entire codebase.
 
+Then the two frozen builds, which CI runs before the tests and which fail more often than
+the tests do. A dependency that is imported dynamically passes `pytest` and dies here.
+
+```bash
+(cd backend && pip install -r requirements.txt && pyinstaller main.py --name PictoPy_Server --onedir --distpath dist)
+(cd sync-microservice && pip install -r requirements.txt && pyinstaller main.py --name PictoPy_Sync_Microservice --onedir --distpath dist)
+```
+
+Skip these only for a change that touches no Python at all, and say that you skipped them.
+
 ## 6. Rust
+
+`cargo fmt` is a CI gate. `cargo test` is not run by any PR workflow, but `CONTRIBUTING.md`
+asks for it, so run it on any `src-tauri/` change.
 
 ```bash
 (cd frontend/src-tauri && cargo fmt -- --check)

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -69,4 +69,9 @@ No virtualenv is committed. Create your own and
 ## Formatting
 
 **black**, 88 columns. Never `ruff format` — see the root `AGENTS.md` for why.
-Verify with `pre-commit run --config ../.pre-commit-config.yaml --all-files`.
+
+Verify from the repository root, like every other command in these files:
+
+```bash
+pre-commit run --config .pre-commit-config.yaml --all-files
+```

--- a/docs/ai-contributing.md
+++ b/docs/ai-contributing.md
@@ -64,12 +64,15 @@ relevant file, or let it find them through `agent-kit/README.md`.
 The agent-skills ecosystem publishes installable skills, for example:
 
 ```bash
-npx skills add shadcn/ui
+npx skills@1.5.21 add shadcn/ui#<reviewed-tag-or-commit>
 ```
 
+Pin the installer and the skill. Left unpinned, both can change under you after you have
+read them, and a skill is a set of instructions an agent will follow on this codebase.
+
 This installs into `.claude/skills/` or `.agents/skills/` and stays updatable in place with
-`npx skills update`. **Leave it where the installer put it** — moving it into `agent-kit/`
-breaks updates. Record what you adopted and why in
+`npx skills@1.5.21 update`. **Leave it where the installer put it** — moving it into
+`agent-kit/` breaks updates. Record what you adopted, at which revision, and why in
 `agent-kit/references/third-party-skills.md`.
 
 ## Keeping it from rotting

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -81,6 +81,8 @@ the rendered output, not implementation details. Run with `npm test`.
 
 ## Before you finish
 
+From the repository root, so the `cd` does not leak into whatever you run next:
+
 ```bash
-npm run lint:check && npm run format:check && npm test
+(cd frontend && npm run lint:check && npm run format:check && npm test)
 ```

--- a/frontend/src-tauri/AGENTS.md
+++ b/frontend/src-tauri/AGENTS.md
@@ -23,11 +23,14 @@ Forgetting step 2 or 3 produces a runtime error with no compile-time warning. Ch
 
 ## Formatting and tests
 
-`cargo fmt` is CI-enforced as `cargo fmt -- --check`. Run it before pushing.
+`cargo fmt` is CI-enforced as `cargo fmt -- --check`. Run it before pushing. `cargo test` is
+not a CI gate, but `CONTRIBUTING.md` asks for it on any change here.
+
+From the repository root, so the `cd` does not leak into whatever you run next:
 
 ```bash
-cargo fmt
-cargo test
+(cd frontend/src-tauri && cargo fmt)
+(cd frontend/src-tauri && cargo test)
 ```
 
 ## Versioning

--- a/scripts/agent-format-hook.test.mjs
+++ b/scripts/agent-format-hook.test.mjs
@@ -2,7 +2,7 @@
 // Regression tests for the agent format hook.
 //
 // Run: node scripts/agent-format-hook.test.mjs
-// Also runs in CI, in the Linting job of .github/workflows/pr-check-tests.yml.
+// Also runs in CI, in the Linting job of .github/workflows/lint.yml.
 //
 // Two layers: the guard and exclusion helpers directly, then the real entrypoint
 // as a subprocess, because Claude Code depends on its exit codes (2 blocks, 0 allows).


### PR DESCRIPTION
Addresses the 7 review comments left on #1453. They were all about the agent
instruction files from #1408, which is already merged, so they are fixed here against
main instead of in the album PR.

What changed:

- `npx skills add` ran unpinned and installed from a repo's default branch. Both move on
  their own, so a skill could change the instructions an agent follows here after someone
  had approved it. The installer is pinned now and the skill needs a reviewed tag or
  commit, recorded in the provenance table.
- The pre-PR check said it ran the same checks as CI but left out both PyInstaller builds,
  treated the agent hook tests as optional, and listed `cargo test` without saying no
  workflow runs it. You could pass everything locally and still fail the build. The backend
  endpoint playbook was missing the same builds.
- `markdownlint-cli2` is pinned to 0.22.1, the version CI's action uses. Bare `npx` resolves
  to 0.23.2 today, so the documented local command was checking against a different release
  than the one deciding the build.
- The area AGENTS.md files gave commands with no working directory while the root file says
  everything runs from the repository root. The backend one only worked from inside
  `backend/`. All wrapped now.
- Codex does support hooks, via `hooks.json` or an inline `[hooks]` table, so the note now
  says this repository configures none rather than that the feature does not exist.
- The hook test header still named the workflow the Linting job lived in before it moved to
  `lint.yml`.

Docs only, plus one comment line in `scripts/agent-format-hook.test.mjs`. Hook tests still
pass 53/53, and markdownlint at the pinned version reports nothing in committed files.

One nitpick from that review is not taken: moving the `Agent hook tests` step below
`Install frontend dependencies` in `lint.yml`. The test only asserts excluded paths are left
alone, which needs no formatter, and running it before `npm ci` is deliberate so it fails
fast.
