### PR TITLE
fix: align the album detail header with the AI Tagging collection page

### DIFF
--- a/frontend/src/pages/Album/AlbumDetail.tsx
+++ b/frontend/src/pages/Album/AlbumDetail.tsx
@@ -231,7 +231,7 @@ export const AlbumDetail = () => {
   return (
     <div className="flex h-full flex-col">
       {/* Header — same shape as the AI Tagging collection page */}
-      <div className="my-6 flex items-center justify-between">
+      <div className="my-6 flex flex-col items-start gap-2 sm:flex-row sm:items-center sm:justify-between">
         <Button
           variant="outline"
           onClick={handleBack}
@@ -241,7 +241,11 @@ export const AlbumDetail = () => {
           Back
         </Button>
 
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center justify-end gap-2 self-end sm:self-auto">
+          <p className="text-muted-foreground mr-1 text-sm">
+            {images.length} {images.length === 1 ? 'photo' : 'photos'}
+            {selectedImages.size > 0 && ` • ${selectedImages.size} selected`}
+          </p>
           {isSelectionMode ? (
             <>
               <Button
@@ -292,10 +296,6 @@ export const AlbumDetail = () => {
         {album.description && (
           <p className="text-muted-foreground text-sm">{album.description}</p>
         )}
-        <p className="text-muted-foreground text-sm">
-          {images.length} {images.length === 1 ? 'photo' : 'photos'}
-          {selectedImages.size > 0 && ` • ${selectedImages.size} selected`}
-        </p>
       </div>
 
       {/* Images Grid */}

--- a/frontend/src/pages/Album/AlbumDetail.tsx
+++ b/frontend/src/pages/Album/AlbumDetail.tsx
@@ -230,73 +230,72 @@ export const AlbumDetail = () => {
 
   return (
     <div className="flex h-full flex-col">
-      {/* Header */}
-      <div className="mb-6">
-        <div className="mb-4 flex items-center gap-3">
-          <Button variant="ghost" size="icon" onClick={handleBack}>
-            <ArrowLeft className="h-5 w-5" />
-          </Button>
-          <div className="flex-1">
-            <h1 className="text-2xl font-bold">{album.name}</h1>
-            {album.description && (
-              <p className="text-muted-foreground text-sm">
-                {album.description}
-              </p>
-            )}
-          </div>
-        </div>
+      {/* Header — same shape as the AI Tagging collection page */}
+      <div className="my-6 flex items-center justify-between">
+        <Button
+          variant="outline"
+          onClick={handleBack}
+          className="flex cursor-pointer items-center gap-2"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back
+        </Button>
 
-        <div className="flex items-center justify-between">
-          <p className="text-muted-foreground text-sm">
-            {images.length} {images.length === 1 ? 'photo' : 'photos'}
-            {selectedImages.size > 0 && ` • ${selectedImages.size} selected`}
-          </p>
-
-          <div className="flex items-center gap-2">
-            {isSelectionMode ? (
-              <>
+        <div className="flex items-center gap-2">
+          {isSelectionMode ? (
+            <>
+              <Button
+                variant="outline"
+                onClick={() => {
+                  setIsSelectionMode(false);
+                  setSelectedImages(new Set());
+                }}
+                className="cursor-pointer"
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="destructive"
+                onClick={handleRemoveSelected}
+                disabled={selectedImages.size === 0}
+                className="cursor-pointer"
+              >
+                <Trash2 className="mr-2 h-4 w-4" />
+                Remove Selected
+              </Button>
+            </>
+          ) : (
+            <>
+              {images.length > 0 && (
                 <Button
                   variant="outline"
-                  size="sm"
-                  onClick={() => {
-                    setIsSelectionMode(false);
-                    setSelectedImages(new Set());
-                  }}
+                  onClick={() => setIsSelectionMode(true)}
+                  className="cursor-pointer"
                 >
-                  Cancel
+                  Select Images
                 </Button>
-                <Button
-                  variant="destructive"
-                  size="sm"
-                  onClick={handleRemoveSelected}
-                  disabled={selectedImages.size === 0}
-                >
-                  <Trash2 className="mr-2 h-4 w-4" />
-                  Remove Selected
-                </Button>
-              </>
-            ) : (
-              <>
-                {images.length > 0 && (
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => setIsSelectionMode(true)}
-                  >
-                    Select Images
-                  </Button>
-                )}
-                <Button
-                  size="sm"
-                  onClick={() => setIsAddImagesDialogOpen(true)}
-                >
-                  <Plus className="mr-2 h-4 w-4" />
-                  Add Images
-                </Button>
-              </>
-            )}
-          </div>
+              )}
+              <Button
+                onClick={() => setIsAddImagesDialogOpen(true)}
+                className="cursor-pointer"
+              >
+                <Plus className="mr-2 h-4 w-4" />
+                Add Images
+              </Button>
+            </>
+          )}
         </div>
+      </div>
+
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold">{album.name}</h1>
+        {album.description && (
+          <p className="text-muted-foreground text-sm">{album.description}</p>
+        )}
+        <p className="text-muted-foreground text-sm">
+          {images.length} {images.length === 1 ? 'photo' : 'photos'}
+          {selectedImages.size > 0 && ` • ${selectedImages.size} selected`}
+        </p>
       </div>
 
       {/* Images Grid */}

--- a/frontend/src/pages/__tests__/AlbumDetail.test.tsx
+++ b/frontend/src/pages/__tests__/AlbumDetail.test.tsx
@@ -112,6 +112,21 @@ describe('AlbumDetail', () => {
     expect(store.getState().loader.loading).toBe(false);
   }, 30000);
 
+  // The header mirrors the AI Tagging collection page: a labelled Back button
+  // on its own row, with the album name as the heading underneath.
+  test('renders a labelled back button that returns to the albums list', async () => {
+    const user = userEvent.setup();
+    renderDetail();
+
+    expect(
+      await screen.findByRole('heading', { name: 'Trip' }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Back' }));
+
+    expect(await screen.findByText('Albums list')).toBeInTheDocument();
+  }, 30000);
+
   // The cover is whatever image comes first in the album, so there is nothing
   // to pick and no per-image menu left to pick it from.
   test('offers no per-image cover menu', async () => {


### PR DESCRIPTION
Fixes #1455

## What

Restructures the header on the Albums detail page (`/albums/:albumId`) so it matches the layout every other media detail page in the app already uses.

Before: an icon-only ghost back button sat inline with the album title on the first row, and the photo count shared the second row with the action buttons.

After, mirroring `PersonImages` (the AI Tagging collection page) and `SearchResults`:

- Row 1 — a labelled outline **Back** button (`ArrowLeft` + "Back") on the left; on the right, the photo/selected count followed by the page actions (Select Images / Add Images, or Cancel / Remove Selected in selection mode).
- Row 2 — the album name as an `h1`, with the description underneath.

The count sits in the right-side action area as the issue asks. Below `sm:` the header stacks and the action group wraps, so selection mode (`Cancel` + `Remove Selected`) cannot push it wider than a mobile viewport.

The header action buttons drop `size="sm"` so they match the Back button's height in the same row, exactly as "Edit Name" does on the AI Tagging collection page, and pick up the `cursor-pointer` class those pages use.

## Why

`frontend/src/pages/Album/AlbumDetail.tsx` was the only detail page not following this shape. `PersonImages.tsx` and `SearchResults.tsx` both render `<div className="my-6 flex items-center justify-between">` with a labelled Back button followed by `<h1 className="mb-6 text-2xl font-bold">`. Aligning it makes back-navigation land in the same place and at the same size across pages, and the title-below-controls rhythm consistent.

No behaviour changed — same handlers, same selection flow, same grid, same dialogs.

## How tested

- Added a test to `frontend/src/pages/__tests__/AlbumDetail.test.tsx` asserting the album name renders as a heading and that a button with the accessible name **Back** navigates to the albums list. This pins the new header shape: the old icon-only button had no accessible name, so the test would fail against the previous markup.
- `npm run lint:check`, `npm run format:check`, `npx tsc --noEmit` — all clean.
- `npm test` — **352/352 pass**.
- Re-ran every gate above after the review follow-up in `0c7311a`; all still clean.

## Notes

- The issue describes *the outlined `Back to Albums` button style used by the AI Tagging face-collection detail page*. I treated that page as the source of truth for the style, and its button label is `Back` (`PersonImages.tsx:92-93`), so this matches it exactly. Happy to switch to the literal string "Back to Albums" if that was the intent.
- Drafted with AI assistance (Claude) following the conventions in `AGENTS.md`; the change and its tests were reviewed before submission.
- `0c7311a` addresses the review: the count moved into the action area, and the header now stacks below `sm:` to prevent horizontal overflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Refined the album detail header layout for clearer organization of the title, description, photo count, and image controls.
  - Updated button styling, spacing, icons, and cursor behavior while preserving existing selection and album information functionality.

- **Tests**
  - Added coverage confirming the Back button is labelled correctly and returns to the albums list when selected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->