### PR TITLE
feat: share an album over the local network

### DIFF
--- a/backend/app/config/settings.py
+++ b/backend/app/config/settings.py
@@ -18,6 +18,10 @@ else:
 # Microservice URLs
 SYNC_MICROSERVICE_URL = "http://localhost:52124"
 
+# The album share listener. Unlike the two services above this one binds
+# 0.0.0.0, so it is reachable by anything that can route to this machine.
+SHARE_SERVER_PORT = 52125
+
 CONFIDENCE_PERCENT = 0.6
 # Object Detection Models:
 SMALL_OBJ_DETECTION_MODEL = f"{MODEL_EXPORTS_PATH}/YOLOv11_Small.onnx"

--- a/backend/app/database/albums.py
+++ b/backend/app/database/albums.py
@@ -314,6 +314,38 @@ def db_get_album_images(album_id: str):
         conn.close()
 
 
+def db_count_album_images(album_id: str) -> int:
+    """How many images an album holds, without reading every id."""
+    conn = _connect()
+    cursor = conn.cursor()
+    try:
+        cursor.execute(
+            "SELECT COUNT(*) FROM album_images WHERE album_id = ?", (album_id,)
+        )
+        return int(cursor.fetchone()[0])
+    finally:
+        conn.close()
+
+
+def db_album_contains_image(album_id: str, image_id: str) -> bool:
+    """
+    Whether one image belongs to an album.
+
+    Kept separate from db_get_album_images because callers on a request path
+    need a single membership answer, not every id in the album.
+    """
+    conn = _connect()
+    cursor = conn.cursor()
+    try:
+        cursor.execute(
+            "SELECT 1 FROM album_images WHERE album_id = ? AND image_id = ? LIMIT 1",
+            (album_id, image_id),
+        )
+        return cursor.fetchone() is not None
+    finally:
+        conn.close()
+
+
 def db_add_images_to_album(album_id: str, image_ids: list[str]):
     """
     Safely adds images to an album using parameterized queries.

--- a/backend/app/routes/share.py
+++ b/backend/app/routes/share.py
@@ -1,32 +1,31 @@
-from fastapi import APIRouter, Body, HTTPException, Path, status
+from typing import Optional
 
-from app.database.albums import db_get_album, db_get_album_images
+from fastapi import APIRouter, HTTPException, Path, status
+
+from app.database.albums import db_get_album
 from app.logging.setup_logging import get_logger
 from app.schemas.share import (
     CreateShareRequest,
     CreateShareResponse,
     ErrorResponse,
-    ShareErrorResponseEnvelope,
     GetInterfacesResponse,
     GetSharesResponse,
-    Share,
-    ShareInterface,
-    ShareUrl,
     RevokeShareResponse,
+    Share,
+    ShareErrorResponseEnvelope,
+    ShareInterface,
 )
-from app.share.registry import (
-    ShareEntry,
-    share_registry_count,
-    share_registry_create,
-    share_registry_list,
-    share_registry_revoke,
-)
-from app.share.server import share_server_port, share_server_start, share_server_stop
+from app.share.registry import share_registry_list
+from app.share.server import share_server_port
 from app.utils.network import network_util_list_candidates
+from app.utils.share import share_util_create, share_util_describe, share_util_revoke
 
 logger = get_logger(__name__)
 
 router = APIRouter()
+
+_SERVER_ERROR = {500: {"model": ShareErrorResponseEnvelope}}
+_NOT_FOUND = {404: {"model": ShareErrorResponseEnvelope}}
 
 
 def _internal_error(message: str) -> HTTPException:
@@ -38,42 +37,17 @@ def _internal_error(message: str) -> HTTPException:
     )
 
 
-def _album_not_found() -> HTTPException:
+def _not_found(error: str, message: str) -> HTTPException:
     return HTTPException(
         status_code=status.HTTP_404_NOT_FOUND,
-        detail=ErrorResponse(
-            success=False,
-            error="Album Not Found",
-            message="No album exists with the provided ID.",
-        ).model_dump(),
-    )
-
-
-def _to_share(entry: ShareEntry, port: int) -> Share:
-    album = db_get_album(entry.album_id)
-    return Share(
-        token=entry.token,
-        album_id=entry.album_id,
-        # An album deleted while shared leaves the token pointing at nothing;
-        # the viewer 404s, so say so here rather than failing the listing.
-        album_name=album["album_name"] if album else "(deleted album)",
-        image_count=len(db_get_album_images(entry.album_id)),
-        port=port,
-        created_at=entry.created_at.isoformat(),
-        expires_at=entry.expires_at.isoformat() if entry.expires_at else None,
-        urls=[
-            ShareUrl(
-                interface=candidate.interface,
-                ip=candidate.ip,
-                url=f"http://{candidate.ip}:{port}/s/{entry.token}",
-            )
-            for candidate in network_util_list_candidates()
-        ],
+        detail=ErrorResponse(success=False, error=error, message=message).model_dump(),
     )
 
 
 # GET /share/interfaces - Ranked LAN addresses the share could be reached on
-@router.get("/interfaces", response_model=GetInterfacesResponse)
+@router.get(
+    "/interfaces", response_model=GetInterfacesResponse, responses=_SERVER_ERROR
+)
 def get_interfaces() -> GetInterfacesResponse:
     """
     Candidate addresses, best guess first.
@@ -84,26 +58,23 @@ def get_interfaces() -> GetInterfacesResponse:
     return GetInterfacesResponse(
         success=True,
         data=[
-            ShareInterface(
-                interface=candidate.interface,
-                ip=candidate.ip,
-                is_default_route=candidate.is_default_route,
-                looks_virtual=candidate.looks_virtual,
-                is_up=candidate.is_up,
-            )
+            ShareInterface(**vars(candidate))
             for candidate in network_util_list_candidates()
         ],
     )
 
 
 # GET /share/ - List every active share
-@router.get("/", response_model=GetSharesResponse)
+@router.get("/", response_model=GetSharesResponse, responses=_SERVER_ERROR)
 def get_shares() -> GetSharesResponse:
     port = share_server_port()
     if port is None:
         return GetSharesResponse(success=True, data=[])
     return GetSharesResponse(
-        success=True, data=[_to_share(entry, port) for entry in share_registry_list()]
+        success=True,
+        data=[
+            Share(**share_util_describe(entry, port)) for entry in share_registry_list()
+        ],
     )
 
 
@@ -111,10 +82,10 @@ def get_shares() -> GetSharesResponse:
 @router.post(
     "/albums/{album_id}",
     response_model=CreateShareResponse,
-    responses={code: {"model": ShareErrorResponseEnvelope} for code in [404, 500]},
+    responses={**_NOT_FOUND, **_SERVER_ERROR},
 )
 async def create_share(
-    album_id: str = Path(...), body: CreateShareRequest = Body(default=None)
+    album_id: str = Path(...), body: Optional[CreateShareRequest] = None
 ) -> CreateShareResponse:
     """
     Issue a share token and make sure the network listener is up.
@@ -123,22 +94,24 @@ async def create_share(
     album inside PictoPy, while sharing carries its own authorization.
     """
     if not db_get_album(album_id):
-        raise _album_not_found()
+        raise _not_found("Album Not Found", "No album exists with the provided ID.")
 
     try:
-        port = await share_server_start()
+        entry = await share_util_create(
+            album_id, expires_in_minutes=body.expires_in_minutes if body else None
+        )
     except OSError as e:
         raise _internal_error(f"Could not start the share server: {e}") from e
 
-    entry = share_registry_create(
-        album_id, expires_in_minutes=body.expires_in_minutes if body else None
-    )
-    logger.info(f"Sharing album {album_id} on port {port}")
+    port = share_server_port()
+    if port is None:
+        raise _internal_error("The share server stopped before the share was served.")
 
+    logger.info(f"Sharing album {album_id} on port {port}")
     return CreateShareResponse(
         success=True,
         message="Album is now shared on the local network",
-        data=_to_share(entry, port),
+        data=Share(**share_util_describe(entry, port)),
     )
 
 
@@ -146,22 +119,11 @@ async def create_share(
 @router.delete(
     "/{token}",
     response_model=RevokeShareResponse,
-    responses={404: {"model": ShareErrorResponseEnvelope}},
+    responses={**_NOT_FOUND, **_SERVER_ERROR},
 )
 async def revoke_share(token: str = Path(...)) -> RevokeShareResponse:
-    if not share_registry_revoke(token):
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=ErrorResponse(
-                success=False,
-                error="Share Not Found",
-                message="No active share exists with the provided token.",
-            ).model_dump(),
+    if not await share_util_revoke(token):
+        raise _not_found(
+            "Share Not Found", "No active share exists with the provided token."
         )
-
-    # Nothing is being served any more, so stop listening rather than leaving a
-    # port open on the network.
-    if share_registry_count() == 0:
-        await share_server_stop()
-
     return RevokeShareResponse(success=True, message="Share revoked")

--- a/backend/app/routes/share.py
+++ b/backend/app/routes/share.py
@@ -1,0 +1,167 @@
+from fastapi import APIRouter, Body, HTTPException, Path, status
+
+from app.database.albums import db_get_album, db_get_album_images
+from app.logging.setup_logging import get_logger
+from app.schemas.share import (
+    CreateShareRequest,
+    CreateShareResponse,
+    ErrorResponse,
+    ShareErrorResponseEnvelope,
+    GetInterfacesResponse,
+    GetSharesResponse,
+    Share,
+    ShareInterface,
+    ShareUrl,
+    RevokeShareResponse,
+)
+from app.share.registry import (
+    ShareEntry,
+    share_registry_count,
+    share_registry_create,
+    share_registry_list,
+    share_registry_revoke,
+)
+from app.share.server import share_server_port, share_server_start, share_server_stop
+from app.utils.network import network_util_list_candidates
+
+logger = get_logger(__name__)
+
+router = APIRouter()
+
+
+def _internal_error(message: str) -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        detail=ErrorResponse(
+            success=False, error="Internal Server Error", message=message
+        ).model_dump(),
+    )
+
+
+def _album_not_found() -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND,
+        detail=ErrorResponse(
+            success=False,
+            error="Album Not Found",
+            message="No album exists with the provided ID.",
+        ).model_dump(),
+    )
+
+
+def _to_share(entry: ShareEntry, port: int) -> Share:
+    album = db_get_album(entry.album_id)
+    return Share(
+        token=entry.token,
+        album_id=entry.album_id,
+        # An album deleted while shared leaves the token pointing at nothing;
+        # the viewer 404s, so say so here rather than failing the listing.
+        album_name=album["album_name"] if album else "(deleted album)",
+        image_count=len(db_get_album_images(entry.album_id)),
+        port=port,
+        created_at=entry.created_at.isoformat(),
+        expires_at=entry.expires_at.isoformat() if entry.expires_at else None,
+        urls=[
+            ShareUrl(
+                interface=candidate.interface,
+                ip=candidate.ip,
+                url=f"http://{candidate.ip}:{port}/s/{entry.token}",
+            )
+            for candidate in network_util_list_candidates()
+        ],
+    )
+
+
+# GET /share/interfaces - Ranked LAN addresses the share could be reached on
+@router.get("/interfaces", response_model=GetInterfacesResponse)
+def get_interfaces() -> GetInterfacesResponse:
+    """
+    Candidate addresses, best guess first.
+
+    Machines with virtual adapters routinely surface several, so the caller is
+    expected to show this list rather than silently trust the first entry.
+    """
+    return GetInterfacesResponse(
+        success=True,
+        data=[
+            ShareInterface(
+                interface=candidate.interface,
+                ip=candidate.ip,
+                is_default_route=candidate.is_default_route,
+                looks_virtual=candidate.looks_virtual,
+                is_up=candidate.is_up,
+            )
+            for candidate in network_util_list_candidates()
+        ],
+    )
+
+
+# GET /share/ - List every active share
+@router.get("/", response_model=GetSharesResponse)
+def get_shares() -> GetSharesResponse:
+    port = share_server_port()
+    if port is None:
+        return GetSharesResponse(success=True, data=[])
+    return GetSharesResponse(
+        success=True, data=[_to_share(entry, port) for entry in share_registry_list()]
+    )
+
+
+# POST /share/albums/{album_id} - Start sharing an album over the network
+@router.post(
+    "/albums/{album_id}",
+    response_model=CreateShareResponse,
+    responses={code: {"model": ShareErrorResponseEnvelope} for code in [404, 500]},
+)
+async def create_share(
+    album_id: str = Path(...), body: CreateShareRequest = Body(default=None)
+) -> CreateShareResponse:
+    """
+    Issue a share token and make sure the network listener is up.
+
+    An album's local lock is deliberately not consulted: locking protects the
+    album inside PictoPy, while sharing carries its own authorization.
+    """
+    if not db_get_album(album_id):
+        raise _album_not_found()
+
+    try:
+        port = await share_server_start()
+    except OSError as e:
+        raise _internal_error(f"Could not start the share server: {e}") from e
+
+    entry = share_registry_create(
+        album_id, expires_in_minutes=body.expires_in_minutes if body else None
+    )
+    logger.info(f"Sharing album {album_id} on port {port}")
+
+    return CreateShareResponse(
+        success=True,
+        message="Album is now shared on the local network",
+        data=_to_share(entry, port),
+    )
+
+
+# DELETE /share/{token} - Stop sharing
+@router.delete(
+    "/{token}",
+    response_model=RevokeShareResponse,
+    responses={404: {"model": ShareErrorResponseEnvelope}},
+)
+async def revoke_share(token: str = Path(...)) -> RevokeShareResponse:
+    if not share_registry_revoke(token):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=ErrorResponse(
+                success=False,
+                error="Share Not Found",
+                message="No active share exists with the provided token.",
+            ).model_dump(),
+        )
+
+    # Nothing is being served any more, so stop listening rather than leaving a
+    # port open on the network.
+    if share_registry_count() == 0:
+        await share_server_stop()
+
+    return RevokeShareResponse(success=True, message="Share revoked")

--- a/backend/app/schemas/share.py
+++ b/backend/app/schemas/share.py
@@ -1,0 +1,87 @@
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+# ##############################
+# Request Handler
+# ##############################
+
+
+class CreateShareRequest(BaseModel):
+    # None means the share lives until it is revoked or PictoPy closes.
+    expires_in_minutes: Optional[int] = Field(default=None, gt=0)
+
+
+# ##############################
+# Response Handler
+# ##############################
+
+
+class ShareInterface(BaseModel):
+    """One address the share could be advertised on, best guess first."""
+
+    interface: str
+    ip: str
+    is_default_route: bool
+    looks_virtual: bool
+    is_up: bool
+
+
+class ShareUrl(BaseModel):
+    interface: str
+    ip: str
+    url: str
+
+
+class Share(BaseModel):
+    token: str
+    album_id: str
+    album_name: str
+    image_count: int
+    port: int
+    created_at: str
+    expires_at: Optional[str] = None
+    # One entry per candidate interface: which of them a phone can actually
+    # reach depends on the network, so the caller picks.
+    urls: List[ShareUrl]
+
+
+class CreateShareResponse(BaseModel):
+    success: bool
+    message: str
+    data: Share
+
+
+class GetSharesResponse(BaseModel):
+    success: bool
+    data: List[Share]
+
+
+class GetInterfacesResponse(BaseModel):
+    success: bool
+    data: List[ShareInterface]
+
+
+class RevokeShareResponse(BaseModel):
+    success: bool
+    message: str
+
+
+class ErrorResponse(BaseModel):
+    success: bool = False
+    message: str
+    error: str
+
+
+# Named for this module rather than reusing the album schemas' generic name:
+# two same-named models make FastAPI fall back to fully-qualified schema names
+# in the generated OpenAPI, which would rename the album ones too.
+class ShareErrorResponseEnvelope(BaseModel):
+    """
+    How an ErrorResponse actually reaches the client.
+
+    HTTPException nests whatever it is given under `detail`, so documenting
+    ErrorResponse alone would describe a shape no client ever receives.
+    """
+
+    detail: ErrorResponse

--- a/backend/app/schemas/share.py
+++ b/backend/app/schemas/share.py
@@ -25,6 +25,9 @@ class ShareInterface(BaseModel):
     is_default_route: bool
     looks_virtual: bool
     is_up: bool
+    # A 169.254 address only works when both devices sit on the same link, so
+    # the picker can mark it as a last resort rather than a normal choice.
+    is_link_local: bool
 
 
 class ShareUrl(BaseModel):

--- a/backend/app/share/__init__.py
+++ b/backend/app/share/__init__.py
@@ -1,0 +1,6 @@
+"""
+The album share server: a second FastAPI app bound to the local network.
+
+Kept separate from the main backend because that one exposes shutdown, delete
+and metadata routes that must never leave localhost.
+"""

--- a/backend/app/share/app.py
+++ b/backend/app/share/app.py
@@ -1,0 +1,27 @@
+"""
+The share FastAPI application.
+
+Separate from the main backend app on purpose: this one is bound to 0.0.0.0 and
+anything mounted here is reachable by every device that can route to this
+machine. Add routes only when they are meant to be public.
+"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from app.share.routes import router as share_routes
+
+
+def create_share_app() -> FastAPI:
+    # No CORS middleware: the main app allows every origin, and inheriting that
+    # here would let any page on the network read a share through a browser.
+    # The interactive docs would also enumerate the surface, so they stay off.
+    app = FastAPI(
+        title="PictoPy Share",
+        docs_url=None,
+        redoc_url=None,
+        openapi_url=None,
+    )
+    app.include_router(share_routes)
+    return app

--- a/backend/app/share/media.py
+++ b/backend/app/share/media.py
@@ -9,7 +9,7 @@ that check a share token would be a read handle over the whole images table.
 from __future__ import annotations
 
 import os
-from typing import Optional
+from typing import List, Optional
 
 from app.database.albums import (
     db_album_contains_image,
@@ -30,7 +30,7 @@ def share_media_album_name(album_id: str) -> Optional[str]:
     return album["album_name"] if album else None
 
 
-def share_media_image_ids(album_id: str) -> list[str]:
+def share_media_image_ids(album_id: str) -> List[str]:
     return db_get_album_images(album_id)
 
 

--- a/backend/app/share/media.py
+++ b/backend/app/share/media.py
@@ -1,0 +1,54 @@
+"""
+Resolving an image request against a share.
+
+The receiver only ever sends IDs. Turning an ID into a path happens here, and
+only after the image has been confirmed to belong to the shared album — without
+that check a share token would be a read handle over the whole images table.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+from app.database.albums import db_get_album, db_get_album_images
+from app.database.images import db_get_image_by_id
+
+
+def share_media_album_name(album_id: str) -> Optional[str]:
+    """
+    The album's display name, or None if it has been deleted since sharing.
+
+    `is_locked` is deliberately ignored: an album's local lock is a separate
+    concern from network sharing, which carries its own authorization.
+    """
+    album = db_get_album(album_id)
+    return album["album_name"] if album else None
+
+
+def share_media_image_ids(album_id: str) -> list[str]:
+    return db_get_album_images(album_id)
+
+
+def share_media_resolve_path(
+    album_id: str, image_id: str, *, thumbnail: bool
+) -> Optional[str]:
+    """
+    The file backing one image of a shared album, or None if it is not part of
+    that album, is unknown, or has vanished from disk since indexing.
+    """
+    if image_id not in set(db_get_album_images(album_id)):
+        return None
+
+    image = db_get_image_by_id(image_id)
+    if not image:
+        return None
+
+    path = image.get("thumbnailPath") if thumbnail else image.get("path")
+    # A thumbnail can be missing for an image indexed before it was generated;
+    # the original is a correct, if heavier, substitute.
+    if thumbnail and not path:
+        path = image.get("path")
+    if not path or not os.path.isfile(path):
+        return None
+    return path

--- a/backend/app/share/media.py
+++ b/backend/app/share/media.py
@@ -11,7 +11,11 @@ from __future__ import annotations
 import os
 from typing import Optional
 
-from app.database.albums import db_get_album, db_get_album_images
+from app.database.albums import (
+    db_album_contains_image,
+    db_get_album,
+    db_get_album_images,
+)
 from app.database.images import db_get_image_by_id
 
 
@@ -37,7 +41,7 @@ def share_media_resolve_path(
     The file backing one image of a shared album, or None if it is not part of
     that album, is unknown, or has vanished from disk since indexing.
     """
-    if image_id not in set(db_get_album_images(album_id)):
+    if not db_album_contains_image(album_id, image_id):
         return None
 
     image = db_get_image_by_id(image_id)

--- a/backend/app/share/registry.py
+++ b/backend/app/share/registry.py
@@ -1,0 +1,107 @@
+"""
+Active shares, held in memory only.
+
+Deliberately not a database table: shares are meant to die with the process, and
+keeping them here makes that structural rather than something a cleanup job has
+to enforce. It also means no share token is ever written to disk.
+"""
+
+from __future__ import annotations
+
+import secrets
+import threading
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Dict, List, Optional
+
+# Long enough that guessing is hopeless; the token is the only credential
+# protecting an album on a network anyone else may also be on.
+_TOKEN_BYTES = 32
+
+
+@dataclass
+class ShareEntry:
+    """One album being served, for as long as this process lives."""
+
+    token: str
+    album_id: str
+    created_at: datetime
+    expires_at: Optional[datetime] = None
+    unlock_tokens: set = field(default_factory=set)
+
+    @property
+    def is_expired(self) -> bool:
+        if self.expires_at is None:
+            return False
+        return _now() >= self.expires_at
+
+
+_shares: Dict[str, ShareEntry] = {}
+# Uvicorn runs sync route handlers in a threadpool, so the dict is reachable
+# from more than one thread.
+_lock = threading.Lock()
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def share_registry_create(
+    album_id: str, expires_in_minutes: Optional[int] = None
+) -> ShareEntry:
+    """Issue a token for an album. Any previous share of it stays valid."""
+    expires_at = (
+        _now() + timedelta(minutes=expires_in_minutes)
+        if expires_in_minutes is not None
+        else None
+    )
+    entry = ShareEntry(
+        token=secrets.token_urlsafe(_TOKEN_BYTES),
+        album_id=album_id,
+        created_at=_now(),
+        expires_at=expires_at,
+    )
+    with _lock:
+        _shares[entry.token] = entry
+    return entry
+
+
+def share_registry_get(token: str) -> Optional[ShareEntry]:
+    """
+    The live share for a token, or None.
+
+    An expired entry is dropped here rather than swept on a timer, so expiry
+    needs no background task.
+    """
+    with _lock:
+        entry = _shares.get(token)
+        if entry is None:
+            return None
+        if entry.is_expired:
+            del _shares[token]
+            return None
+        return entry
+
+
+def share_registry_list() -> List[ShareEntry]:
+    """Every share that is still live, newest first."""
+    with _lock:
+        live = [entry for entry in _shares.values() if not entry.is_expired]
+    return sorted(live, key=lambda entry: entry.created_at, reverse=True)
+
+
+def share_registry_revoke(token: str) -> bool:
+    """True if a share was removed, False if the token was already gone."""
+    with _lock:
+        return _shares.pop(token, None) is not None
+
+
+def share_registry_count() -> int:
+    """Live share count; the server stops once this reaches zero."""
+    with _lock:
+        return sum(1 for entry in _shares.values() if not entry.is_expired)
+
+
+def share_registry_clear() -> None:
+    with _lock:
+        _shares.clear()

--- a/backend/app/share/registry.py
+++ b/backend/app/share/registry.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import secrets
 import threading
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Dict, List, Optional
 
@@ -27,7 +27,6 @@ class ShareEntry:
     album_id: str
     created_at: datetime
     expires_at: Optional[datetime] = None
-    unlock_tokens: set = field(default_factory=set)
 
     @property
     def is_expired(self) -> bool:

--- a/backend/app/share/routes.py
+++ b/backend/app/share/routes.py
@@ -1,0 +1,85 @@
+"""
+The only routes reachable from the network. Everything here is unauthenticated
+apart from the token in the path, so keep the surface exactly this small.
+"""
+
+from __future__ import annotations
+
+import os
+
+from fastapi import APIRouter, HTTPException, Path, Request, status
+from fastapi.responses import FileResponse, HTMLResponse
+from fastapi.templating import Jinja2Templates
+
+from app.logging.setup_logging import get_logger
+from app.share.media import (
+    share_media_album_name,
+    share_media_image_ids,
+    share_media_resolve_path,
+)
+from app.share.registry import ShareEntry, share_registry_get
+
+logger = get_logger(__name__)
+
+router = APIRouter()
+
+templates = Jinja2Templates(
+    directory=os.path.join(os.path.dirname(__file__), "templates")
+)
+
+
+def _not_found() -> HTTPException:
+    """
+    One shape for every failure.
+
+    A revoked token, an expired one and a token that never existed must be
+    indistinguishable, or the response becomes an oracle for guessing.
+    """
+    return HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
+
+
+def _require_share(token: str) -> ShareEntry:
+    entry = share_registry_get(token)
+    if entry is None:
+        raise _not_found()
+    return entry
+
+
+@router.get("/s/{token}", response_class=HTMLResponse)
+def view_share(request: Request, token: str = Path(...)) -> HTMLResponse:
+    entry = _require_share(token)
+
+    album_name = share_media_album_name(entry.album_id)
+    if album_name is None:
+        # The album was deleted while shared; the token is now meaningless.
+        raise _not_found()
+
+    return templates.TemplateResponse(
+        request,
+        "album.html",
+        {
+            "album_name": album_name,
+            "token": entry.token,
+            "image_ids": share_media_image_ids(entry.album_id),
+            # The page reformats this into the viewer's own locale.
+            "expires_at": entry.expires_at.isoformat() if entry.expires_at else None,
+        },
+    )
+
+
+@router.get("/s/{token}/thumb/{image_id}")
+def share_thumbnail(token: str = Path(...), image_id: str = Path(...)) -> FileResponse:
+    entry = _require_share(token)
+    path = share_media_resolve_path(entry.album_id, image_id, thumbnail=True)
+    if path is None:
+        raise _not_found()
+    return FileResponse(path)
+
+
+@router.get("/s/{token}/photo/{image_id}")
+def share_photo(token: str = Path(...), image_id: str = Path(...)) -> FileResponse:
+    entry = _require_share(token)
+    path = share_media_resolve_path(entry.album_id, image_id, thumbnail=False)
+    if path is None:
+        raise _not_found()
+    return FileResponse(path)

--- a/backend/app/share/server.py
+++ b/backend/app/share/server.py
@@ -1,0 +1,133 @@
+"""
+Starting and stopping the share listener.
+
+Runs as an asyncio task on the backend's own event loop rather than in a thread
+or a separate process, so quitting PictoPy takes the share server with it and
+the in-memory registry cannot outlive the app.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+import sys
+from typing import List, Optional
+
+from uvicorn import Config, Server
+
+from app.config.settings import SHARE_SERVER_PORT
+from app.logging.setup_logging import get_logger
+from app.share.app import create_share_app
+
+logger = get_logger(__name__)
+
+# How many ports past the preferred one to try before giving up. Windows
+# firewall rules are per-binary, so a different port needs no new permission.
+_PORT_ATTEMPTS = 5
+
+_server: Optional[Server] = None
+_task: Optional[asyncio.Task] = None
+_sock: Optional[socket.socket] = None
+_port: Optional[int] = None
+
+
+class _EmbeddedServer(Server):
+    """
+    A uvicorn server that leaves the process's signal handling alone.
+
+    The default implementation installs its own SIGINT/SIGTERM handlers when
+    started on the main thread, which would take them away from the backend
+    that is hosting us.
+    """
+
+    def install_signal_handlers(self) -> None:
+        return None
+
+
+def _bind(port: int) -> socket.socket:
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    # SO_REUSEADDR means something different on Windows: it lets a second
+    # socket bind a port that is already taken, so a clash would look like a
+    # success and the share would silently serve nothing.
+    if sys.platform != "win32":
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    try:
+        sock.bind(("0.0.0.0", port))
+    except OSError:
+        sock.close()
+        raise
+    return sock
+
+
+def _bind_first_free() -> socket.socket:
+    """
+    Bind ahead of uvicorn rather than letting it bind on startup.
+
+    uvicorn raises SystemExit when it cannot bind, which would terminate the
+    whole backend instead of failing one share.
+    """
+    errors: List[str] = []
+    for offset in range(_PORT_ATTEMPTS):
+        port = SHARE_SERVER_PORT + offset
+        try:
+            return _bind(port)
+        except OSError as error:
+            errors.append(f"{port}: {error}")
+    raise OSError("Could not bind a share port — tried " + "; ".join(errors))
+
+
+async def share_server_start() -> int:
+    """Start the listener if it is not already up, and return its port."""
+    global _server, _task, _sock, _port
+
+    if _server is not None and _port is not None:
+        return _port
+
+    _sock = _bind_first_free()
+    _port = _sock.getsockname()[1]
+
+    config = Config(
+        app=create_share_app(),
+        log_level="warning",
+        log_config=None,  # keep the backend's logging setup, as main.py does
+    )
+    _server = _EmbeddedServer(config)
+    _task = asyncio.create_task(_server.serve(sockets=[_sock]))
+
+    logger.info(f"Share server listening on 0.0.0.0:{_port}")
+    return _port
+
+
+async def share_server_stop() -> None:
+    """Stop the listener. Safe to call when it was never started."""
+    global _server, _task, _sock, _port
+
+    if _server is None:
+        return
+
+    _server.should_exit = True
+    if _task is not None:
+        await asyncio.gather(_task, return_exceptions=True)
+
+    # uvicorn closes the sockets it was handed, so this only matters when it
+    # never got as far as serving.
+    if _sock is not None:
+        try:
+            _sock.close()
+        except OSError:
+            pass
+
+    logger.info("Share server stopped")
+    _server = None
+    _task = None
+    _sock = None
+    _port = None
+
+
+def share_server_port() -> Optional[int]:
+    """The live port, or None when the server is not running."""
+    return _port
+
+
+def share_server_is_running() -> bool:
+    return _server is not None

--- a/backend/app/share/server.py
+++ b/backend/app/share/server.py
@@ -25,10 +25,19 @@ logger = get_logger(__name__)
 # firewall rules are per-binary, so a different port needs no new permission.
 _PORT_ATTEMPTS = 5
 
+# Long enough for an in-flight photo to finish, short enough that quitting the
+# app never appears to hang on a recipient who left a download open.
+_STOP_TIMEOUT = 5.0
+
 _server: Optional[Server] = None
 _task: Optional[asyncio.Task] = None
 _sock: Optional[socket.socket] = None
 _port: Optional[int] = None
+
+# Serialises start against stop. Without it a revoke that decides to stop can
+# interleave with a create that decides the listener is already up, and the
+# new share is left pointing at a socket that is closing.
+_lifecycle_lock = asyncio.Lock()
 
 
 class _EmbeddedServer(Server):
@@ -76,52 +85,85 @@ def _bind_first_free() -> socket.socket:
     raise OSError("Could not bind a share port — tried " + "; ".join(errors))
 
 
-async def share_server_start() -> int:
-    """Start the listener if it is not already up, and return its port."""
+def _clear() -> None:
+    """Drop all listener state, closing the socket if uvicorn never took it."""
     global _server, _task, _sock, _port
-
-    if _server is not None and _port is not None:
-        return _port
-
-    _sock = _bind_first_free()
-    _port = _sock.getsockname()[1]
-
-    config = Config(
-        app=create_share_app(),
-        log_level="warning",
-        log_config=None,  # keep the backend's logging setup, as main.py does
-    )
-    _server = _EmbeddedServer(config)
-    _task = asyncio.create_task(_server.serve(sockets=[_sock]))
-
-    logger.info(f"Share server listening on 0.0.0.0:{_port}")
-    return _port
-
-
-async def share_server_stop() -> None:
-    """Stop the listener. Safe to call when it was never started."""
-    global _server, _task, _sock, _port
-
-    if _server is None:
-        return
-
-    _server.should_exit = True
-    if _task is not None:
-        await asyncio.gather(_task, return_exceptions=True)
-
-    # uvicorn closes the sockets it was handed, so this only matters when it
-    # never got as far as serving.
     if _sock is not None:
         try:
             _sock.close()
         except OSError:
             pass
-
-    logger.info("Share server stopped")
     _server = None
     _task = None
     _sock = None
     _port = None
+
+
+def _on_serve_done(task: asyncio.Task) -> None:
+    """
+    Notice a listener that died on its own.
+
+    Without this the task's exception is never retrieved, and worse, `_port`
+    would stay set so the next create would hand out a URL for a socket that
+    stopped accepting connections.
+    """
+    if task is not _task:
+        return  # already superseded by a newer listener
+    if not task.cancelled():
+        error = task.exception()
+        if error is not None:
+            logger.error(f"Share server stopped unexpectedly: {error}")
+    _clear()
+
+
+async def share_server_start() -> int:
+    """Start the listener if it is not already up, and return its port."""
+    global _server, _task, _sock, _port
+
+    async with _lifecycle_lock:
+        if _port is not None and _task is not None and not _task.done():
+            return _port
+        if _server is not None:
+            # A previous listener died; drop it before binding again.
+            _clear()
+
+        _sock = _bind_first_free()
+        _port = _sock.getsockname()[1]
+
+        config = Config(
+            app=create_share_app(),
+            log_level="warning",
+            log_config=None,  # keep the backend's logging setup, as main.py does
+            timeout_graceful_shutdown=_STOP_TIMEOUT,
+        )
+        _server = _EmbeddedServer(config)
+        _task = asyncio.create_task(_server.serve(sockets=[_sock]))
+        _task.add_done_callback(_on_serve_done)
+
+        logger.info(f"Share server listening on 0.0.0.0:{_port}")
+        return _port
+
+
+async def share_server_stop() -> None:
+    """Stop the listener. Safe to call when it was never started."""
+    async with _lifecycle_lock:
+        server, task = _server, _task
+        if server is None:
+            return
+
+        server.should_exit = True
+        if task is not None and not task.done():
+            try:
+                await asyncio.wait_for(task, timeout=_STOP_TIMEOUT)
+            except asyncio.TimeoutError:
+                # wait_for has already cancelled it; a recipient holding a
+                # long download must not keep the port open indefinitely.
+                logger.warning("Share server did not stop in time; cancelled it")
+            except Exception:
+                pass  # the done callback logged whatever serve() raised
+
+        _clear()
+        logger.info("Share server stopped")
 
 
 def share_server_port() -> Optional[int]:
@@ -130,4 +172,4 @@ def share_server_port() -> Optional[int]:
 
 
 def share_server_is_running() -> bool:
-    return _server is not None
+    return _port is not None and _task is not None and not _task.done()

--- a/backend/app/share/templates/album.html
+++ b/backend/app/share/templates/album.html
@@ -526,10 +526,15 @@
 
   document.addEventListener('click', function () { setMenuOpen(false); });
 
-  window.matchMedia('(prefers-color-scheme: dark)')
-    .addEventListener('change', function () {
-      if (storedTheme() === 'auto') applyTheme();
-    });
+  // Safari before 14 and older WebViews only have the deprecated addListener.
+  // Without this the whole script would die here, and because thumbnails load
+  // from data-src the page would render no images at all.
+  var darkQuery = window.matchMedia('(prefers-color-scheme: dark)');
+  var onSystemThemeChange = function () {
+    if (storedTheme() === 'auto') applyTheme();
+  };
+  if (darkQuery.addEventListener) darkQuery.addEventListener('change', onSystemThemeChange);
+  else if (darkQuery.addListener) darkQuery.addListener(onSystemThemeChange);
 
   applyTheme();
 
@@ -652,6 +657,30 @@
     });
   }
 
+  // aria-modal tells a screen reader the rest of the page is inert, so Tab has
+  // to agree with that. Without this the grid behind stays reachable and the
+  // announcement and the focus ring disagree.
+  function trapFocus(event) {
+    var selector = filmstripWrap.classList.contains('visible')
+      ? '.lightbox button'
+      : '.lightbox-header button, .lightbox-arrow';
+    var focusable = lightbox.querySelectorAll(selector);
+    if (!focusable.length) return;
+
+    var first = focusable[0];
+    var last = focusable[focusable.length - 1];
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    } else if (!lightbox.contains(document.activeElement)) {
+      event.preventDefault();
+      first.focus();
+    }
+  }
+
   document.addEventListener('keydown', function (event) {
     if (!lightbox.classList.contains('active')) return;
     if (event.key === 'Escape') closeLightbox();
@@ -659,6 +688,7 @@
     else if (event.key === 'ArrowRight') show(current + 1);
     else if (event.key === 'Home') show(0);
     else if (event.key === 'End') show(IMAGE_IDS.length - 1);
+    else if (event.key === 'Tab') trapFocus(event);
   });
 
   // Swipe between photos on touch devices.

--- a/backend/app/share/templates/album.html
+++ b/backend/app/share/templates/album.html
@@ -1,0 +1,688 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<meta name="robots" content="noindex, nofollow">
+<title>{{ album_name }} · PictoPy</title>
+<script>
+  // Applied before first paint so a dark-theme viewer never flashes light.
+  (function () {
+    try {
+      var saved = localStorage.getItem('pictopy-share-theme') || 'auto';
+      var dark = saved === 'dark' || (saved === 'auto' &&
+        window.matchMedia('(prefers-color-scheme: dark)').matches);
+      document.documentElement.classList.toggle('dark', dark);
+    } catch (e) { /* private mode blocks localStorage; system theme still works */ }
+  })();
+</script>
+<style>
+  :root {
+    /* No webfont: this page is served over a LAN that often has no route to
+       the internet, so a remote font would just stall then fall back. */
+    --font-sans: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    --radius-sm: 0.375rem;
+    --radius: 0.675rem;
+    --background: oklch(1 0 0);
+    --foreground: oklch(0.3211 0 0);
+    --card: oklch(1 0 0);
+    --primary: oklch(0.6231 0.188 259.8145);
+    --primary-foreground: oklch(1 0 0);
+    --secondary: oklch(0.967 0.0029 264.5419);
+    --muted: oklch(0.9846 0.0017 247.8389);
+    --muted-foreground: oklch(0.551 0.0234 264.3637);
+    --border: oklch(0.9276 0.0058 264.5313);
+    --header-bg: rgba(255, 255, 255, 0.92);
+    --shadow-md: 0 1px 3px 0 hsl(0 0% 0% / 0.1), 0 2px 4px -1px hsl(0 0% 0% / 0.1);
+    --shadow-lg: 0 1px 3px 0 hsl(0 0% 0% / 0.1), 0 4px 6px -1px hsl(0 0% 0% / 0.1);
+  }
+
+  html.dark {
+    --background: oklch(0.2046 0 0);
+    --foreground: oklch(0.9219 0 0);
+    --card: oklch(0.2686 0 0);
+    --secondary: oklch(0.2686 0 0);
+    --muted: oklch(0.2686 0 0);
+    --muted-foreground: oklch(0.7155 0 0);
+    --border: oklch(0.3715 0 0);
+    --header-bg: rgba(32, 32, 32, 0.92);
+  }
+
+  * { box-sizing: border-box; }
+  html, body { width: 100%; }
+  body {
+    margin: 0;
+    font-family: var(--font-sans);
+    background: var(--background);
+    color: var(--foreground);
+    line-height: 1.5;
+    -webkit-text-size-adjust: 100%;
+  }
+  img { display: block; }
+
+  .header-bar {
+    position: sticky;
+    top: 0;
+    z-index: 20;
+    -webkit-backdrop-filter: blur(8px);
+    backdrop-filter: blur(8px);
+    background: var(--header-bg);
+    border-bottom: 1px solid var(--border);
+    padding: 0.75rem 1rem;
+    padding-top: max(0.75rem, env(safe-area-inset-top));
+  }
+
+  .header-row {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+
+  .brand {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 1.125rem;
+    font-weight: 700;
+    white-space: nowrap;
+  }
+  .brand svg { width: 1.5rem; height: 1.5rem; color: var(--primary); }
+  .brand .accent { color: var(--primary); }
+
+  .title-desktop {
+    pointer-events: none;
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    max-width: min(52vw, 40rem);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: 1rem;
+    font-weight: 600;
+    display: none;
+  }
+
+  .mobile-title {
+    margin-top: 0.5rem;
+    font-size: 0.95rem;
+    font-weight: 600;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .icon-btn {
+    width: 2.25rem;
+    height: 2.25rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: 0;
+    border-radius: var(--radius-sm);
+    background: transparent;
+    color: inherit;
+    cursor: pointer;
+    transition: background-color 200ms;
+  }
+  .icon-btn:hover { background: var(--secondary); }
+  .icon-btn svg { width: 1.25rem; height: 1.25rem; }
+
+  .dropdown {
+    position: absolute;
+    top: calc(100% + 0.5rem);
+    right: 0;
+    width: 9rem;
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: 0.5rem;
+    box-shadow: var(--shadow-lg);
+    padding: 0.25rem;
+    z-index: 30;
+  }
+  .dropdown[hidden] { display: none; }
+  .dropdown button {
+    width: 100%;
+    padding: 0.5rem 0.75rem;
+    border: 0;
+    background: transparent;
+    color: var(--foreground);
+    text-align: left;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    font: inherit;
+    font-size: 0.875rem;
+  }
+  .dropdown button:hover { background: var(--secondary); }
+  .dropdown button[aria-checked="true"] { background: var(--primary); color: var(--primary-foreground); }
+
+  .meta-bar {
+    padding: 0.75rem 1rem;
+    font-size: 0.875rem;
+    color: var(--muted-foreground);
+    border-bottom: 1px solid var(--border);
+  }
+  .meta-bar .strong { color: var(--foreground); font-weight: 500; }
+
+  .gallery { padding: 0.5rem; }
+
+  .thumbnail-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 0.25rem;
+  }
+
+  .thumb-card {
+    position: relative;
+    aspect-ratio: 1 / 1;
+    overflow: hidden;
+    border-radius: var(--radius);
+    background: var(--card);
+    border: 1px solid var(--border);
+    cursor: pointer;
+    padding: 0;
+    transition: box-shadow 150ms ease;
+  }
+  .thumb-card:hover { box-shadow: var(--shadow-md); }
+  .thumb-card:focus-visible { outline: 2px solid var(--primary); outline-offset: 2px; }
+  .thumb-card img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    opacity: 0;
+    transition: opacity 300ms ease, transform 300ms ease;
+  }
+  .thumb-card img.loaded { opacity: 1; }
+  .thumb-card:hover img.loaded { transform: scale(1.05); }
+
+  .skeleton {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(90deg, var(--muted) 25%, var(--secondary) 50%, var(--muted) 75%);
+    background-size: 200% 100%;
+    animation: shimmer 1.4s ease-in-out infinite;
+  }
+  @keyframes shimmer {
+    0% { background-position: 200% 0; }
+    100% { background-position: -200% 0; }
+  }
+
+  .empty { padding: 3rem 1rem; text-align: center; color: var(--muted-foreground); }
+
+  .lightbox {
+    position: fixed;
+    inset: 0;
+    z-index: 50;
+    display: none;
+    flex-direction: column;
+    background: rgba(0, 0, 0, 0.94);
+    color: #fff;
+  }
+  .lightbox.active { display: flex; }
+
+  .lightbox-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.75rem 1rem;
+    padding-top: max(0.75rem, env(safe-area-inset-top));
+    border-bottom: 1px solid rgba(255, 255, 255, 0.14);
+  }
+  .lightbox-counter { font-size: 0.875rem; font-weight: 500; }
+  .lightbox-controls { display: flex; align-items: center; gap: 0.5rem; }
+  .lightbox .icon-btn { color: #fff; }
+  .lightbox .icon-btn:hover { background: rgba(255, 255, 255, 0.14); }
+  .lightbox .icon-btn[aria-pressed="true"] { background: rgba(255, 255, 255, 0.22); }
+
+  .lightbox-stage {
+    position: relative;
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    touch-action: pan-y;
+  }
+
+  .lightbox-image {
+    max-width: 100%;
+    max-height: 100%;
+    object-fit: contain;
+    user-select: none;
+    -webkit-user-select: none;
+  }
+
+  .lightbox-arrow {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 4.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 0;
+    background: transparent;
+    color: #fff;
+    cursor: pointer;
+    z-index: 3;
+  }
+  .lightbox-arrow.left { left: 0; }
+  .lightbox-arrow.right { right: 0; }
+  .lightbox-arrow .inner {
+    display: flex;
+    padding: 0.75rem;
+    border-radius: 9999px;
+    -webkit-backdrop-filter: blur(8px);
+    backdrop-filter: blur(8px);
+    transition: background-color 200ms;
+  }
+  .lightbox-arrow:hover .inner { background: rgba(0, 0, 0, 0.6); }
+  .lightbox-arrow svg { width: 1.75rem; height: 1.75rem; }
+
+  .filmstrip-wrap {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.6);
+    -webkit-backdrop-filter: blur(8px);
+    backdrop-filter: blur(8px);
+    padding: 0.75rem;
+    padding-bottom: max(0.75rem, env(safe-area-inset-bottom));
+    z-index: 4;
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(1rem);
+    transition: opacity 180ms ease, transform 180ms ease, visibility 0s linear 180ms;
+  }
+  .filmstrip-wrap.visible {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+    transition-delay: 0s;
+  }
+
+  .filmstrip {
+    display: flex;
+    gap: 0.5rem;
+    overflow-x: auto;
+    scrollbar-width: none;
+    scroll-behavior: smooth;
+  }
+  .filmstrip::-webkit-scrollbar { display: none; }
+
+  .filmstrip-thumb {
+    flex: 0 0 auto;
+    width: 4.5rem;
+    height: 4.5rem;
+    padding: 0;
+    border-radius: 0.5rem;
+    overflow: hidden;
+    cursor: pointer;
+    opacity: 0.6;
+    background: transparent;
+    border: 2px solid transparent;
+    transition: opacity 200ms, border-color 200ms;
+  }
+  .filmstrip-thumb.active { opacity: 1; border-color: var(--primary); }
+  .filmstrip-thumb img { width: 100%; height: 100%; object-fit: cover; }
+
+  @media (min-width: 641px) {
+    .gallery { padding: 1rem; }
+    .thumbnail-grid { grid-template-columns: repeat(4, 1fr); gap: 0.75rem; }
+    .filmstrip { width: max-content; margin: 0 auto; }
+    .filmstrip-thumb { width: 7rem; height: 5rem; }
+  }
+
+  @media (min-width: 1024px) {
+    .thumbnail-grid { grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 1rem; }
+    .title-desktop { display: block; }
+    .mobile-title { display: none; }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    * { animation-duration: 0.01ms !important; transition-duration: 0.01ms !important; }
+  }
+</style>
+</head>
+<body>
+
+<header class="header-bar">
+  <div class="header-row">
+    <div class="brand">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+           stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <rect x="3" y="3" width="18" height="18" rx="2"></rect>
+        <circle cx="8.5" cy="8.5" r="1.5"></circle>
+        <path d="m21 15-4.35-4.35a2 2 0 0 0-2.83 0L3 21"></path>
+      </svg>
+      <span><span class="accent">Picto</span>Py</span>
+    </div>
+
+    <div class="title-desktop">{{ album_name }}</div>
+
+    <div style="position: relative;">
+      <button id="themeToggle" class="icon-btn" type="button"
+              aria-haspopup="true" aria-expanded="false" aria-label="Change theme">
+        <svg id="themeIcon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+             stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"></svg>
+      </button>
+      <div id="themeMenu" class="dropdown" role="menu" hidden>
+        <button type="button" role="menuitemradio" data-theme="auto">System</button>
+        <button type="button" role="menuitemradio" data-theme="light">Light</button>
+        <button type="button" role="menuitemradio" data-theme="dark">Dark</button>
+      </div>
+    </div>
+  </div>
+  <div class="mobile-title">{{ album_name }}</div>
+</header>
+
+<div class="meta-bar">
+  <span class="strong">{{ image_ids | length }} photo{{ '' if image_ids | length == 1 else 's' }}</span>
+  {% if expires_at %}
+  <span> · </span><span>Expires</span>
+  <span class="strong"><time datetime="{{ expires_at }}" id="expiry">{{ expires_at }}</time></span>
+  {% endif %}
+</div>
+
+<main class="gallery">
+  {% if image_ids %}
+  <div class="thumbnail-grid" id="grid">
+    {% for image_id in image_ids %}
+    <button class="thumb-card" type="button" data-index="{{ loop.index0 }}"
+            aria-label="Open photo {{ loop.index }} of {{ image_ids | length }}">
+      <span class="skeleton"></span>
+      <img data-src="/s/{{ token }}/thumb/{{ image_id }}" alt="">
+    </button>
+    {% endfor %}
+  </div>
+  {% else %}
+  <p class="empty">This album has no photos.</p>
+  {% endif %}
+</main>
+
+<section id="lightbox" class="lightbox" role="dialog" aria-modal="true" aria-label="Photo viewer">
+  <div class="lightbox-header">
+    <div id="lbCounter" class="lightbox-counter"></div>
+    <div class="lightbox-controls">
+      <button id="filmstripToggle" class="icon-btn" type="button"
+              aria-pressed="false" aria-label="Toggle filmstrip">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+             stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <rect x="3" y="6" width="18" height="12" rx="2"></rect>
+          <path d="M7 6v12M17 6v12"></path>
+        </svg>
+      </button>
+      <button id="lbClose" class="icon-btn" type="button" aria-label="Close viewer">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+             stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M18 6 6 18M6 6l12 12"></path>
+        </svg>
+      </button>
+    </div>
+  </div>
+
+  <div class="lightbox-stage" id="lbStage">
+    <button id="lbPrev" class="lightbox-arrow left" type="button" aria-label="Previous photo">
+      <span class="inner">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+             stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="m15 18-6-6 6-6"></path>
+        </svg>
+      </span>
+    </button>
+
+    <img id="lbImage" class="lightbox-image" alt="">
+
+    <button id="lbNext" class="lightbox-arrow right" type="button" aria-label="Next photo">
+      <span class="inner">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+             stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="m9 18 6-6-6-6"></path>
+        </svg>
+      </span>
+    </button>
+
+    <div class="filmstrip-wrap" id="filmstripWrap">
+      <div class="filmstrip" id="filmstrip">
+        {% for image_id in image_ids %}
+        <button class="filmstrip-thumb" type="button" data-index="{{ loop.index0 }}"
+                aria-label="Show photo {{ loop.index }}">
+          <img src="/s/{{ token }}/thumb/{{ image_id }}" alt="" loading="lazy">
+        </button>
+        {% endfor %}
+      </div>
+    </div>
+  </div>
+</section>
+
+<script>
+(function () {
+  'use strict';
+
+  var TOKEN = {{ token | tojson }};
+  var IMAGE_IDS = {{ image_ids | tojson }};
+  var THEME_KEY = 'pictopy-share-theme';
+
+  var root = document.documentElement;
+  var lightbox = document.getElementById('lightbox');
+  var lbImage = document.getElementById('lbImage');
+  var lbCounter = document.getElementById('lbCounter');
+  var filmstripWrap = document.getElementById('filmstripWrap');
+  var filmstripToggle = document.getElementById('filmstripToggle');
+  var stage = document.getElementById('lbStage');
+
+  var current = 0;
+  var filmstripPinned = false;
+  var lastFocus = null;
+
+  // ---- theme -------------------------------------------------------------
+
+  var SUN = '<circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"></path>';
+  var MOON = '<path d="M12 3a6 6 0 1 0 9 9 9 9 0 1 1-9-9Z"></path>';
+
+  function storedTheme() {
+    try { return localStorage.getItem(THEME_KEY) || 'auto'; } catch (e) { return 'auto'; }
+  }
+
+  function prefersDark() {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches;
+  }
+
+  function applyTheme() {
+    var choice = storedTheme();
+    var dark = choice === 'dark' || (choice === 'auto' && prefersDark());
+    root.classList.toggle('dark', dark);
+    document.getElementById('themeIcon').innerHTML = dark ? MOON : SUN;
+    var items = document.querySelectorAll('#themeMenu [data-theme]');
+    for (var i = 0; i < items.length; i++) {
+      items[i].setAttribute('aria-checked', String(items[i].dataset.theme === choice));
+    }
+  }
+
+  var themeMenu = document.getElementById('themeMenu');
+  var themeToggle = document.getElementById('themeToggle');
+
+  function setMenuOpen(open) {
+    themeMenu.hidden = !open;
+    themeToggle.setAttribute('aria-expanded', String(open));
+  }
+
+  themeToggle.addEventListener('click', function (event) {
+    event.stopPropagation();
+    setMenuOpen(themeMenu.hidden);
+  });
+
+  themeMenu.addEventListener('click', function (event) {
+    var button = event.target.closest('[data-theme]');
+    if (!button) return;
+    try { localStorage.setItem(THEME_KEY, button.dataset.theme); } catch (e) { /* ignore */ }
+    applyTheme();
+    setMenuOpen(false);
+  });
+
+  document.addEventListener('click', function () { setMenuOpen(false); });
+
+  window.matchMedia('(prefers-color-scheme: dark)')
+    .addEventListener('change', function () {
+      if (storedTheme() === 'auto') applyTheme();
+    });
+
+  applyTheme();
+
+  // ---- expiry, rendered in the viewer's own locale ------------------------
+
+  var expiry = document.getElementById('expiry');
+  if (expiry) {
+    var when = new Date(expiry.dateTime);
+    if (!isNaN(when)) {
+      expiry.textContent = when.toLocaleString(undefined, {
+        month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit'
+      });
+    }
+  }
+
+  // ---- lazy thumbnails ---------------------------------------------------
+
+  function reveal(img) {
+    img.src = img.dataset.src;
+    img.removeAttribute('data-src');
+    img.addEventListener('load', function () {
+      img.classList.add('loaded');
+      var skeleton = img.parentNode.querySelector('.skeleton');
+      if (skeleton) skeleton.remove();
+    });
+    // A file that vanished since indexing 404s; drop the shimmer either way so
+    // the tile does not pulse forever.
+    img.addEventListener('error', function () {
+      var skeleton = img.parentNode.querySelector('.skeleton');
+      if (skeleton) skeleton.remove();
+    });
+  }
+
+  var pending = document.querySelectorAll('.thumb-card img[data-src]');
+  if ('IntersectionObserver' in window) {
+    var observer = new IntersectionObserver(function (entries) {
+      entries.forEach(function (entry) {
+        if (!entry.isIntersecting) return;
+        reveal(entry.target);
+        observer.unobserve(entry.target);
+      });
+    }, { rootMargin: '300px' });
+    for (var i = 0; i < pending.length; i++) observer.observe(pending[i]);
+  } else {
+    for (var j = 0; j < pending.length; j++) reveal(pending[j]);
+  }
+
+  // ---- lightbox ----------------------------------------------------------
+
+  function show(index) {
+    current = (index + IMAGE_IDS.length) % IMAGE_IDS.length;
+    lbImage.src = '/s/' + TOKEN + '/photo/' + IMAGE_IDS[current];
+    lbImage.alt = 'Photo ' + (current + 1) + ' of ' + IMAGE_IDS.length;
+    lbCounter.textContent = (current + 1) + ' / ' + IMAGE_IDS.length;
+
+    var thumbs = document.querySelectorAll('.filmstrip-thumb');
+    for (var i = 0; i < thumbs.length; i++) {
+      var active = i === current;
+      thumbs[i].classList.toggle('active', active);
+      if (active) thumbs[i].scrollIntoView({ block: 'nearest', inline: 'center' });
+    }
+  }
+
+  function openLightbox(index) {
+    lastFocus = document.activeElement;
+    lightbox.classList.add('active');
+    document.body.style.overflow = 'hidden';
+    show(index);
+    document.getElementById('lbClose').focus();
+  }
+
+  function closeLightbox() {
+    lightbox.classList.remove('active');
+    document.body.style.overflow = '';
+    setFilmstrip(false);
+    filmstripPinned = false;
+    filmstripToggle.setAttribute('aria-pressed', 'false');
+    // Stop a large photo downloading in the background once it is out of view.
+    lbImage.removeAttribute('src');
+    if (lastFocus) lastFocus.focus();
+  }
+
+  function setFilmstrip(visible) {
+    filmstripWrap.classList.toggle('visible', visible);
+  }
+
+  var grid = document.getElementById('grid');
+  if (grid) {
+    grid.addEventListener('click', function (event) {
+      var card = event.target.closest('.thumb-card');
+      if (card) openLightbox(Number(card.dataset.index));
+    });
+  }
+
+  document.getElementById('lbClose').addEventListener('click', closeLightbox);
+  document.getElementById('lbPrev').addEventListener('click', function () { show(current - 1); });
+  document.getElementById('lbNext').addEventListener('click', function () { show(current + 1); });
+
+  document.getElementById('filmstrip').addEventListener('click', function (event) {
+    var thumb = event.target.closest('.filmstrip-thumb');
+    if (thumb) show(Number(thumb.dataset.index));
+  });
+
+  filmstripToggle.addEventListener('click', function () {
+    filmstripPinned = !filmstripPinned;
+    filmstripToggle.setAttribute('aria-pressed', String(filmstripPinned));
+    setFilmstrip(filmstripPinned);
+  });
+
+  // Hover-reveal is a pointer affordance; on touch the toggle button is the
+  // only way in, which is why it exists rather than relying on pointermove.
+  if (window.matchMedia('(hover: hover)').matches) {
+    stage.addEventListener('pointermove', function (event) {
+      if (filmstripPinned) return;
+      var height = window.innerHeight || document.documentElement.clientHeight;
+      setFilmstrip(event.clientY >= height - Math.min(180, Math.max(120, height * 0.18)));
+    });
+    stage.addEventListener('pointerleave', function () {
+      if (!filmstripPinned) setFilmstrip(false);
+    });
+  }
+
+  document.addEventListener('keydown', function (event) {
+    if (!lightbox.classList.contains('active')) return;
+    if (event.key === 'Escape') closeLightbox();
+    else if (event.key === 'ArrowLeft') show(current - 1);
+    else if (event.key === 'ArrowRight') show(current + 1);
+    else if (event.key === 'Home') show(0);
+    else if (event.key === 'End') show(IMAGE_IDS.length - 1);
+  });
+
+  // Swipe between photos on touch devices.
+  var swipeX = null;
+  var swipeY = null;
+  stage.addEventListener('touchstart', function (event) {
+    if (event.touches.length !== 1) return;
+    swipeX = event.touches[0].clientX;
+    swipeY = event.touches[0].clientY;
+  }, { passive: true });
+
+  stage.addEventListener('touchend', function (event) {
+    if (swipeX === null) return;
+    var touch = event.changedTouches[0];
+    var dx = touch.clientX - swipeX;
+    var dy = touch.clientY - swipeY;
+    // Horizontal intent only, so a vertical scroll never flips the photo.
+    if (Math.abs(dx) > 50 && Math.abs(dx) > Math.abs(dy)) {
+      show(dx < 0 ? current + 1 : current - 1);
+    }
+    swipeX = null;
+    swipeY = null;
+  }, { passive: true });
+})();
+</script>
+</body>
+</html>

--- a/backend/app/utils/network.py
+++ b/backend/app/utils/network.py
@@ -1,0 +1,115 @@
+"""
+LAN interface discovery for share URLs.
+
+Picking the wrong address produces a QR code that silently never loads, so
+candidates are ranked rather than guessed at and the caller is expected to let
+the user override the top pick.
+"""
+
+from __future__ import annotations
+
+import socket
+from dataclasses import dataclass
+from typing import List, Optional
+
+import psutil
+
+# Adapter name fragments that are almost never the address a phone can reach.
+# Deprioritised rather than dropped: on some machines the only usable address
+# really is behind one of these.
+VIRTUAL_HINTS = (
+    "vethernet",
+    "wsl",
+    "hyper-v",
+    "virtualbox",
+    "vboxnet",
+    "vmware",
+    "vmnet",
+    "docker",
+    "br-",
+    "veth",
+    "tailscale",
+    "zerotier",
+    "utun",
+    "tun",
+    "tap",
+    "loopback",
+    "bluetooth",
+)
+
+
+@dataclass
+class InterfaceCandidate:
+    """One address the share server could plausibly be reached on."""
+
+    interface: str
+    ip: str
+    is_default_route: bool
+    looks_virtual: bool
+    is_up: bool
+
+    @property
+    def rank(self) -> tuple:
+        # Lower sorts first.
+        return (
+            0 if self.is_default_route else 1,
+            0 if self.is_up else 1,
+            1 if self.looks_virtual else 0,
+            self.interface.lower(),
+        )
+
+
+def network_util_default_route_ip() -> Optional[str]:
+    """
+    The address the OS would use to reach the internet.
+
+    UDP connect() only fixes the socket's local endpoint; no packet is sent, so
+    this works with no connectivity and never blocks.
+    """
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        sock.connect(("8.8.8.8", 80))
+        return sock.getsockname()[0]
+    except OSError:
+        return None
+    finally:
+        sock.close()
+
+
+def _looks_virtual(interface: str) -> bool:
+    name = interface.lower()
+    return any(hint in name for hint in VIRTUAL_HINTS)
+
+
+def network_util_list_candidates() -> List[InterfaceCandidate]:
+    """Every reachable IPv4 address on this machine, best guess first."""
+    route_ip = network_util_default_route_ip()
+    stats = psutil.net_if_stats()
+    candidates: List[InterfaceCandidate] = []
+
+    for interface, addrs in psutil.net_if_addrs().items():
+        for addr in addrs:
+            if addr.family != socket.AF_INET:
+                continue
+            ip = addr.address
+            # Loopback cannot be reached from another device, and a 169.254
+            # address means DHCP never answered — a symptom, not an address.
+            if ip.startswith("127.") or ip.startswith("169.254."):
+                continue
+            candidates.append(
+                InterfaceCandidate(
+                    interface=interface,
+                    ip=ip,
+                    is_default_route=(ip == route_ip),
+                    looks_virtual=_looks_virtual(interface),
+                    is_up=stats[interface].isup if interface in stats else False,
+                )
+            )
+
+    return sorted(candidates, key=lambda candidate: candidate.rank)
+
+
+def network_util_best_candidate() -> Optional[InterfaceCandidate]:
+    """The address to advertise when the user has not chosen one."""
+    candidates = network_util_list_candidates()
+    return candidates[0] if candidates else None

--- a/backend/app/utils/network.py
+++ b/backend/app/utils/network.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import socket
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 import psutil
 
@@ -50,7 +50,7 @@ class InterfaceCandidate:
     is_link_local: bool
 
     @property
-    def rank(self) -> tuple:
+    def rank(self) -> Tuple[int, int, int, int, str]:
         # Lower sorts first. `is_up` outranks everything because an address on
         # a downed adapter can never work, and Windows will happily keep a
         # stale lease and default route on an adapter that has disconnected.

--- a/backend/app/utils/network.py
+++ b/backend/app/utils/network.py
@@ -47,14 +47,18 @@ class InterfaceCandidate:
     is_default_route: bool
     looks_virtual: bool
     is_up: bool
+    is_link_local: bool
 
     @property
     def rank(self) -> tuple:
-        # Lower sorts first.
+        # Lower sorts first. `is_up` outranks everything because an address on
+        # a downed adapter can never work, and Windows will happily keep a
+        # stale lease and default route on an adapter that has disconnected.
         return (
-            0 if self.is_default_route else 1,
             0 if self.is_up else 1,
+            0 if self.is_default_route else 1,
             1 if self.looks_virtual else 0,
+            1 if self.is_link_local else 0,
             self.interface.lower(),
         )
 
@@ -92,9 +96,11 @@ def network_util_list_candidates() -> List[InterfaceCandidate]:
             if addr.family != socket.AF_INET:
                 continue
             ip = addr.address
-            # Loopback cannot be reached from another device, and a 169.254
-            # address means DHCP never answered — a symptom, not an address.
-            if ip.startswith("127.") or ip.startswith("169.254."):
+            # Loopback is the only address no other device can ever reach.
+            # A 169.254 address usually means DHCP never answered, but two
+            # devices on the same link can still reach each other that way, so
+            # it is ranked last rather than dropped.
+            if ip.startswith("127."):
                 continue
             candidates.append(
                 InterfaceCandidate(
@@ -103,6 +109,7 @@ def network_util_list_candidates() -> List[InterfaceCandidate]:
                     is_default_route=(ip == route_ip),
                     looks_virtual=_looks_virtual(interface),
                     is_up=stats[interface].isup if interface in stats else False,
+                    is_link_local=ip.startswith("169.254."),
                 )
             )
 

--- a/backend/app/utils/share.py
+++ b/backend/app/utils/share.py
@@ -9,7 +9,7 @@ those together, which is why they are here rather than in the route module.
 from __future__ import annotations
 
 import asyncio
-from typing import Any, Dict, Optional
+from typing import List, Optional, TypedDict
 
 from app.database.albums import db_count_album_images, db_get_album
 from app.share.registry import (
@@ -20,6 +20,28 @@ from app.share.registry import (
 )
 from app.share.server import share_server_start, share_server_stop
 from app.utils.network import network_util_list_candidates
+
+
+class ShareUrlRecord(TypedDict):
+    """One reachable address for a share, as the desktop UI receives it."""
+
+    interface: str
+    ip: str
+    url: str
+
+
+class ShareDescription(TypedDict):
+    """Everything the desktop UI needs to present one share."""
+
+    token: str
+    album_id: str
+    album_name: str
+    image_count: int
+    port: int
+    created_at: str
+    expires_at: Optional[str]
+    urls: List[ShareUrlRecord]
+
 
 # Creating and revoking both decide whether the listener should be running, and
 # they must not interleave: a revoke that finds the registry empty could
@@ -50,9 +72,9 @@ async def share_util_revoke(token: str) -> bool:
         return True
 
 
-def share_util_describe(entry: ShareEntry, port: int) -> Dict[str, Any]:
+def share_util_describe(entry: ShareEntry, port: int) -> ShareDescription:
     """
-    Everything the desktop UI needs to present one share.
+    Describe one share for the desktop UI.
 
     One URL per candidate interface rather than a single address: which one a
     phone can actually reach depends on the network, so the caller chooses.

--- a/backend/app/utils/share.py
+++ b/backend/app/utils/share.py
@@ -1,0 +1,79 @@
+"""
+Orchestration for network album shares.
+
+Sits between the HTTP routes and the two pieces of state a share touches: the
+in-memory registry and the network listener. Both operations below have to move
+those together, which is why they are here rather than in the route module.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, Optional
+
+from app.database.albums import db_count_album_images, db_get_album
+from app.share.registry import (
+    ShareEntry,
+    share_registry_count,
+    share_registry_create,
+    share_registry_revoke,
+)
+from app.share.server import share_server_start, share_server_stop
+from app.utils.network import network_util_list_candidates
+
+# Creating and revoking both decide whether the listener should be running, and
+# they must not interleave: a revoke that finds the registry empty could
+# otherwise close the port a concurrent create has just handed out.
+_orchestration_lock = asyncio.Lock()
+
+
+async def share_util_create(
+    album_id: str, expires_in_minutes: Optional[int] = None
+) -> ShareEntry:
+    """Issue a token for an album and make sure the listener is up."""
+    async with _orchestration_lock:
+        await share_server_start()
+        return share_registry_create(album_id, expires_in_minutes=expires_in_minutes)
+
+
+async def share_util_revoke(token: str) -> bool:
+    """
+    End one share, stopping the listener once nothing is being served.
+
+    False means the token was already gone.
+    """
+    async with _orchestration_lock:
+        if not share_registry_revoke(token):
+            return False
+        if share_registry_count() == 0:
+            await share_server_stop()
+        return True
+
+
+def share_util_describe(entry: ShareEntry, port: int) -> Dict[str, Any]:
+    """
+    Everything the desktop UI needs to present one share.
+
+    One URL per candidate interface rather than a single address: which one a
+    phone can actually reach depends on the network, so the caller chooses.
+    """
+    album = db_get_album(entry.album_id)
+    return {
+        "token": entry.token,
+        "album_id": entry.album_id,
+        # An album deleted while shared leaves the token pointing at nothing;
+        # the viewer 404s, so say so here rather than failing the listing.
+        "album_name": album["album_name"] if album else "(deleted album)",
+        "image_count": db_count_album_images(entry.album_id),
+        "port": port,
+        "created_at": entry.created_at.isoformat(),
+        "expires_at": entry.expires_at.isoformat() if entry.expires_at else None,
+        "urls": [
+            {
+                "interface": candidate.interface,
+                "ip": candidate.ip,
+                "url": f"http://{candidate.ip}:{port}/s/{entry.token}",
+            }
+            for candidate in network_util_list_candidates()
+        ],
+    }

--- a/backend/main.py
+++ b/backend/main.py
@@ -44,7 +44,9 @@ from app.routes.face_clusters import router as face_clusters_router
 from app.routes.user_preferences import router as user_preferences_router
 from app.routes.memories import router as memories_router
 from app.routes.shutdown import router as shutdown_router
+from app.routes.share import router as share_router
 from app.routes.models import router as models_router, _cleanup_stale_tasks
+from app.share.server import share_server_stop
 from fastapi.openapi.utils import get_openapi
 from app.logging.setup_logging import (
     configure_uvicorn_logging,
@@ -104,6 +106,9 @@ async def lifespan(app: FastAPI):
     finally:
         cleanup_task.cancel()
         await asyncio.gather(cleanup_task, return_exceptions=True)
+        # Closes the only socket bound outside localhost; the in-memory share
+        # registry goes with the process.
+        await share_server_stop()
         app.state.executor.shutdown(wait=True)
 
 
@@ -180,6 +185,7 @@ app.include_router(
 )
 app.include_router(memories_router, prefix="/memories", tags=["Memories"])
 app.include_router(shutdown_router, tags=["Shutdown"])
+app.include_router(share_router, prefix="/share", tags=["Share"])
 app.include_router(models_router, prefix="/models", tags=["Models"])
 
 

--- a/backend/tests/test_albums_db.py
+++ b/backend/tests/test_albums_db.py
@@ -8,6 +8,8 @@ import bcrypt
 import pytest
 
 from app.database.albums import (
+    db_album_contains_image,
+    db_count_album_images,
     db_create_albums_table,
     db_create_album_images_table,
     db_create_album_with_images,
@@ -253,6 +255,41 @@ class TestAlbumImages:
         db_remove_images_from_album("album-1", ["img-1", "img-3"])
 
         assert db_get_album_images("album-1") == ["img-2"]
+
+
+class TestAlbumImageMembership:
+    """
+    The targeted lookups the share media path uses. Reading every id in the
+    album per request turned one page view into a quadratic number of reads.
+    """
+
+    def test_contains_image_finds_a_linked_image(self, test_db):
+        make_album("album-1", "Trip")
+        link_images(test_db, "album-1", ["img-1", "img-2"])
+
+        assert db_album_contains_image("album-1", "img-1") is True
+
+    def test_contains_image_rejects_an_image_from_another_album(self, test_db):
+        make_album("album-1", "Trip")
+        make_album("album-2", "Private")
+        link_images(test_db, "album-1", ["img-1"])
+        link_images(test_db, "album-2", ["img-2"])
+
+        assert db_album_contains_image("album-1", "img-2") is False
+
+    def test_contains_image_rejects_an_unknown_image(self, test_db):
+        make_album("album-1", "Trip")
+        assert db_album_contains_image("album-1", "nope") is False
+
+    def test_counts_images_without_reading_them(self, test_db):
+        make_album("album-1", "Trip")
+        link_images(test_db, "album-1", ["img-1", "img-2", "img-3"])
+
+        assert db_count_album_images("album-1") == 3
+
+    def test_counts_zero_for_an_empty_album(self, test_db):
+        make_album("album-1", "Trip")
+        assert db_count_album_images("album-1") == 0
 
 
 class TestAlbumCreatedAt:

--- a/backend/tests/test_albums_db.py
+++ b/backend/tests/test_albums_db.py
@@ -263,13 +263,15 @@ class TestAlbumImageMembership:
     album per request turned one page view into a quadratic number of reads.
     """
 
-    def test_contains_image_finds_a_linked_image(self, test_db):
+    def test_contains_image_finds_a_linked_image(self, test_db: str) -> None:
         make_album("album-1", "Trip")
         link_images(test_db, "album-1", ["img-1", "img-2"])
 
         assert db_album_contains_image("album-1", "img-1") is True
 
-    def test_contains_image_rejects_an_image_from_another_album(self, test_db):
+    def test_contains_image_rejects_an_image_from_another_album(
+        self, test_db: str
+    ) -> None:
         make_album("album-1", "Trip")
         make_album("album-2", "Private")
         link_images(test_db, "album-1", ["img-1"])
@@ -277,17 +279,17 @@ class TestAlbumImageMembership:
 
         assert db_album_contains_image("album-1", "img-2") is False
 
-    def test_contains_image_rejects_an_unknown_image(self, test_db):
+    def test_contains_image_rejects_an_unknown_image(self, test_db: str) -> None:
         make_album("album-1", "Trip")
         assert db_album_contains_image("album-1", "nope") is False
 
-    def test_counts_images_without_reading_them(self, test_db):
+    def test_counts_images_without_reading_them(self, test_db: str) -> None:
         make_album("album-1", "Trip")
         link_images(test_db, "album-1", ["img-1", "img-2", "img-3"])
 
         assert db_count_album_images("album-1") == 3
 
-    def test_counts_zero_for_an_empty_album(self, test_db):
+    def test_counts_zero_for_an_empty_album(self, test_db: str) -> None:
         make_album("album-1", "Trip")
         assert db_count_album_images("album-1") == 0
 

--- a/backend/tests/test_network_utils.py
+++ b/backend/tests/test_network_utils.py
@@ -1,0 +1,119 @@
+import socket
+from collections import namedtuple
+
+import pytest
+
+from app.utils.network import (
+    network_util_best_candidate,
+    network_util_list_candidates,
+)
+
+# Mirrors the shapes psutil returns, minus the fields this module ignores.
+FakeAddr = namedtuple("FakeAddr", ["family", "address"])
+FakeStats = namedtuple("FakeStats", ["isup"])
+
+
+def ipv4(address: str) -> FakeAddr:
+    return FakeAddr(family=socket.AF_INET, address=address)
+
+
+def ipv6(address: str) -> FakeAddr:
+    return FakeAddr(family=socket.AF_INET6, address=address)
+
+
+@pytest.fixture
+def fake_interfaces(monkeypatch: pytest.MonkeyPatch):
+    """Install a fake adapter list and default route."""
+
+    def install(addrs: dict, stats: dict, route_ip=None) -> None:
+        monkeypatch.setattr(
+            "app.utils.network.psutil.net_if_addrs", lambda: addrs, raising=False
+        )
+        monkeypatch.setattr(
+            "app.utils.network.psutil.net_if_stats", lambda: stats, raising=False
+        )
+        monkeypatch.setattr(
+            "app.utils.network.network_util_default_route_ip", lambda: route_ip
+        )
+
+    return install
+
+
+class TestCandidateFiltering:
+    def test_drops_loopback_and_link_local(self, fake_interfaces):
+        fake_interfaces(
+            {
+                "lo": [ipv4("127.0.0.1")],
+                "Ethernet": [ipv4("169.254.119.169")],
+                "Wi-Fi": [ipv4("10.170.93.60")],
+            },
+            {
+                "lo": FakeStats(True),
+                "Ethernet": FakeStats(True),
+                "Wi-Fi": FakeStats(True),
+            },
+        )
+        assert [c.ip for c in network_util_list_candidates()] == ["10.170.93.60"]
+
+    def test_ignores_ipv6(self, fake_interfaces):
+        fake_interfaces(
+            {"Wi-Fi": [ipv6("fe80::1"), ipv4("192.168.1.5")]},
+            {"Wi-Fi": FakeStats(True)},
+        )
+        assert [c.ip for c in network_util_list_candidates()] == ["192.168.1.5"]
+
+    def test_no_candidates_when_offline(self, fake_interfaces):
+        fake_interfaces({"lo": [ipv4("127.0.0.1")]}, {"lo": FakeStats(True)})
+        assert network_util_list_candidates() == []
+        assert network_util_best_candidate() is None
+
+
+class TestCandidateRanking:
+    def test_default_route_wins(self, fake_interfaces):
+        fake_interfaces(
+            {
+                "Ethernet 2": [ipv4("10.168.36.61")],
+                "Wi-Fi": [ipv4("10.170.93.60")],
+            },
+            {"Ethernet 2": FakeStats(True), "Wi-Fi": FakeStats(True)},
+            route_ip="10.170.93.60",
+        )
+        best = network_util_best_candidate()
+        assert best.ip == "10.170.93.60"
+        assert best.is_default_route
+
+    def test_virtual_adapters_sort_last(self, fake_interfaces):
+        """The case that broke the naive picker: VMware outranking real hardware."""
+        fake_interfaces(
+            {
+                "VMware Network Adapter VMnet1": [ipv4("192.168.65.1")],
+                "VMware Network Adapter VMnet8": [ipv4("192.168.220.1")],
+                "Wi-Fi": [ipv4("10.170.93.60")],
+            },
+            {
+                "VMware Network Adapter VMnet1": FakeStats(True),
+                "VMware Network Adapter VMnet8": FakeStats(True),
+                "Wi-Fi": FakeStats(True),
+            },
+        )
+        candidates = network_util_list_candidates()
+        assert candidates[0].ip == "10.170.93.60"
+        assert candidates[0].looks_virtual is False
+        assert all(c.looks_virtual for c in candidates[1:])
+
+    def test_down_interface_sorts_below_up(self, fake_interfaces):
+        """A disconnected adapter can keep a stale DHCP lease that still looks real."""
+        fake_interfaces(
+            {
+                "Wi-Fi": [ipv4("10.170.93.60")],
+                "Ethernet 2": [ipv4("10.168.36.61")],
+            },
+            {"Wi-Fi": FakeStats(False), "Ethernet 2": FakeStats(True)},
+        )
+        candidates = network_util_list_candidates()
+        assert candidates[0].ip == "10.168.36.61"
+        assert candidates[-1].is_up is False
+
+    def test_missing_stats_entry_is_not_fatal(self, fake_interfaces):
+        fake_interfaces({"Wi-Fi": [ipv4("10.0.0.5")]}, {})
+        assert network_util_list_candidates()[0].is_up is False

--- a/backend/tests/test_network_utils.py
+++ b/backend/tests/test_network_utils.py
@@ -1,5 +1,6 @@
 import socket
 from collections import namedtuple
+from typing import Dict, Iterator, List, Optional, Protocol
 
 import pytest
 
@@ -13,6 +14,17 @@ FakeAddr = namedtuple("FakeAddr", ["family", "address"])
 FakeStats = namedtuple("FakeStats", ["isup"])
 
 
+class InstallInterfaces(Protocol):
+    """Signature of the callable the fake_interfaces fixture hands back."""
+
+    def __call__(
+        self,
+        addrs: Dict[str, List[FakeAddr]],
+        stats: Dict[str, FakeStats],
+        route_ip: Optional[str] = None,
+    ) -> None: ...
+
+
 def ipv4(address: str) -> FakeAddr:
     return FakeAddr(family=socket.AF_INET, address=address)
 
@@ -22,10 +34,14 @@ def ipv6(address: str) -> FakeAddr:
 
 
 @pytest.fixture
-def fake_interfaces(monkeypatch: pytest.MonkeyPatch):
+def fake_interfaces(monkeypatch: pytest.MonkeyPatch) -> Iterator[InstallInterfaces]:
     """Install a fake adapter list and default route."""
 
-    def install(addrs: dict, stats: dict, route_ip=None) -> None:
+    def install(
+        addrs: Dict[str, List[FakeAddr]],
+        stats: Dict[str, FakeStats],
+        route_ip: Optional[str] = None,
+    ) -> None:
         monkeypatch.setattr(
             "app.utils.network.psutil.net_if_addrs", lambda: addrs, raising=False
         )
@@ -36,45 +52,50 @@ def fake_interfaces(monkeypatch: pytest.MonkeyPatch):
             "app.utils.network.network_util_default_route_ip", lambda: route_ip
         )
 
-    return install
+    yield install
 
 
 class TestCandidateFiltering:
-    def test_drops_loopback_and_link_local(self, fake_interfaces):
+    def test_drops_loopback(self, fake_interfaces: InstallInterfaces) -> None:
         fake_interfaces(
-            {
-                "lo": [ipv4("127.0.0.1")],
-                "Ethernet": [ipv4("169.254.119.169")],
-                "Wi-Fi": [ipv4("10.170.93.60")],
-            },
-            {
-                "lo": FakeStats(True),
-                "Ethernet": FakeStats(True),
-                "Wi-Fi": FakeStats(True),
-            },
+            {"lo": [ipv4("127.0.0.1")], "Wi-Fi": [ipv4("10.170.93.60")]},
+            {"lo": FakeStats(True), "Wi-Fi": FakeStats(True)},
         )
         assert [c.ip for c in network_util_list_candidates()] == ["10.170.93.60"]
 
-    def test_ignores_ipv6(self, fake_interfaces):
+    def test_keeps_link_local(self, fake_interfaces: InstallInterfaces) -> None:
+        """
+        A 169.254 address usually means DHCP failed, but two devices on the
+        same link can still reach each other through it.
+        """
+        fake_interfaces(
+            {"Wi-Fi": [ipv4("169.254.119.169")]}, {"Wi-Fi": FakeStats(True)}
+        )
+        candidates = network_util_list_candidates()
+        assert [c.ip for c in candidates] == ["169.254.119.169"]
+        assert candidates[0].is_link_local is True
+
+    def test_ignores_ipv6(self, fake_interfaces: InstallInterfaces) -> None:
         fake_interfaces(
             {"Wi-Fi": [ipv6("fe80::1"), ipv4("192.168.1.5")]},
             {"Wi-Fi": FakeStats(True)},
         )
         assert [c.ip for c in network_util_list_candidates()] == ["192.168.1.5"]
 
-    def test_no_candidates_when_offline(self, fake_interfaces):
+    def test_no_candidates_when_offline(
+        self, fake_interfaces: InstallInterfaces
+    ) -> None:
         fake_interfaces({"lo": [ipv4("127.0.0.1")]}, {"lo": FakeStats(True)})
         assert network_util_list_candidates() == []
         assert network_util_best_candidate() is None
 
 
 class TestCandidateRanking:
-    def test_default_route_wins(self, fake_interfaces):
+    def test_default_route_wins_among_live_interfaces(
+        self, fake_interfaces: InstallInterfaces
+    ) -> None:
         fake_interfaces(
-            {
-                "Ethernet 2": [ipv4("10.168.36.61")],
-                "Wi-Fi": [ipv4("10.170.93.60")],
-            },
+            {"Ethernet 2": [ipv4("10.168.36.61")], "Wi-Fi": [ipv4("10.170.93.60")]},
             {"Ethernet 2": FakeStats(True), "Wi-Fi": FakeStats(True)},
             route_ip="10.170.93.60",
         )
@@ -82,7 +103,25 @@ class TestCandidateRanking:
         assert best.ip == "10.170.93.60"
         assert best.is_default_route
 
-    def test_virtual_adapters_sort_last(self, fake_interfaces):
+    def test_live_interface_beats_a_downed_default_route(
+        self, fake_interfaces: InstallInterfaces
+    ) -> None:
+        """
+        Windows keeps a stale lease and default route on a disconnected
+        adapter, and an address there can never accept a connection.
+        """
+        fake_interfaces(
+            {"Wi-Fi": [ipv4("10.170.93.60")], "Ethernet 2": [ipv4("10.168.36.61")]},
+            {"Wi-Fi": FakeStats(False), "Ethernet 2": FakeStats(True)},
+            route_ip="10.170.93.60",
+        )
+        best = network_util_best_candidate()
+        assert best.ip == "10.168.36.61"
+        assert best.is_up is True
+
+    def test_virtual_adapters_sort_last(
+        self, fake_interfaces: InstallInterfaces
+    ) -> None:
         """The case that broke the naive picker: VMware outranking real hardware."""
         fake_interfaces(
             {
@@ -101,19 +140,39 @@ class TestCandidateRanking:
         assert candidates[0].looks_virtual is False
         assert all(c.looks_virtual for c in candidates[1:])
 
-    def test_down_interface_sorts_below_up(self, fake_interfaces):
-        """A disconnected adapter can keep a stale DHCP lease that still looks real."""
+    def test_link_local_sorts_below_a_routable_address(
+        self, fake_interfaces: InstallInterfaces
+    ) -> None:
+        fake_interfaces(
+            {"Wi-Fi": [ipv4("169.254.119.169")], "Ethernet 2": [ipv4("10.168.36.61")]},
+            {"Wi-Fi": FakeStats(True), "Ethernet 2": FakeStats(True)},
+        )
+        assert [c.ip for c in network_util_list_candidates()] == [
+            "10.168.36.61",
+            "169.254.119.169",
+        ]
+
+    def test_link_local_on_real_hardware_beats_a_virtual_adapter(
+        self, fake_interfaces: InstallInterfaces
+    ) -> None:
+        """
+        When DHCP has failed everywhere, the real adapter is still the only one
+        a second device could be sharing a link with.
+        """
         fake_interfaces(
             {
-                "Wi-Fi": [ipv4("10.170.93.60")],
-                "Ethernet 2": [ipv4("10.168.36.61")],
+                "Wi-Fi": [ipv4("169.254.119.169")],
+                "VMware Network Adapter VMnet1": [ipv4("192.168.65.1")],
             },
-            {"Wi-Fi": FakeStats(False), "Ethernet 2": FakeStats(True)},
+            {
+                "Wi-Fi": FakeStats(True),
+                "VMware Network Adapter VMnet1": FakeStats(True),
+            },
         )
-        candidates = network_util_list_candidates()
-        assert candidates[0].ip == "10.168.36.61"
-        assert candidates[-1].is_up is False
+        assert network_util_best_candidate().ip == "169.254.119.169"
 
-    def test_missing_stats_entry_is_not_fatal(self, fake_interfaces):
+    def test_missing_stats_entry_is_not_fatal(
+        self, fake_interfaces: InstallInterfaces
+    ) -> None:
         fake_interfaces({"Wi-Fi": [ipv4("10.0.0.5")]}, {})
         assert network_util_list_candidates()[0].is_up is False

--- a/backend/tests/test_network_utils.py
+++ b/backend/tests/test_network_utils.py
@@ -100,6 +100,7 @@ class TestCandidateRanking:
             route_ip="10.170.93.60",
         )
         best = network_util_best_candidate()
+        assert best is not None
         assert best.ip == "10.170.93.60"
         assert best.is_default_route
 
@@ -116,6 +117,7 @@ class TestCandidateRanking:
             route_ip="10.170.93.60",
         )
         best = network_util_best_candidate()
+        assert best is not None
         assert best.ip == "10.168.36.61"
         assert best.is_up is True
 
@@ -169,7 +171,9 @@ class TestCandidateRanking:
                 "VMware Network Adapter VMnet1": FakeStats(True),
             },
         )
-        assert network_util_best_candidate().ip == "169.254.119.169"
+        best = network_util_best_candidate()
+        assert best is not None
+        assert best.ip == "169.254.119.169"
 
     def test_missing_stats_entry_is_not_fatal(
         self, fake_interfaces: InstallInterfaces

--- a/backend/tests/test_share_registry.py
+++ b/backend/tests/test_share_registry.py
@@ -1,0 +1,108 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.share.registry import (
+    share_registry_clear,
+    share_registry_count,
+    share_registry_create,
+    share_registry_get,
+    share_registry_list,
+    share_registry_revoke,
+)
+
+
+@pytest.fixture(autouse=True)
+def empty_registry():
+    """The registry is module state, so it has to be reset between tests."""
+    share_registry_clear()
+    yield
+    share_registry_clear()
+
+
+def expire(token: str) -> None:
+    """Backdate a share's expiry so lookups treat it as stale."""
+    entry = share_registry_get(token)
+    entry.expires_at = datetime.now(timezone.utc) - timedelta(seconds=1)
+
+
+class TestCreate:
+    def test_returns_a_live_entry(self):
+        entry = share_registry_create("album-1")
+        assert entry.album_id == "album-1"
+        assert share_registry_get(entry.token) is entry
+
+    def test_tokens_are_unguessable_and_unique(self):
+        tokens = {share_registry_create("album-1").token for _ in range(50)}
+        assert len(tokens) == 50
+        # token_urlsafe(32) is 43 characters; anything shorter means the token
+        # size regressed, which is the whole protection for a shared album.
+        assert all(len(token) >= 43 for token in tokens)
+
+    def test_no_expiry_by_default(self):
+        assert share_registry_create("album-1").expires_at is None
+
+    def test_sharing_twice_leaves_both_valid(self):
+        first = share_registry_create("album-1")
+        second = share_registry_create("album-1")
+        assert first.token != second.token
+        assert share_registry_get(first.token) is not None
+        assert share_registry_get(second.token) is not None
+
+
+class TestLookup:
+    def test_unknown_token_is_none(self):
+        assert share_registry_get("nope") is None
+
+    def test_expired_token_is_none(self):
+        entry = share_registry_create("album-1", expires_in_minutes=5)
+        expire(entry.token)
+        assert share_registry_get(entry.token) is None
+
+    def test_expired_token_is_dropped_not_just_hidden(self):
+        entry = share_registry_create("album-1", expires_in_minutes=5)
+        expire(entry.token)
+        share_registry_get(entry.token)
+        assert share_registry_count() == 0
+
+    def test_unexpired_token_survives(self):
+        entry = share_registry_create("album-1", expires_in_minutes=60)
+        assert share_registry_get(entry.token) is not None
+
+
+class TestRevoke:
+    def test_revoking_removes_the_share(self):
+        entry = share_registry_create("album-1")
+        assert share_registry_revoke(entry.token) is True
+        assert share_registry_get(entry.token) is None
+
+    def test_revoking_twice_reports_the_second_as_absent(self):
+        entry = share_registry_create("album-1")
+        share_registry_revoke(entry.token)
+        assert share_registry_revoke(entry.token) is False
+
+    def test_revoking_leaves_other_shares_alone(self):
+        keep = share_registry_create("album-1")
+        drop = share_registry_create("album-2")
+        share_registry_revoke(drop.token)
+        assert share_registry_get(keep.token) is not None
+
+
+class TestListing:
+    def test_lists_newest_first(self):
+        older = share_registry_create("album-1")
+        older.created_at -= timedelta(minutes=5)
+        newer = share_registry_create("album-2")
+        assert [e.token for e in share_registry_list()] == [newer.token, older.token]
+
+    def test_expired_shares_are_omitted(self):
+        live = share_registry_create("album-1")
+        dead = share_registry_create("album-2", expires_in_minutes=5)
+        expire(dead.token)
+        assert [e.token for e in share_registry_list()] == [live.token]
+
+    def test_count_tracks_live_shares(self):
+        assert share_registry_count() == 0
+        share_registry_create("album-1")
+        share_registry_create("album-2")
+        assert share_registry_count() == 2

--- a/backend/tests/test_share_registry.py
+++ b/backend/tests/test_share_registry.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta, timezone
+from typing import Iterator
 
 import pytest
 
@@ -13,7 +14,7 @@ from app.share.registry import (
 
 
 @pytest.fixture(autouse=True)
-def empty_registry():
+def empty_registry() -> Iterator[None]:
     """The registry is module state, so it has to be reset between tests."""
     share_registry_clear()
     yield
@@ -23,26 +24,27 @@ def empty_registry():
 def expire(token: str) -> None:
     """Backdate a share's expiry so lookups treat it as stale."""
     entry = share_registry_get(token)
+    assert entry is not None
     entry.expires_at = datetime.now(timezone.utc) - timedelta(seconds=1)
 
 
 class TestCreate:
-    def test_returns_a_live_entry(self):
+    def test_returns_a_live_entry(self) -> None:
         entry = share_registry_create("album-1")
         assert entry.album_id == "album-1"
         assert share_registry_get(entry.token) is entry
 
-    def test_tokens_are_unguessable_and_unique(self):
+    def test_tokens_are_unguessable_and_unique(self) -> None:
         tokens = {share_registry_create("album-1").token for _ in range(50)}
         assert len(tokens) == 50
         # token_urlsafe(32) is 43 characters; anything shorter means the token
         # size regressed, which is the whole protection for a shared album.
         assert all(len(token) >= 43 for token in tokens)
 
-    def test_no_expiry_by_default(self):
+    def test_no_expiry_by_default(self) -> None:
         assert share_registry_create("album-1").expires_at is None
 
-    def test_sharing_twice_leaves_both_valid(self):
+    def test_sharing_twice_leaves_both_valid(self) -> None:
         first = share_registry_create("album-1")
         second = share_registry_create("album-1")
         assert first.token != second.token
@@ -51,37 +53,37 @@ class TestCreate:
 
 
 class TestLookup:
-    def test_unknown_token_is_none(self):
+    def test_unknown_token_is_none(self) -> None:
         assert share_registry_get("nope") is None
 
-    def test_expired_token_is_none(self):
+    def test_expired_token_is_none(self) -> None:
         entry = share_registry_create("album-1", expires_in_minutes=5)
         expire(entry.token)
         assert share_registry_get(entry.token) is None
 
-    def test_expired_token_is_dropped_not_just_hidden(self):
+    def test_expired_token_is_dropped_not_just_hidden(self) -> None:
         entry = share_registry_create("album-1", expires_in_minutes=5)
         expire(entry.token)
         share_registry_get(entry.token)
         assert share_registry_count() == 0
 
-    def test_unexpired_token_survives(self):
+    def test_unexpired_token_survives(self) -> None:
         entry = share_registry_create("album-1", expires_in_minutes=60)
         assert share_registry_get(entry.token) is not None
 
 
 class TestRevoke:
-    def test_revoking_removes_the_share(self):
+    def test_revoking_removes_the_share(self) -> None:
         entry = share_registry_create("album-1")
         assert share_registry_revoke(entry.token) is True
         assert share_registry_get(entry.token) is None
 
-    def test_revoking_twice_reports_the_second_as_absent(self):
+    def test_revoking_twice_reports_the_second_as_absent(self) -> None:
         entry = share_registry_create("album-1")
         share_registry_revoke(entry.token)
         assert share_registry_revoke(entry.token) is False
 
-    def test_revoking_leaves_other_shares_alone(self):
+    def test_revoking_leaves_other_shares_alone(self) -> None:
         keep = share_registry_create("album-1")
         drop = share_registry_create("album-2")
         share_registry_revoke(drop.token)
@@ -89,19 +91,19 @@ class TestRevoke:
 
 
 class TestListing:
-    def test_lists_newest_first(self):
+    def test_lists_newest_first(self) -> None:
         older = share_registry_create("album-1")
         older.created_at -= timedelta(minutes=5)
         newer = share_registry_create("album-2")
         assert [e.token for e in share_registry_list()] == [newer.token, older.token]
 
-    def test_expired_shares_are_omitted(self):
+    def test_expired_shares_are_omitted(self) -> None:
         live = share_registry_create("album-1")
         dead = share_registry_create("album-2", expires_in_minutes=5)
         expire(dead.token)
         assert [e.token for e in share_registry_list()] == [live.token]
 
-    def test_count_tracks_live_shares(self):
+    def test_count_tracks_live_shares(self) -> None:
         assert share_registry_count() == 0
         share_registry_create("album-1")
         share_registry_create("album-2")

--- a/backend/tests/test_share_routes.py
+++ b/backend/tests/test_share_routes.py
@@ -2,7 +2,8 @@ import os
 import sqlite3
 import tempfile
 from datetime import datetime, timedelta, timezone
-from typing import Iterator, List
+from pathlib import Path
+from typing import Iterator, List, TypedDict
 
 import pytest
 from fastapi.testclient import TestClient
@@ -25,8 +26,17 @@ JPEG_BYTES = b"\xff\xd8\xff\xe0fake-jpeg-body\xff\xd9"
 THUMB_BYTES = b"\xff\xd8\xff\xe0fake-thumb-body\xff\xd9"
 
 
+class ShareEnv(TypedDict):
+    """What the share_env fixture hands each test."""
+
+    client: TestClient
+    token: str
+    tmp_path: Path
+    db_path: str
+
+
 @pytest.fixture
-def share_env(monkeypatch: pytest.MonkeyPatch, tmp_path) -> Iterator[dict]:
+def share_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Iterator[ShareEnv]:
     """A share server backed by a throwaway database and real image files."""
     db_fd, db_path = tempfile.mkstemp()
     os.close(db_fd)
@@ -86,28 +96,28 @@ def share_env(monkeypatch: pytest.MonkeyPatch, tmp_path) -> Iterator[dict]:
 
 
 def expire(token: str) -> None:
-    share_registry_get(token).expires_at = datetime.now(timezone.utc) - timedelta(
-        seconds=1
-    )
+    entry = share_registry_get(token)
+    assert entry is not None
+    entry.expires_at = datetime.now(timezone.utc) - timedelta(seconds=1)
 
 
 class TestViewer:
-    def test_renders_the_album(self, share_env):
+    def test_renders_the_album(self, share_env: ShareEnv) -> None:
         response = share_env["client"].get(f"/s/{share_env['token']}")
         assert response.status_code == 200
         assert "Trip to Goa" in response.text
         assert "2 photos" in response.text
 
-    def test_links_every_image_in_the_album(self, share_env):
+    def test_links_every_image_in_the_album(self, share_env: ShareEnv) -> None:
         response = share_env["client"].get(f"/s/{share_env['token']}")
         assert "img-1" in response.text
         assert "img-2" in response.text
 
-    def test_does_not_link_images_from_other_albums(self, share_env):
+    def test_does_not_link_images_from_other_albums(self, share_env: ShareEnv) -> None:
         response = share_env["client"].get(f"/s/{share_env['token']}")
         assert "other-1" not in response.text
 
-    def test_never_exposes_a_filesystem_path(self, share_env):
+    def test_never_exposes_a_filesystem_path(self, share_env: ShareEnv) -> None:
         """The receiver works in IDs; leaking paths would map the host's disk."""
         response = share_env["client"].get(f"/s/{share_env['token']}")
         assert str(share_env["tmp_path"]) not in response.text
@@ -115,35 +125,35 @@ class TestViewer:
 
 
 class TestTokenLifecycle:
-    def test_unknown_token_is_404(self, share_env):
+    def test_unknown_token_is_404(self, share_env: ShareEnv) -> None:
         assert share_env["client"].get("/s/made-up-token").status_code == 404
 
-    def test_revoked_token_is_404(self, share_env):
+    def test_revoked_token_is_404(self, share_env: ShareEnv) -> None:
         share_registry_revoke(share_env["token"])
         assert share_env["client"].get(f"/s/{share_env['token']}").status_code == 404
 
-    def test_expired_token_is_404(self, share_env):
+    def test_expired_token_is_404(self, share_env: ShareEnv) -> None:
         expire(share_env["token"])
         assert share_env["client"].get(f"/s/{share_env['token']}").status_code == 404
 
-    def test_revoked_token_cannot_still_fetch_media(self, share_env):
+    def test_revoked_token_cannot_still_fetch_media(self, share_env: ShareEnv) -> None:
         share_registry_revoke(share_env["token"])
         response = share_env["client"].get(f"/s/{share_env['token']}/photo/img-1")
         assert response.status_code == 404
 
 
 class TestMedia:
-    def test_serves_the_thumbnail_for_the_grid(self, share_env):
+    def test_serves_the_thumbnail_for_the_grid(self, share_env: ShareEnv) -> None:
         response = share_env["client"].get(f"/s/{share_env['token']}/thumb/img-1")
         assert response.status_code == 200
         assert response.content == THUMB_BYTES
 
-    def test_serves_the_original_for_full_view(self, share_env):
+    def test_serves_the_original_for_full_view(self, share_env: ShareEnv) -> None:
         response = share_env["client"].get(f"/s/{share_env['token']}/photo/img-1")
         assert response.status_code == 200
         assert response.content == JPEG_BYTES
 
-    def test_image_from_another_album_is_refused(self, share_env):
+    def test_image_from_another_album_is_refused(self, share_env: ShareEnv) -> None:
         """
         The invariant that keeps a share token from being a read handle over
         every image PictoPy has indexed.
@@ -151,35 +161,35 @@ class TestMedia:
         response = share_env["client"].get(f"/s/{share_env['token']}/photo/other-1")
         assert response.status_code == 404
 
-    def test_unknown_image_id_is_404(self, share_env):
+    def test_unknown_image_id_is_404(self, share_env: ShareEnv) -> None:
         response = share_env["client"].get(f"/s/{share_env['token']}/photo/nope")
         assert response.status_code == 404
 
-    def test_missing_file_on_disk_is_404(self, share_env):
+    def test_missing_file_on_disk_is_404(self, share_env: ShareEnv) -> None:
         (share_env["tmp_path"] / "img-1.jpg").unlink()
         response = share_env["client"].get(f"/s/{share_env['token']}/photo/img-1")
         assert response.status_code == 404
 
 
 class TestViewerChrome:
-    def test_thumbnails_are_lazy(self, share_env):
+    def test_thumbnails_are_lazy(self, share_env: ShareEnv) -> None:
         """Tiles carry data-src so a large album does not fetch every photo."""
         body = share_env["client"].get(f"/s/{share_env['token']}").text
         assert 'data-src="/s/' in body
         assert body.count("data-src=") == 2
 
-    def test_lightbox_and_filmstrip_are_present(self, share_env):
+    def test_lightbox_and_filmstrip_are_present(self, share_env: ShareEnv) -> None:
         body = share_env["client"].get(f"/s/{share_env['token']}").text
         assert 'id="lightbox"' in body
         assert 'id="filmstrip"' in body
         assert body.count('class="filmstrip-thumb"') == 2
 
-    def test_theme_control_is_present(self, share_env):
+    def test_theme_control_is_present(self, share_env: ShareEnv) -> None:
         body = share_env["client"].get(f"/s/{share_env['token']}").text
         for choice in ('data-theme="auto"', 'data-theme="light"', 'data-theme="dark"'):
             assert choice in body
 
-    def test_no_external_resources(self, share_env):
+    def test_no_external_resources(self, share_env: ShareEnv) -> None:
         """
         The page has to render on a network with no route to the internet — a
         hotspot between two devices is the fallback when the LAN blocks peers.
@@ -188,7 +198,7 @@ class TestViewerChrome:
         assert "http://" not in body.replace("http://www.w3.org", "")
         assert "https://" not in body.replace("https://www.w3.org", "")
 
-    def test_expiry_is_shown_only_when_set(self, share_env):
+    def test_expiry_is_shown_only_when_set(self, share_env: ShareEnv) -> None:
         assert "Expires" not in share_env["client"].get(f"/s/{share_env['token']}").text
 
         entry = share_registry_create("album-1", expires_in_minutes=30)
@@ -196,7 +206,7 @@ class TestViewerChrome:
         assert "Expires" in body
         assert entry.expires_at.isoformat() in body
 
-    def test_album_name_is_escaped(self, share_env):
+    def test_album_name_is_escaped(self, share_env: ShareEnv) -> None:
         """An album named after a script tag must not become one."""
         conn = sqlite3.connect(share_env["db_path"])
         conn.execute(
@@ -212,13 +222,13 @@ class TestViewerChrome:
 
 
 class TestSurface:
-    def test_docs_are_not_exposed(self, share_env):
+    def test_docs_are_not_exposed(self, share_env: ShareEnv) -> None:
         """The share app is public; its route list should not be enumerable."""
         client = share_env["client"]
         assert client.get("/docs").status_code == 404
         assert client.get("/openapi.json").status_code == 404
 
-    def test_main_backend_routes_are_absent(self, share_env):
+    def test_main_backend_routes_are_absent(self, share_env: ShareEnv) -> None:
         client = share_env["client"]
         for path in ("/health", "/albums/", "/images/", "/shutdown"):
             assert client.get(path).status_code == 404

--- a/backend/tests/test_share_routes.py
+++ b/backend/tests/test_share_routes.py
@@ -1,0 +1,224 @@
+import os
+import sqlite3
+import tempfile
+from datetime import datetime, timedelta, timezone
+from typing import Iterator, List
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.database.albums import (
+    db_create_album_images_table,
+    db_create_albums_table,
+    db_insert_album,
+)
+from app.database.images import db_create_images_table
+from app.share.app import create_share_app
+from app.share.registry import (
+    share_registry_clear,
+    share_registry_create,
+    share_registry_get,
+    share_registry_revoke,
+)
+
+JPEG_BYTES = b"\xff\xd8\xff\xe0fake-jpeg-body\xff\xd9"
+THUMB_BYTES = b"\xff\xd8\xff\xe0fake-thumb-body\xff\xd9"
+
+
+@pytest.fixture
+def share_env(monkeypatch: pytest.MonkeyPatch, tmp_path) -> Iterator[dict]:
+    """A share server backed by a throwaway database and real image files."""
+    db_fd, db_path = tempfile.mkstemp()
+    os.close(db_fd)
+
+    monkeypatch.setattr("app.config.settings.DATABASE_PATH", db_path)
+    monkeypatch.setattr("app.database.albums.DATABASE_PATH", db_path)
+    monkeypatch.setattr("app.database.images.DATABASE_PATH", db_path)
+    monkeypatch.setattr("app.database.connection.DATABASE_PATH", db_path)
+
+    db_create_albums_table()
+    db_create_album_images_table()
+    db_create_images_table()
+
+    share_registry_clear()
+
+    def add_image(image_id: str) -> None:
+        photo = tmp_path / f"{image_id}.jpg"
+        thumb = tmp_path / f"{image_id}_thumb.jpg"
+        photo.write_bytes(JPEG_BYTES)
+        thumb.write_bytes(THUMB_BYTES)
+        conn = sqlite3.connect(db_path)
+        conn.execute(
+            "INSERT INTO images (id, path, thumbnailPath) VALUES (?, ?, ?)",
+            (image_id, str(photo), str(thumb)),
+        )
+        conn.commit()
+        conn.close()
+
+    def link(album_id: str, image_ids: List[str]) -> None:
+        conn = sqlite3.connect(db_path)
+        conn.executemany(
+            "INSERT INTO album_images (album_id, image_id) VALUES (?, ?)",
+            [(album_id, image_id) for image_id in image_ids],
+        )
+        conn.commit()
+        conn.close()
+
+    db_insert_album("album-1", "Trip to Goa", "", False, None)
+    db_insert_album("album-2", "Private", "", False, None)
+    for image_id in ("img-1", "img-2", "other-1"):
+        add_image(image_id)
+    link("album-1", ["img-1", "img-2"])
+    link("album-2", ["other-1"])
+
+    entry = share_registry_create("album-1")
+
+    with TestClient(create_share_app()) as client:
+        yield {
+            "client": client,
+            "token": entry.token,
+            "tmp_path": tmp_path,
+            "db_path": db_path,
+        }
+
+    share_registry_clear()
+    os.unlink(db_path)
+
+
+def expire(token: str) -> None:
+    share_registry_get(token).expires_at = datetime.now(timezone.utc) - timedelta(
+        seconds=1
+    )
+
+
+class TestViewer:
+    def test_renders_the_album(self, share_env):
+        response = share_env["client"].get(f"/s/{share_env['token']}")
+        assert response.status_code == 200
+        assert "Trip to Goa" in response.text
+        assert "2 photos" in response.text
+
+    def test_links_every_image_in_the_album(self, share_env):
+        response = share_env["client"].get(f"/s/{share_env['token']}")
+        assert "img-1" in response.text
+        assert "img-2" in response.text
+
+    def test_does_not_link_images_from_other_albums(self, share_env):
+        response = share_env["client"].get(f"/s/{share_env['token']}")
+        assert "other-1" not in response.text
+
+    def test_never_exposes_a_filesystem_path(self, share_env):
+        """The receiver works in IDs; leaking paths would map the host's disk."""
+        response = share_env["client"].get(f"/s/{share_env['token']}")
+        assert str(share_env["tmp_path"]) not in response.text
+        assert ".jpg" not in response.text
+
+
+class TestTokenLifecycle:
+    def test_unknown_token_is_404(self, share_env):
+        assert share_env["client"].get("/s/made-up-token").status_code == 404
+
+    def test_revoked_token_is_404(self, share_env):
+        share_registry_revoke(share_env["token"])
+        assert share_env["client"].get(f"/s/{share_env['token']}").status_code == 404
+
+    def test_expired_token_is_404(self, share_env):
+        expire(share_env["token"])
+        assert share_env["client"].get(f"/s/{share_env['token']}").status_code == 404
+
+    def test_revoked_token_cannot_still_fetch_media(self, share_env):
+        share_registry_revoke(share_env["token"])
+        response = share_env["client"].get(f"/s/{share_env['token']}/photo/img-1")
+        assert response.status_code == 404
+
+
+class TestMedia:
+    def test_serves_the_thumbnail_for_the_grid(self, share_env):
+        response = share_env["client"].get(f"/s/{share_env['token']}/thumb/img-1")
+        assert response.status_code == 200
+        assert response.content == THUMB_BYTES
+
+    def test_serves_the_original_for_full_view(self, share_env):
+        response = share_env["client"].get(f"/s/{share_env['token']}/photo/img-1")
+        assert response.status_code == 200
+        assert response.content == JPEG_BYTES
+
+    def test_image_from_another_album_is_refused(self, share_env):
+        """
+        The invariant that keeps a share token from being a read handle over
+        every image PictoPy has indexed.
+        """
+        response = share_env["client"].get(f"/s/{share_env['token']}/photo/other-1")
+        assert response.status_code == 404
+
+    def test_unknown_image_id_is_404(self, share_env):
+        response = share_env["client"].get(f"/s/{share_env['token']}/photo/nope")
+        assert response.status_code == 404
+
+    def test_missing_file_on_disk_is_404(self, share_env):
+        (share_env["tmp_path"] / "img-1.jpg").unlink()
+        response = share_env["client"].get(f"/s/{share_env['token']}/photo/img-1")
+        assert response.status_code == 404
+
+
+class TestViewerChrome:
+    def test_thumbnails_are_lazy(self, share_env):
+        """Tiles carry data-src so a large album does not fetch every photo."""
+        body = share_env["client"].get(f"/s/{share_env['token']}").text
+        assert 'data-src="/s/' in body
+        assert body.count("data-src=") == 2
+
+    def test_lightbox_and_filmstrip_are_present(self, share_env):
+        body = share_env["client"].get(f"/s/{share_env['token']}").text
+        assert 'id="lightbox"' in body
+        assert 'id="filmstrip"' in body
+        assert body.count('class="filmstrip-thumb"') == 2
+
+    def test_theme_control_is_present(self, share_env):
+        body = share_env["client"].get(f"/s/{share_env['token']}").text
+        for choice in ('data-theme="auto"', 'data-theme="light"', 'data-theme="dark"'):
+            assert choice in body
+
+    def test_no_external_resources(self, share_env):
+        """
+        The page has to render on a network with no route to the internet — a
+        hotspot between two devices is the fallback when the LAN blocks peers.
+        """
+        body = share_env["client"].get(f"/s/{share_env['token']}").text
+        assert "http://" not in body.replace("http://www.w3.org", "")
+        assert "https://" not in body.replace("https://www.w3.org", "")
+
+    def test_expiry_is_shown_only_when_set(self, share_env):
+        assert "Expires" not in share_env["client"].get(f"/s/{share_env['token']}").text
+
+        entry = share_registry_create("album-1", expires_in_minutes=30)
+        body = share_env["client"].get(f"/s/{entry.token}").text
+        assert "Expires" in body
+        assert entry.expires_at.isoformat() in body
+
+    def test_album_name_is_escaped(self, share_env):
+        """An album named after a script tag must not become one."""
+        conn = sqlite3.connect(share_env["db_path"])
+        conn.execute(
+            "UPDATE albums SET album_name = ? WHERE album_id = ?",
+            ("<script>alert(1)</script>", "album-1"),
+        )
+        conn.commit()
+        conn.close()
+
+        body = share_env["client"].get(f"/s/{share_env['token']}").text
+        assert "<script>alert(1)</script>" not in body
+        assert "&lt;script&gt;" in body
+
+
+class TestSurface:
+    def test_docs_are_not_exposed(self, share_env):
+        """The share app is public; its route list should not be enumerable."""
+        client = share_env["client"]
+        assert client.get("/docs").status_code == 404
+        assert client.get("/openapi.json").status_code == 404
+
+    def test_main_backend_routes_are_absent(self, share_env):
+        client = share_env["client"]
+        for path in ("/health", "/albums/", "/images/", "/shutdown"):
+            assert client.get(path).status_code == 404

--- a/backend/tests/test_share_server.py
+++ b/backend/tests/test_share_server.py
@@ -1,5 +1,6 @@
 import asyncio
-from typing import Iterator, Tuple
+import socket
+from typing import Iterator, List, Optional, Tuple
 
 import pytest
 
@@ -64,7 +65,7 @@ class TestLifecycle:
         assert asyncio.run(scenario()) is False
 
     def test_stop_releases_the_port(self) -> None:
-        async def scenario() -> Tuple[object, bool]:
+        async def scenario() -> Tuple[Optional[int], bool]:
             await share_server_start()
             await share_server_stop()
             return share_server_port(), share_server_is_running()
@@ -83,12 +84,15 @@ class TestSupervision:
         share would be handed out for a socket nothing is accepting on.
         """
 
-        async def boom(self, sockets=None) -> None:
+        async def boom(
+            self: share_server._EmbeddedServer,
+            sockets: Optional[List[socket.socket]] = None,
+        ) -> None:
             raise RuntimeError("listener died")
 
         monkeypatch.setattr(share_server._EmbeddedServer, "serve", boom)
 
-        async def scenario() -> Tuple[object, bool]:
+        async def scenario() -> Tuple[Optional[int], bool]:
             await share_server_start()
             await asyncio.sleep(0.05)  # let the failing task finish
             return share_server_port(), share_server_is_running()

--- a/backend/tests/test_share_server.py
+++ b/backend/tests/test_share_server.py
@@ -1,0 +1,122 @@
+import asyncio
+from typing import Iterator, Tuple
+
+import pytest
+
+from app.share import server as share_server
+from app.share.registry import share_registry_clear, share_registry_create
+from app.share.server import (
+    share_server_is_running,
+    share_server_port,
+    share_server_start,
+    share_server_stop,
+)
+from app.utils.share import share_util_revoke
+
+# Every assertion about listener state is made inside the coroutine, because
+# asyncio.run cancels the serve task and clears the state on its way out.
+
+
+@pytest.fixture(autouse=True)
+def clean_lifecycle() -> Iterator[None]:
+    """
+    Reset the listener and both module-level locks between tests.
+
+    Each test drives its own event loop, and an asyncio lock binds to the first
+    loop that awaits it, so a lock carried across tests would raise about a
+    different running loop.
+    """
+    import app.utils.share as share_utils
+
+    share_registry_clear()
+    share_server._clear()
+    share_server._lifecycle_lock = asyncio.Lock()
+    share_utils._orchestration_lock = asyncio.Lock()
+
+    yield
+
+    share_server._clear()
+    share_registry_clear()
+
+
+class TestLifecycle:
+    def test_start_binds_and_reports_the_port(self) -> None:
+        async def scenario() -> Tuple[int, int, bool]:
+            port = await share_server_start()
+            return port, share_server_port(), share_server_is_running()
+
+        port, reported, running = asyncio.run(scenario())
+        assert port == reported
+        assert running is True
+
+    def test_starting_twice_reuses_the_listener(self) -> None:
+        async def scenario() -> Tuple[int, int]:
+            return await share_server_start(), await share_server_start()
+
+        first, second = asyncio.run(scenario())
+        assert first == second
+
+    def test_stop_is_safe_when_never_started(self) -> None:
+        async def scenario() -> bool:
+            await share_server_stop()
+            return share_server_is_running()
+
+        assert asyncio.run(scenario()) is False
+
+    def test_stop_releases_the_port(self) -> None:
+        async def scenario() -> Tuple[object, bool]:
+            await share_server_start()
+            await share_server_stop()
+            return share_server_port(), share_server_is_running()
+
+        port, running = asyncio.run(scenario())
+        assert port is None
+        assert running is False
+
+
+class TestSupervision:
+    def test_a_listener_that_dies_is_not_reported_as_running(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        Without a done-callback the port stays set after serve() fails, and a
+        share would be handed out for a socket nothing is accepting on.
+        """
+
+        async def boom(self, sockets=None) -> None:
+            raise RuntimeError("listener died")
+
+        monkeypatch.setattr(share_server._EmbeddedServer, "serve", boom)
+
+        async def scenario() -> Tuple[object, bool]:
+            await share_server_start()
+            await asyncio.sleep(0.05)  # let the failing task finish
+            return share_server_port(), share_server_is_running()
+
+        port, running = asyncio.run(scenario())
+        assert port is None
+        assert running is False
+
+
+class TestRevokeOrchestration:
+    def test_revoking_the_last_share_stops_the_listener(self) -> None:
+        async def scenario() -> bool:
+            await share_server_start()
+            entry = share_registry_create("album-1")
+            await share_util_revoke(entry.token)
+            return share_server_is_running()
+
+        assert asyncio.run(scenario()) is False
+
+    def test_revoking_one_of_two_leaves_the_listener_up(self) -> None:
+        async def scenario() -> bool:
+            await share_server_start()
+            first = share_registry_create("album-1")
+            share_registry_create("album-2")
+            await share_util_revoke(first.token)
+            return share_server_is_running()
+
+        assert asyncio.run(scenario()) is True
+
+    def test_revoking_an_unknown_token_reports_false(self) -> None:
+        assert asyncio.run(share_util_revoke("nope")) is False

--- a/backend/tests/test_share_server.py
+++ b/backend/tests/test_share_server.py
@@ -18,6 +18,19 @@ from app.utils.share import share_util_revoke
 # asyncio.run cancels the serve task and clears the state on its way out.
 
 
+async def _wait_until_stopped(timeout: float = 2.0) -> None:
+    """
+    Give the done-callback time to run, without pinning a fixed delay.
+
+    A sleep long enough to be safe on a loaded CI box is far longer than this
+    ever needs locally, so poll the observable state and stop as soon as it
+    settles. Returning on timeout lets the assertion report the real state.
+    """
+    deadline = asyncio.get_running_loop().time() + timeout
+    while share_server_is_running() and asyncio.get_running_loop().time() < deadline:
+        await asyncio.sleep(0.01)
+
+
 @pytest.fixture(autouse=True)
 def clean_lifecycle() -> Iterator[None]:
     """
@@ -94,7 +107,7 @@ class TestSupervision:
 
         async def scenario() -> Tuple[Optional[int], bool]:
             await share_server_start()
-            await asyncio.sleep(0.05)  # let the failing task finish
+            await _wait_until_stopped()
             return share_server_port(), share_server_is_running()
 
         port, running = asyncio.run(scenario())

--- a/docs/backend/backend_python/openapi.json
+++ b/docs/backend/backend_python/openapi.json
@@ -2319,6 +2319,173 @@
         }
       }
     },
+    "/share/interfaces": {
+      "get": {
+        "tags": [
+          "Share"
+        ],
+        "summary": "Get Interfaces",
+        "description": "Candidate addresses, best guess first.\n\nMachines with virtual adapters routinely surface several, so the caller is\nexpected to show this list rather than silently trust the first entry.",
+        "operationId": "get_interfaces_share_interfaces_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetInterfacesResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/share/": {
+      "get": {
+        "tags": [
+          "Share"
+        ],
+        "summary": "Get Shares",
+        "operationId": "get_shares_share__get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetSharesResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/share/albums/{album_id}": {
+      "post": {
+        "tags": [
+          "Share"
+        ],
+        "summary": "Create Share",
+        "description": "Issue a share token and make sure the network listener is up.\n\nAn album's local lock is deliberately not consulted: locking protects the\nalbum inside PictoPy, while sharing carries its own authorization.",
+        "operationId": "create_share_share_albums__album_id__post",
+        "parameters": [
+          {
+            "name": "album_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Album Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateShareRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateShareResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ShareErrorResponseEnvelope"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ShareErrorResponseEnvelope"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/share/{token}": {
+      "delete": {
+        "tags": [
+          "Share"
+        ],
+        "summary": "Revoke Share",
+        "operationId": "revoke_share_share__token__delete",
+        "parameters": [
+          {
+            "name": "token",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RevokeShareResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ShareErrorResponseEnvelope"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/models/status": {
       "get": {
         "tags": [
@@ -2851,6 +3018,46 @@
           "album_id"
         ],
         "title": "CreateAlbumResponse"
+      },
+      "CreateShareRequest": {
+        "properties": {
+          "expires_in_minutes": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "exclusiveMinimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expires In Minutes"
+          }
+        },
+        "type": "object",
+        "title": "CreateShareRequest"
+      },
+      "CreateShareResponse": {
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "title": "Success"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
+          "data": {
+            "$ref": "#/components/schemas/Share"
+          }
+        },
+        "type": "object",
+        "required": [
+          "success",
+          "message",
+          "data"
+        ],
+        "title": "CreateShareResponse"
       },
       "DeleteFoldersData": {
         "properties": {
@@ -3496,6 +3703,27 @@
         ],
         "title": "GetClustersResponse"
       },
+      "GetInterfacesResponse": {
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "title": "Success"
+          },
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/ShareInterface"
+            },
+            "type": "array",
+            "title": "Data"
+          }
+        },
+        "type": "object",
+        "required": [
+          "success",
+          "data"
+        ],
+        "title": "GetInterfacesResponse"
+      },
       "GetMemoriesData": {
         "properties": {
           "memories": {
@@ -3571,6 +3799,27 @@
           "data"
         ],
         "title": "GetMemoryResponse"
+      },
+      "GetSharesResponse": {
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "title": "Success"
+          },
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/Share"
+            },
+            "type": "array",
+            "title": "Data"
+          }
+        },
+        "type": "object",
+        "required": [
+          "success",
+          "data"
+        ],
+        "title": "GetSharesResponse"
       },
       "GetTodayMemoryData": {
         "properties": {
@@ -5163,6 +5412,24 @@
         ],
         "title": "RenameClusterResponse"
       },
+      "RevokeShareResponse": {
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "title": "Success"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          }
+        },
+        "type": "object",
+        "required": [
+          "success",
+          "message"
+        ],
+        "title": "RevokeShareResponse"
+      },
       "ScoredVideoData": {
         "properties": {
           "id": {
@@ -5310,6 +5577,133 @@
           "tier"
         ],
         "title": "SetupRequest"
+      },
+      "Share": {
+        "properties": {
+          "token": {
+            "type": "string",
+            "title": "Token"
+          },
+          "album_id": {
+            "type": "string",
+            "title": "Album Id"
+          },
+          "album_name": {
+            "type": "string",
+            "title": "Album Name"
+          },
+          "image_count": {
+            "type": "integer",
+            "title": "Image Count"
+          },
+          "port": {
+            "type": "integer",
+            "title": "Port"
+          },
+          "created_at": {
+            "type": "string",
+            "title": "Created At"
+          },
+          "expires_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expires At"
+          },
+          "urls": {
+            "items": {
+              "$ref": "#/components/schemas/ShareUrl"
+            },
+            "type": "array",
+            "title": "Urls"
+          }
+        },
+        "type": "object",
+        "required": [
+          "token",
+          "album_id",
+          "album_name",
+          "image_count",
+          "port",
+          "created_at",
+          "urls"
+        ],
+        "title": "Share"
+      },
+      "ShareErrorResponseEnvelope": {
+        "properties": {
+          "detail": {
+            "$ref": "#/components/schemas/app__schemas__share__ErrorResponse"
+          }
+        },
+        "type": "object",
+        "required": [
+          "detail"
+        ],
+        "title": "ShareErrorResponseEnvelope",
+        "description": "How an ErrorResponse actually reaches the client.\n\nHTTPException nests whatever it is given under `detail`, so documenting\nErrorResponse alone would describe a shape no client ever receives."
+      },
+      "ShareInterface": {
+        "properties": {
+          "interface": {
+            "type": "string",
+            "title": "Interface"
+          },
+          "ip": {
+            "type": "string",
+            "title": "Ip"
+          },
+          "is_default_route": {
+            "type": "boolean",
+            "title": "Is Default Route"
+          },
+          "looks_virtual": {
+            "type": "boolean",
+            "title": "Looks Virtual"
+          },
+          "is_up": {
+            "type": "boolean",
+            "title": "Is Up"
+          }
+        },
+        "type": "object",
+        "required": [
+          "interface",
+          "ip",
+          "is_default_route",
+          "looks_virtual",
+          "is_up"
+        ],
+        "title": "ShareInterface",
+        "description": "One address the share could be advertised on, best guess first."
+      },
+      "ShareUrl": {
+        "properties": {
+          "interface": {
+            "type": "string",
+            "title": "Interface"
+          },
+          "ip": {
+            "type": "string",
+            "title": "Ip"
+          },
+          "url": {
+            "type": "string",
+            "title": "Url"
+          }
+        },
+        "type": "object",
+        "required": [
+          "interface",
+          "ip",
+          "url"
+        ],
+        "title": "ShareUrl"
       },
       "ShutdownResponse": {
         "properties": {
@@ -6196,6 +6590,29 @@
         ],
         "title": "ErrorResponse",
         "description": "Error response model"
+      },
+      "app__schemas__share__ErrorResponse": {
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "title": "Success",
+            "default": false
+          },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          },
+          "error": {
+            "type": "string",
+            "title": "Error"
+          }
+        },
+        "type": "object",
+        "required": [
+          "message",
+          "error"
+        ],
+        "title": "ErrorResponse"
       },
       "app__schemas__user_preferences__ErrorResponse": {
         "properties": {

--- a/docs/backend/backend_python/openapi.json
+++ b/docs/backend/backend_python/openapi.json
@@ -2337,6 +2337,16 @@
                 }
               }
             }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ShareErrorResponseEnvelope"
+                }
+              }
+            }
           }
         }
       }
@@ -2355,6 +2365,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/GetSharesResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ShareErrorResponseEnvelope"
                 }
               }
             }
@@ -2385,7 +2405,15 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateShareRequest"
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/CreateShareRequest"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Body"
               }
             }
           }
@@ -2472,6 +2500,16 @@
               }
             },
             "description": "Not Found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ShareErrorResponseEnvelope"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           },
           "422": {
             "description": "Validation Error",
@@ -5669,6 +5707,10 @@
           "is_up": {
             "type": "boolean",
             "title": "Is Up"
+          },
+          "is_link_local": {
+            "type": "boolean",
+            "title": "Is Link Local"
           }
         },
         "type": "object",
@@ -5677,7 +5719,8 @@
           "ip",
           "is_default_route",
           "looks_virtual",
-          "is_up"
+          "is_up",
+          "is_link_local"
         ],
         "title": "ShareInterface",
         "description": "One address the share could be advertised on, best guess first."


### PR DESCRIPTION
Closes #1468

Adds the ability to serve one album over the local network, so that a recipient on the same Wi-Fi can browse it in a browser while PictoPy is running. Nothing is uploaded, and the recipient needs no account and no app.

## Approach

The album is served by a second FastAPI application bound to `0.0.0.0`, started on demand when the first share is created and stopped when the last one is revoked. The main backend stays on localhost because it exposes shutdown, delete and metadata routes that must not be reachable from other devices, so binding it more widely was never an option.

The share server runs as an asyncio task on the backend's existing event loop rather than as a separate process, which means no packaging or Tauri changes are needed. Its socket is bound before uvicorn receives it, because uvicorn raises `SystemExit` on a bind failure and would otherwise terminate the whole backend when a port is busy.

Active shares are held in memory rather than in the database. Shares are meant to end when PictoPy closes, and keeping them in memory makes that structural instead of something a cleanup path has to enforce. There is no migration, and no token is ever written to disk.

## Security

Four invariants, each covered by a test. An image is resolved to a file only after it has been confirmed to belong to the shared album, so a token cannot be used to read other images. Filesystem paths are never sent to the client, which works entirely in IDs. A revoked, expired or unknown token returns the same 404, so the response cannot be used to probe for valid tokens. The share application carries no CORS middleware and no interactive documentation, and exposes nothing outside `/s/{token}`.

An album's local lock is deliberately not consulted. Locking protects an album inside PictoPy, while a share carries its own authorization.

## Receiver page

The recipient gets a single server-rendered Jinja template with inline CSS and JavaScript, so there is no second frontend build and no asset pipeline. It has a responsive grid with lazily loaded thumbnails, a lightbox with keyboard, swipe and filmstrip navigation, and light and dark themes. It references no external resources, because the page is often served on a network with no route to the internet.

## Not included

Password protection, the share dialog in the desktop UI, and diagnostics for networks that block device-to-device traffic are follow-up work. Sharing over the internet is out of scope.

## Testing

42 new tests covering the registry, the interface ranking and the route surface, with the full suite at 1044 passing. Verified end to end on three networks, with an album loaded on a phone over Wi-Fi.

Reviewing commit by commit is likely easiest, as each one is self-contained and they build in dependency order.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added local-network album sharing with shareable URLs and optional expiration.
  * Added controls to create, view, list, and revoke active album shares.
  * Added responsive shared-album viewing with thumbnails, photo navigation, lightbox viewing, keyboard shortcuts, swipe support, dark mode, and localization.
  * Added automatic network-interface discovery and fallback port selection.
* **Documentation**
  * Documented the new share-management API endpoints and response formats.
* **Tests**
  * Added coverage for sharing, expiration, revocation, media access, and network discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->