### PR TITLE
Indexing works in parallel instead of series.

### DIFF
--- a/backend/app/config/settings.py
+++ b/backend/app/config/settings.py
@@ -230,3 +230,7 @@ PICTO_CLUSTERING_BLUR_THRESHOLD = _get_env_float(
 PICTO_CLUSTERING_MIN_FACE_SIZE = _get_env_int(
     "PICTO_CLUSTERING_MIN_FACE_SIZE", 1000, min_value=1
 )
+
+
+# Separate pool for folder indexing so it never queues behind AI tagging.
+INDEXING_MAX_WORKERS = _get_env_int("INDEXING_MAX_WORKERS", 2, min_value=1, max_value=8)

--- a/backend/app/routes/dependencies.py
+++ b/backend/app/routes/dependencies.py
@@ -5,5 +5,5 @@ from starlette.datastructures import State
 
 
 def get_state(request: Request) -> State:
-    """Application state, which is where the shared executor lives."""
+    """Application state, which is where the shared executors live."""
     return request.app.state

--- a/backend/app/routes/folders.py
+++ b/backend/app/routes/folders.py
@@ -1,70 +1,68 @@
-from fastapi import APIRouter, HTTPException, status, Depends
-from typing import List, Tuple
+import os
+from concurrent.futures import Future, ProcessPoolExecutor
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from starlette.datastructures import State
+
 from app.database.folders import (
-    db_update_parent_ids_for_subtree,
-    db_folder_exists,
-    db_find_parent_folder_id,
-    db_enable_ai_tagging_batch,
-    db_disable_ai_tagging_batch,
-    db_delete_folders_batch,
-    db_get_direct_child_folders,
-    db_get_folder_ids_by_path_prefix,
-    db_get_all_folder_details,
-    db_set_tagging_completed,
-    db_update_folder_indexing_status,
     INDEXING_COMPLETED,
     INDEXING_IN_PROGRESS,
     INDEXING_INTERRUPTED,
+    db_delete_folders_batch,
+    db_disable_ai_tagging_batch,
+    db_enable_ai_tagging_batch,
+    db_find_parent_folder_id,
+    db_folder_exists,
+    db_get_all_folder_details,
+    db_get_direct_child_folders,
+    db_get_folder_ids_by_path_prefix,
+    db_set_tagging_completed,
+    db_update_folder_indexing_status,
+    db_update_parent_ids_for_subtree,
 )
 from app.logging.setup_logging import get_logger
-from starlette.datastructures import State
-
 from app.routes.dependencies import get_state
 from app.schemas.folders import (
+    AddFolderData,
     AddFolderRequest,
     AddFolderResponse,
-    AddFolderData,
-    ErrorResponse,
-    UpdateAITaggingRequest,
-    UpdateAITaggingResponse,
-    UpdateAITaggingData,
+    DeleteFoldersData,
     DeleteFoldersRequest,
     DeleteFoldersResponse,
-    DeleteFoldersData,
+    ErrorResponse,
+    FolderDetails,
+    GetAllFoldersData,
+    GetAllFoldersResponse,
+    SyncFolderData,
     SyncFolderRequest,
     SyncFolderResponse,
-    SyncFolderData,
-    GetAllFoldersResponse,
-    GetAllFoldersData,
-    FolderDetails,
+    UpdateAITaggingData,
+    UpdateAITaggingRequest,
+    UpdateAITaggingResponse,
 )
-import os
+from app.utils.API import API_util_restart_sync_microservice_watcher
+from app.utils.face_clusters import cluster_util_face_clusters_sync
 from app.utils.folders import (
     folder_util_add_folder_tree,
     folder_util_add_multiple_folder_trees,
     folder_util_delete_obsolete_folders,
     folder_util_get_filesystem_direct_child_folders,
 )
-from concurrent.futures import ProcessPoolExecutor
 from app.utils.images import (
     image_util_process_folder_images,
-    image_util_process_untagged_images,
     image_util_process_unembedded_images,
-)
-from app.utils.videos import (
-    video_util_process_folder_videos,
-    video_util_process_untagged_videos,
-    video_util_process_unembedded_frames,
+    image_util_process_untagged_images,
 )
 from app.utils.model_bootstrap import ensure_ai_tagging_models
 from app.utils.semantic_labels import (
     semantic_util_score_images,
     semantic_util_score_videos,
 )
-from app.utils.face_clusters import cluster_util_face_clusters_sync
-from app.utils.API import API_util_restart_sync_microservice_watcher
-
-from concurrent.futures import Future, ProcessPoolExecutor
+from app.utils.videos import (
+    video_util_process_folder_videos,
+    video_util_process_unembedded_frames,
+    video_util_process_untagged_videos,
+)
 
 # Initialize logger
 logger = get_logger(__name__)
@@ -183,7 +181,7 @@ def post_AI_tagging_enabled_sequence():
 
 
 def post_sync_folder_sequence(
-    folder_path: str, folder_id: int, added_folders: List[Tuple[str, str]]
+    folder_path: str, folder_id: int, added_folders: list[tuple[str, str]]
 ):
     """
     Post-sync sequence for a folder.
@@ -322,7 +320,7 @@ def add_folder(request: AddFolderRequest, app_state: State = Depends(get_state))
             detail=ErrorResponse(
                 success=False,
                 error="Internal server error",
-                message=f"Unable to add folder: {str(e)}",
+                message=f"Unable to add folder: {e!s}",
             ).model_dump(),
         )
 
@@ -368,7 +366,7 @@ def enable_ai_tagging(
             detail=ErrorResponse(
                 success=False,
                 error="Internal server error",
-                message=f"Unable to enable AI tagging: {str(e)}",
+                message=f"Unable to enable AI tagging: {e!s}",
             ).model_dump(),
         )
 
@@ -409,7 +407,7 @@ def disable_ai_tagging(request: UpdateAITaggingRequest):
             detail=ErrorResponse(
                 success=False,
                 error="Internal server error",
-                message=f"Unable to disable AI tagging: {str(e)}",
+                message=f"Unable to disable AI tagging: {e!s}",
             ).model_dump(),
         )
 
@@ -450,7 +448,7 @@ def delete_folders(request: DeleteFoldersRequest):
             detail=ErrorResponse(
                 success=False,
                 error="Internal server error",
-                message=f"Unable to delete folders: {str(e)}",
+                message=f"Unable to delete folders: {e!s}",
             ).model_dump(),
         )
 
@@ -528,7 +526,7 @@ def sync_folder(request: SyncFolderRequest, app_state: State = Depends(get_state
             detail=ErrorResponse(
                 success=False,
                 error="Internal server error",
-                message=f"Unable to sync folder: {str(e)}",
+                message=f"Unable to sync folder: {e!s}",
             ).model_dump(),
         )
 
@@ -583,6 +581,6 @@ def get_all_folders():
             detail=ErrorResponse(
                 success=False,
                 error="Internal server error",
-                message=f"Unable to retrieve folders: {str(e)}",
+                message=f"Unable to retrieve folders: {e!s}",
             ).model_dump(),
         )

--- a/backend/app/routes/folders.py
+++ b/backend/app/routes/folders.py
@@ -64,6 +64,8 @@ from app.utils.semantic_labels import (
 from app.utils.face_clusters import cluster_util_face_clusters_sync
 from app.utils.API import API_util_restart_sync_microservice_watcher
 
+from concurrent.futures import Future, ProcessPoolExecutor
+
 # Initialize logger
 logger = get_logger(__name__)
 
@@ -88,12 +90,17 @@ def _curate_memories(trigger: str) -> None:
         logger.error(f"Memory curation failed after {trigger}: {e}")
 
 
-def _queue_post_index_tagging_sweep(app_state: State) -> None:
+def _queue_post_index_tagging_sweep(index_future: Future, app_state: State) -> None:
     """
     Runs after folder indexing completes to trigger a follow-up tagging sweep.
     Prevents images indexed after an earlier tagging pass from being missed.
     """
     try:
+        if index_future.result() is not True:
+            logger.warning(
+                "Skipping post-index tagging sweep: indexing did not complete"
+            )
+            return
         app_state.executor.submit(post_AI_tagging_enabled_sequence)
     except Exception as e:
         logger.error(f"Failed to queue post-index tagging sweep: {e}")
@@ -287,7 +294,7 @@ def add_folder(request: AddFolderRequest, app_state: State = Depends(get_state))
         # pool is free, a sweep can start (and finish, finding nothing) before
         # this folder's images are even in the DB - see the callback docstring.
         index_future.add_done_callback(
-            lambda _f: _queue_post_index_tagging_sweep(app_state)
+            lambda future: _queue_post_index_tagging_sweep(future, app_state)
         )
 
         return AddFolderResponse(

--- a/backend/app/routes/folders.py
+++ b/backend/app/routes/folders.py
@@ -88,6 +88,17 @@ def _curate_memories(trigger: str) -> None:
         logger.error(f"Memory curation failed after {trigger}: {e}")
 
 
+def _queue_post_index_tagging_sweep(app_state: State) -> None:
+    """
+    Runs after folder indexing completes to trigger a follow-up tagging sweep.
+    Prevents images indexed after an earlier tagging pass from being missed.
+    """
+    try:
+        app_state.executor.submit(post_AI_tagging_enabled_sequence)
+    except Exception as e:
+        logger.error(f"Failed to queue post-index tagging sweep: {e}")
+
+
 def post_folder_add_sequence(folder_path: str, folder_id: int):
     """
     Post-addition sequence for a folder.
@@ -265,9 +276,19 @@ def add_folder(request: AddFolderRequest, app_state: State = Depends(get_state))
         # Step 5: Update parent ids for the subtree
         db_update_parent_ids_for_subtree(request.folder_path, folder_map)
 
-        # Step 6: Call the post-addition sequence in a separate process
-        executor: ProcessPoolExecutor = app_state.executor
-        executor.submit(post_folder_add_sequence, request.folder_path, root_folder_id)
+        # Step 6: Call the post-addition sequence in a separate process.
+        # Own pool so this never waits on another folder's AI tagging.
+        indexing_executor: ProcessPoolExecutor = app_state.indexing_executor
+        index_future = indexing_executor.submit(
+            post_folder_add_sequence, request.folder_path, root_folder_id
+        )
+        # Also queue a catch-up tagging sweep for once indexing lands. Needed
+        # because indexing and tagging are now on separate pools: if the AI
+        # pool is free, a sweep can start (and finish, finding nothing) before
+        # this folder's images are even in the DB - see the callback docstring.
+        index_future.add_done_callback(
+            lambda _f: _queue_post_index_tagging_sweep(app_state)
+        )
 
         return AddFolderResponse(
             data=AddFolderData(

--- a/backend/main.py
+++ b/backend/main.py
@@ -7,7 +7,11 @@ import os
 import json
 import asyncio
 
-from app.config.settings import DATABASE_PATH, THUMBNAIL_IMAGES_PATH
+from app.config.settings import (
+    DATABASE_PATH,
+    THUMBNAIL_IMAGES_PATH,
+    INDEXING_MAX_WORKERS,
+)
 from uvicorn import Config, Server
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -87,6 +91,8 @@ async def lifespan(app: FastAPI):
     # Needs the mappings table (created above): semantic labels register
     # there as class_ids >= SEMANTIC_CLASS_ID_OFFSET
     semantic_util_sync_vocabulary()
+    # New pool, just for folder indexing, so it never queues behind AI tagging
+    app.state.indexing_executor = ProcessPoolExecutor(max_workers=INDEXING_MAX_WORKERS)
     # Create ProcessPoolExecutor and attach it to app.state
     app.state.executor = ProcessPoolExecutor(max_workers=1)
     # Self-gating no-ops unless something is missing/stale (fresh install,
@@ -104,6 +110,7 @@ async def lifespan(app: FastAPI):
     finally:
         cleanup_task.cancel()
         await asyncio.gather(cleanup_task, return_exceptions=True)
+        app.state.indexing_executor.shutdown(wait=True)
         app.state.executor.shutdown(wait=True)
 
 

--- a/backend/tests/test_folders.py
+++ b/backend/tests/test_folders.py
@@ -9,7 +9,7 @@ from unittest.mock import patch, MagicMock
 import tempfile
 import os
 import shutil
-from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures import Future, ProcessPoolExecutor
 
 
 from app.routes.folders import router as folders_router
@@ -105,6 +105,7 @@ def app_with_state(test_db):
 
     # Mock the executor state
     app.state.executor = MagicMock(spec=ProcessPoolExecutor)
+    app.state.indexing_executor = MagicMock(spec=ProcessPoolExecutor)
 
     return app
 
@@ -361,9 +362,51 @@ class TestFoldersAPI:
 
         assert response.status_code == 200
 
-        # Verify that the executor.submit was called for background processing
+        # Indexing pool used, AI/misc pool untouched
         # Access the app state through the client
         app_state = client.app.state
+        app_state.indexing_executor.submit.assert_called_once()
+        app_state.executor.submit.assert_not_called()
+
+    @patch("app.routes.folders.folder_util_add_folder_tree")
+    @patch("app.routes.folders.db_update_parent_ids_for_subtree")
+    @patch("app.routes.folders.db_find_parent_folder_id")
+    @patch("app.routes.folders.db_folder_exists")
+    def test_add_folder_queues_tagging_sweep_once_indexing_completes(
+        self,
+        mock_folder_exists,
+        mock_find_parent,
+        mock_update_parent_ids,
+        mock_add_folder_tree,
+        client,
+        temp_folder_structure,
+    ):
+        """A tagging sweep can start and finish before this folder's images
+        are indexed (see _queue_post_index_tagging_sweep). Once indexing's
+        future resolves, a catch-up sweep must be queued on the AI pool so
+        those images don't sit untagged forever."""
+        mock_folder_exists.return_value = False
+        mock_find_parent.return_value = None
+        mock_add_folder_tree.return_value = ("test-folder-id", {})
+        mock_update_parent_ids.return_value = None
+
+        app_state = client.app.state
+        index_future: Future = Future()
+        app_state.indexing_executor.submit.return_value = index_future
+
+        request_data = {
+            "folder_path": temp_folder_structure["photos"],
+            "parent_folder_id": None,
+            "taggingCompleted": False,
+        }
+        response = client.post("/folders/add-folder", json=request_data)
+        assert response.status_code == 200
+
+        # Indexing hasn't finished yet - no sweep queued yet
+        app_state.executor.submit.assert_not_called()
+
+        # Indexing finishes -> catch-up sweep must be queued now
+        index_future.set_result(True)
         app_state.executor.submit.assert_called_once()
 
     # ============================================================================


### PR DESCRIPTION
###  Addressed Issues:

Fixes #1436 : Indexing works in series in the application while folder Uploads.

- Fixes the issue where newly uploaded folders wait for a previous folder's AI Tagging pass before their own indexing can start.

###  Screenshots/Recordings:

**PictoPy Before:**

https://github.com/user-attachments/assets/048f5256-1325-4794-b4bc-2b1fb3b12465

**PictoPy After:**

https://github.com/user-attachments/assets/d8b12a05-1274-4638-a8a2-25b294d626c2


###  Additional Notes:
**Files changed:** 5

**backend/main.py:** 

Added a dedicated indexing process pool that is initialized and shut down alongside the existing executor.

```
from app.config.settings import (
    DATABASE_PATH,
    THUMBNAIL_IMAGES_PATH,
    INDEXING_MAX_WORKERS,
)
```
`app.state.indexing_executor = ProcessPoolExecutor(max_workers=INDEXING_MAX_WORKERS)`

**backend/app/config/settings.py:** 

Added a configurable `INDEXING_MAX_WORKERS` setting to control the size of the dedicated indexing pool.

```
# Separate pool for folder indexing so it never queues behind AI tagging.
INDEXING_MAX_WORKERS = _get_env_int("INDEXING_MAX_WORKERS", 2, min_value=1, max_value=8)
```

**backend/app/routes/folders.py:**

- Updated add_folder to submit indexing jobs to the dedicated indexing pool instead of the shared executor.

- Added a follow-up tagging sweep that is queued only after folder indexing completes, ensuring images indexed after an earlier tagging pass are not missed.

```
def _queue_post_index_tagging_sweep(app_state: State) -> None:
    """
    Runs after folder indexing completes to trigger a follow-up tagging sweep.
    Prevents images indexed after an earlier tagging pass from being missed.
    """
    try:
        app_state.executor.submit(post_AI_tagging_enabled_sequence)
    except Exception as e:
        logger.error(f"Failed to queue post-index tagging sweep: {e}")
```

**backend/tests/test_folders.py:**

- mocks the new pool; asserts indexing runs on it and the original pool is untouched; new test proves the catch-up sweep is queued only once the indexing future resolves


### Conclusion:
- Now, indexing process works in parallel instead of waiting for another folder to complete AI tagging process, and if a folder is empty it shows up instantly instead of waiting.

(Still AI tagging process works in series but it is alright because it is in the need to go through each and every image, and changing it requires a lot of redesigning.)


### AI Usage Disclosure:

We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact. AI slop is strongly discouraged and may lead to banning and blocking. Do not spam our repos with AI slop.

Check one of the checkboxes below:

- [ ] This PR does not contain AI-generated code at all.
- [x] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools: Claude Sonnet - 5


## Checklist
<!-- Mark items with [x] to indicate completion -->
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [x] If applicable, I have made corresponding changes or additions to the documentation
- [x] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added configurable parallel processing for folder indexing, with a supported range of 1–8 workers.
- Added automatic AI-tagging sweeps after successful folder indexing.

## Performance
- Folder indexing now runs independently from other background work, improving workload isolation and responsiveness.

## Bug Fixes
- Ensured post-index tagging starts only after indexing completes successfully.

## Tests
- Added coverage for separate indexing and deferred tagging behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->