### PR TITLE
Cropped Image-fix in addImagesCropDialog

### DIFF
--- a/frontend/src/components/Albums/AddImagesToAlbumDialog.tsx
+++ b/frontend/src/components/Albums/AddImagesToAlbumDialog.tsx
@@ -134,9 +134,14 @@ export const AddImagesToAlbumDialog: React.FC<AddImagesToAlbumDialogProps> = ({
             ) : (
               <div className="grid grid-cols-4 gap-3 p-4">
                 {filteredImages.map((image) => (
-                  <div
+                  <button
                     key={image.id}
-                    className="group hover:border-primary relative cursor-pointer overflow-hidden rounded-md border-2 transition-all"
+                    type="button"
+                    aria-pressed={selectedImages.has(image.id)}
+                    aria-label={
+                      image.path.split(/[/\\]/).pop() || 'Untitled image'
+                    }
+                    className="group hover:border-primary focus-visible:ring-ring relative w-full cursor-pointer appearance-none overflow-hidden rounded-md border-2 bg-transparent p-0 text-left transition-all focus-visible:ring-2 focus-visible:outline-none"
                     style={{
                       borderColor: selectedImages.has(image.id)
                         ? 'hsl(var(--primary))'
@@ -170,7 +175,7 @@ export const AddImagesToAlbumDialog: React.FC<AddImagesToAlbumDialogProps> = ({
                         </div>
                       )}
                     </AspectRatio>
-                  </div>
+                  </button>
                 ))}
               </div>
             )}

--- a/frontend/src/components/Albums/AddImagesToAlbumDialog.tsx
+++ b/frontend/src/components/Albums/AddImagesToAlbumDialog.tsx
@@ -156,7 +156,7 @@ export const AddImagesToAlbumDialog: React.FC<AddImagesToAlbumDialogProps> = ({
                         src={convertFileSrc(image.thumbnailPath)}
                         alt={image.path.split('/').pop() || ''}
                         loading="lazy"
-                        className="max-h-full max-w-full object-contain transition-transform group-hover:scale-105"
+                        className="max-h-full max-w-full object-contain"
                         onError={(e) => {
                           const img = e.target as HTMLImageElement;
                           img.onerror = null;

--- a/frontend/src/components/Albums/AddImagesToAlbumDialog.tsx
+++ b/frontend/src/components/Albums/AddImagesToAlbumDialog.tsx
@@ -135,7 +135,7 @@ export const AddImagesToAlbumDialog: React.FC<AddImagesToAlbumDialogProps> = ({
                 {filteredImages.map((image) => (
                   <div
                     key={image.id}
-                    className="group hover:border-primary relative aspect-square cursor-pointer overflow-hidden rounded-md border-2 transition-all"
+                    className="group hover:border-primary bg-muted relative aspect-square cursor-pointer overflow-hidden rounded-md border-2 transition-all"
                     style={{
                       borderColor: selectedImages.has(image.id)
                         ? 'hsl(var(--primary))'
@@ -143,21 +143,24 @@ export const AddImagesToAlbumDialog: React.FC<AddImagesToAlbumDialogProps> = ({
                     }}
                     onClick={() => handleImageToggle(image.id)}
                   >
-                    <img
-                      src={convertFileSrc(image.thumbnailPath)}
-                      alt=""
-                      className="h-full w-full object-cover"
-                      onError={(e) => {
-                        const img = e.target as HTMLImageElement;
-                        img.onerror = null;
-                        const placeholder = window.matchMedia(
-                          '(prefers-color-scheme: dark)',
-                        ).matches
-                          ? '/placeholder-album.svg'
-                          : '/placeholder-album-light.svg';
-                        img.src = placeholder;
-                      }}
-                    />
+                    <div className="bg-muted flex h-full w-full items-center justify-center">
+                      <img
+                        src={convertFileSrc(image.thumbnailPath)}
+                        alt={image.path.split('/').pop() || ''}
+                        loading="lazy"
+                        className="max-h-full max-w-full object-contain transition-transform group-hover:scale-105"
+                        onError={(e) => {
+                          const img = e.target as HTMLImageElement;
+                          img.onerror = null;
+                          const placeholder = window.matchMedia(
+                            '(prefers-color-scheme: dark)',
+                          ).matches
+                            ? '/placeholder-album.svg'
+                            : '/placeholder-album-light.svg';
+                          img.src = placeholder;
+                        }}
+                      />
+                    </div>
 
                     {selectedImages.has(image.id) && (
                       <div className="bg-primary/20 absolute inset-0 flex items-center justify-center">

--- a/frontend/src/components/Albums/AddImagesToAlbumDialog.tsx
+++ b/frontend/src/components/Albums/AddImagesToAlbumDialog.tsx
@@ -156,7 +156,7 @@ export const AddImagesToAlbumDialog: React.FC<AddImagesToAlbumDialogProps> = ({
                         loading="lazy"
                         className="h-full w-full object-cover"
                         onError={(e) => {
-                          const img = e.target as HTMLImageElement;
+                          const img = e.currentTarget;
                           img.onerror = null;
                           const placeholder = window.matchMedia(
                             '(prefers-color-scheme: dark)',

--- a/frontend/src/components/Albums/AddImagesToAlbumDialog.tsx
+++ b/frontend/src/components/Albums/AddImagesToAlbumDialog.tsx
@@ -16,11 +16,10 @@ import { usePictoMutation, usePictoQuery } from '@/hooks/useQueryExtension';
 import { addImagesToAlbum, fetchAllImages } from '@/api/api-functions';
 import { showInfoDialog } from '@/features/infoDialogSlice';
 import { useMutationFeedback } from '@/hooks/useMutationFeedback';
+import { AspectRatio } from '@/components/ui/aspect-ratio';
 import { Image } from '@/types/Media';
 import { convertFileSrc } from '@tauri-apps/api/core';
 import { Search, Check } from 'lucide-react';
-import { useTheme } from '@/contexts/ThemeContext';
-import { cn } from '@/lib/utils';
 
 export const AddImagesToAlbumDialog: React.FC<AddImagesToAlbumDialogProps> = ({
   isOpen,
@@ -32,12 +31,6 @@ export const AddImagesToAlbumDialog: React.FC<AddImagesToAlbumDialogProps> = ({
   const [selectedImages, setSelectedImages] = useState<Set<string>>(new Set());
   const [searchQuery, setSearchQuery] = useState('');
   const [allImages, setAllImages] = useState<Image[]>([]);
-
-  const { theme } = useTheme();
-  const isLightMode = theme === 'light';
-  const placeholderSrc = isLightMode
-    ? '/placeholder-album-light.svg'
-    : '/placeholder-album.svg';
 
   const { data: imagesData, isLoading } = usePictoQuery({
     queryKey: ['images'],
@@ -106,7 +99,7 @@ export const AddImagesToAlbumDialog: React.FC<AddImagesToAlbumDialogProps> = ({
 
   return (
     <Dialog open={isOpen} onOpenChange={handleClose}>
-      <DialogContent className="flex max-h-[80vh] flex-col overflow-hidden p-0 sm:max-w-[700px]">
+      <DialogContent className="flex max-h-[85vh] flex-col overflow-hidden p-0 sm:max-w-[820px]">
         <DialogHeader className="px-6 pt-6">
           <DialogTitle>Add Images to "{albumName}"</DialogTitle>
           <DialogDescription>
@@ -143,35 +136,40 @@ export const AddImagesToAlbumDialog: React.FC<AddImagesToAlbumDialogProps> = ({
                 {filteredImages.map((image) => (
                   <div
                     key={image.id}
-                    className={cn(
-                      'group bg-muted relative aspect-square cursor-pointer overflow-hidden rounded-md border-2 transition-all',
-                      selectedImages.has(image.id)
-                        ? 'border-primary'
-                        : 'hover:border-primary border-transparent',
-                    )}
+                    className="group hover:border-primary relative cursor-pointer overflow-hidden rounded-md border-2 transition-all"
+                    style={{
+                      borderColor: selectedImages.has(image.id)
+                        ? 'hsl(var(--primary))'
+                        : 'transparent',
+                    }}
                     onClick={() => handleImageToggle(image.id)}
                   >
-                    <div className="bg-muted flex h-full w-full items-center justify-center">
+                    <AspectRatio ratio={1}>
                       <img
-                        src={convertFileSrc(image.thumbnailPath)}
-                        alt={image.path.split('/').pop() || ''}
+                        src={convertFileSrc(image.thumbnailPath || image.path)}
+                        alt=""
                         loading="lazy"
-                        className="max-h-full max-w-full object-contain"
+                        className="h-full w-full object-cover"
                         onError={(e) => {
                           const img = e.target as HTMLImageElement;
                           img.onerror = null;
-                          img.src = placeholderSrc;
+                          const placeholder = window.matchMedia(
+                            '(prefers-color-scheme: dark)',
+                          ).matches
+                            ? '/placeholder-album.svg'
+                            : '/placeholder-album-light.svg';
+                          img.src = placeholder;
                         }}
                       />
-                    </div>
 
-                    {selectedImages.has(image.id) && (
-                      <div className="bg-primary/20 absolute inset-0 flex items-center justify-center">
-                        <div className="bg-primary flex h-8 w-8 items-center justify-center rounded-full">
-                          <Check className="text-primary-foreground h-5 w-5" />
+                      {selectedImages.has(image.id) && (
+                        <div className="bg-primary/20 absolute inset-0 flex items-center justify-center">
+                          <div className="bg-primary flex h-8 w-8 items-center justify-center rounded-full">
+                            <Check className="text-primary-foreground h-5 w-5" />
+                          </div>
                         </div>
-                      </div>
-                    )}
+                      )}
+                    </AspectRatio>
                   </div>
                 ))}
               </div>

--- a/frontend/src/components/Albums/AddImagesToAlbumDialog.tsx
+++ b/frontend/src/components/Albums/AddImagesToAlbumDialog.tsx
@@ -19,6 +19,8 @@ import { useMutationFeedback } from '@/hooks/useMutationFeedback';
 import { Image } from '@/types/Media';
 import { convertFileSrc } from '@tauri-apps/api/core';
 import { Search, Check } from 'lucide-react';
+import { useTheme } from '@/contexts/ThemeContext';
+import { cn } from '@/lib/utils';
 
 export const AddImagesToAlbumDialog: React.FC<AddImagesToAlbumDialogProps> = ({
   isOpen,
@@ -30,6 +32,12 @@ export const AddImagesToAlbumDialog: React.FC<AddImagesToAlbumDialogProps> = ({
   const [selectedImages, setSelectedImages] = useState<Set<string>>(new Set());
   const [searchQuery, setSearchQuery] = useState('');
   const [allImages, setAllImages] = useState<Image[]>([]);
+
+  const { theme } = useTheme();
+  const isLightMode = theme === 'light';
+  const placeholderSrc = isLightMode
+    ? '/placeholder-album-light.svg'
+    : '/placeholder-album.svg';
 
   const { data: imagesData, isLoading } = usePictoQuery({
     queryKey: ['images'],
@@ -135,12 +143,12 @@ export const AddImagesToAlbumDialog: React.FC<AddImagesToAlbumDialogProps> = ({
                 {filteredImages.map((image) => (
                   <div
                     key={image.id}
-                    className="group hover:border-primary bg-muted relative aspect-square cursor-pointer overflow-hidden rounded-md border-2 transition-all"
-                    style={{
-                      borderColor: selectedImages.has(image.id)
-                        ? 'hsl(var(--primary))'
-                        : 'transparent',
-                    }}
+                    className={cn(
+                      'group bg-muted relative aspect-square cursor-pointer overflow-hidden rounded-md border-2 transition-all',
+                      selectedImages.has(image.id)
+                        ? 'border-primary'
+                        : 'hover:border-primary border-transparent',
+                    )}
                     onClick={() => handleImageToggle(image.id)}
                   >
                     <div className="bg-muted flex h-full w-full items-center justify-center">
@@ -152,12 +160,7 @@ export const AddImagesToAlbumDialog: React.FC<AddImagesToAlbumDialogProps> = ({
                         onError={(e) => {
                           const img = e.target as HTMLImageElement;
                           img.onerror = null;
-                          const placeholder = window.matchMedia(
-                            '(prefers-color-scheme: dark)',
-                          ).matches
-                            ? '/placeholder-album.svg'
-                            : '/placeholder-album-light.svg';
-                          img.src = placeholder;
+                          img.src = placeholderSrc;
                         }}
                       />
                     </div>


### PR DESCRIPTION
###  Addressed Issues:

Fixes #1459 : Images appear cropped in the "Add Image" window when adding images to an album.

###  Screenshots/Recordings:

PictoPy Before:

https://github.com/user-attachments/assets/8024402e-01e9-4b51-a0d3-11bbf31383f4

PictoPy After:

Portraits:
<img width="693" height="550" alt="Screenshot 2026-08-06 at 2 33 53 PM" src="https://github.com/user-attachments/assets/cdda9031-cba0-46cf-b328-88cbad895451" />

Landscapes:
<img width="695" height="544" alt="Screenshot 2026-08-06 at 9 27 05 AM" src="https://github.com/user-attachments/assets/00ea1dcf-1de4-406c-9383-a977531da864" />

###  Additional Notes:
### File Changed: 1 
**frontend/src/components/Albums/addImagesToAlbumDialog:**
A little bit of css changes:

```
{filteredImages.map((image) => (
                  <div
                    key={image.id}
                    className="group hover:border-primary bg-muted relative aspect-square cursor-pointer overflow-hidden rounded-md border-2 transition-all"
                    style={{
                      borderColor: selectedImages.has(image.id)
                        ? 'hsl(var(--primary))'
                        : 'transparent',
                    }}
                    onClick={() => handleImageToggle(image.id)}
                  >
                    <div className="bg-muted flex h-full w-full items-center justify-center">
                      <img
                        src={convertFileSrc(image.thumbnailPath)}
                        alt={image.path.split('/').pop() || ''}
                        loading="lazy"
                        className="max-h-full max-w-full object-contain transition-transform group-hover:scale-105"
                        onError={(e) => {
                          const img = e.target as HTMLImageElement;
                          img.onerror = null;
                          const placeholder = window.matchMedia(
                            '(prefers-color-scheme: dark)',
                          ).matches
                            ? '/placeholder-album.svg'
                            : '/placeholder-album-light.svg';
                          img.src = placeholder;
                        }}
                      />
                    </div>

                    {selectedImages.has(image.id) && (
                      <div className="bg-primary/20 absolute inset-0 flex items-center justify-center">
                        <div className="bg-primary flex h-8 w-8 items-center justify-center rounded-full">
                          <Check className="text-primary-foreground h-5 w-5" />
                        </div>
                      </div>
                    )}
                  </div>
                ))}
              </div>
            )}
```
### Fixes:
- This shows the whole image to the user that he is adding and fixes the crop issue.

### One Flaw:

The landscape pictures have a little bit of a blank space on the up and down side of the photo box, but if i fix it , it will end up in the crop. It is possible but it will cut a little bit part from landscape images, currently it shows the whole image.
(if you want me to fix it i can, but i kind of prefer the current version)

### AI Usage Disclosure:

We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact. AI slop is strongly discouraged and may lead to banning and blocking. Do not spam our repos with AI slop.

Check one of the checkboxes below:

- [ ] This PR does not contain AI-generated code at all.
- [x] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools: Claude Sonnet - 5


## Checklist
<!-- Mark items with [x] to indicate completion -->
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [x] If applicable, I have made corresponding changes or additions to the documentation
- [x] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved album thumbnail layout with consistent aspect-ratio containers.
  * Expanded the image-selection dialog for easier browsing.
  * Preserved selection styling, image cropping, and theme-specific load-error placeholders.

* **Performance**
  * Added lazy loading for album images.

* **Accessibility**
  * Improved image selection controls with accessible labels based on file names.

* **Bug Fixes**
  * Improved thumbnail loading by falling back to the original image when a thumbnail is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->