### PR TITLE
feat: protect a shared album with a password

### DIFF
--- a/backend/app/routes/share.py
+++ b/backend/app/routes/share.py
@@ -91,14 +91,17 @@ async def create_share(
     Issue a share token and make sure the network listener is up.
 
     An album's local lock is deliberately not consulted: locking protects the
-    album inside PictoPy, while sharing carries its own authorization.
+    album inside PictoPy, while sharing carries its own authorization — the
+    optional password on this request, which is hashed and never read back.
     """
     if not db_get_album(album_id):
         raise _not_found("Album Not Found", "No album exists with the provided ID.")
 
     try:
         entry = await share_util_create(
-            album_id, expires_in_minutes=body.expires_in_minutes if body else None
+            album_id,
+            expires_in_minutes=body.expires_in_minutes if body else None,
+            password=body.password if body else None,
         )
     except OSError as e:
         raise _internal_error(f"Could not start the share server: {e}") from e

--- a/backend/app/schemas/share.py
+++ b/backend/app/schemas/share.py
@@ -1,6 +1,8 @@
 from typing import List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
+
+from app.share.registry import PASSWORD_MAX_BYTES
 
 # ##############################
 # Request Handler
@@ -10,6 +12,16 @@ from pydantic import BaseModel, Field
 class CreateShareRequest(BaseModel):
     # None means the share lives until it is revoked or PictoPy closes.
     expires_in_minutes: Optional[int] = Field(default=None, gt=0)
+    # None leaves the album readable by anyone holding the link.
+    password: Optional[str] = Field(default=None, min_length=4)
+
+    @field_validator("password")
+    def check_password_length(cls, value: Optional[str]) -> Optional[str]:
+        # Measured in bytes because that is where bcrypt truncates; a longer
+        # password would be accepted and then quietly not be the one set.
+        if value is not None and len(value.encode("utf-8")) > PASSWORD_MAX_BYTES:
+            raise ValueError(f"Password must be at most {PASSWORD_MAX_BYTES} bytes")
+        return value
 
 
 # ##############################
@@ -44,6 +56,9 @@ class Share(BaseModel):
     port: int
     created_at: str
     expires_at: Optional[str] = None
+    # Whether a password stands between the link and the photos. The password
+    # itself and its hash never leave the backend.
+    is_protected: bool
     # One entry per candidate interface: which of them a phone can actually
     # reach depends on the network, so the caller picks.
     urls: List[ShareUrl]

--- a/backend/app/schemas/share.py
+++ b/backend/app/schemas/share.py
@@ -16,6 +16,7 @@ class CreateShareRequest(BaseModel):
     password: Optional[str] = Field(default=None, min_length=4)
 
     @field_validator("password")
+    @classmethod
     def check_password_length(cls, value: Optional[str]) -> Optional[str]:
         # Measured in bytes because that is where bcrypt truncates; a longer
         # password would be accepted and then quietly not be the one set.

--- a/backend/app/share/registry.py
+++ b/backend/app/share/registry.py
@@ -8,15 +8,32 @@ to enforce. It also means no share token is ever written to disk.
 
 from __future__ import annotations
 
+import hashlib
+import hmac
 import secrets
 import threading
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Dict, List, Optional
 
+import bcrypt
+
 # Long enough that guessing is hopeless; the token is the only credential
 # protecting an album on a network anyone else may also be on.
 _TOKEN_BYTES = 32
+
+# bcrypt silently truncates past 72 bytes, so anything longer would be accepted
+# at creation and then not be the password the user thinks it is.
+PASSWORD_MAX_BYTES = 72
+
+# A wrong password costs a bcrypt verification, which already caps guessing at a
+# few tries a second. The cooldown is what stops an overnight script.
+_MAX_FAILED_UNLOCKS = 10
+_UNLOCK_COOLDOWN = timedelta(seconds=30)
+
+# Signs the unlock cookie. Regenerated per process, so every unlock dies with
+# PictoPy exactly as the shares themselves do.
+_unlock_secret = secrets.token_bytes(32)
 
 
 @dataclass
@@ -27,12 +44,19 @@ class ShareEntry:
     album_id: str
     created_at: datetime
     expires_at: Optional[datetime] = None
+    password_hash: Optional[bytes] = None
+    failed_unlocks: int = 0
+    locked_until: Optional[datetime] = None
 
     @property
     def is_expired(self) -> bool:
         if self.expires_at is None:
             return False
         return _now() >= self.expires_at
+
+    @property
+    def is_protected(self) -> bool:
+        return self.password_hash is not None
 
 
 _shares: Dict[str, ShareEntry] = {}
@@ -46,7 +70,9 @@ def _now() -> datetime:
 
 
 def share_registry_create(
-    album_id: str, expires_in_minutes: Optional[int] = None
+    album_id: str,
+    expires_in_minutes: Optional[int] = None,
+    password: Optional[str] = None,
 ) -> ShareEntry:
     """Issue a token for an album. Any previous share of it stays valid."""
     expires_at = (
@@ -54,11 +80,15 @@ def share_registry_create(
         if expires_in_minutes is not None
         else None
     )
+    password_hash = (
+        bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()) if password else None
+    )
     entry = ShareEntry(
         token=secrets.token_urlsafe(_TOKEN_BYTES),
         album_id=album_id,
         created_at=_now(),
         expires_at=expires_at,
+        password_hash=password_hash,
     )
     with _lock:
         _shares[entry.token] = entry
@@ -99,6 +129,73 @@ def share_registry_count() -> int:
     """Live share count; the server stops once this reaches zero."""
     with _lock:
         return sum(1 for entry in _shares.values() if not entry.is_expired)
+
+
+def share_registry_is_throttled(entry: ShareEntry) -> bool:
+    """
+    Whether unlock attempts are in cooldown.
+
+    Only for wording the message shown to the visitor; the refusal itself is
+    enforced inside share_registry_unlock.
+    """
+    with _lock:
+        return entry.locked_until is not None and _now() < entry.locked_until
+
+
+def share_registry_unlock(entry: ShareEntry, password: str) -> Optional[str]:
+    """
+    Check a password and, on success, mint the value for the unlock cookie.
+
+    None means the visitor stays locked out, whether the password was wrong or
+    too many attempts have already been made.
+    """
+    if entry.password_hash is None:
+        return None
+    if share_registry_is_throttled(entry):
+        return None
+
+    # Deliberately outside the lock: bcrypt takes a few hundred milliseconds and
+    # holding the registry for that long would serialise every other request.
+    accepted = bcrypt.checkpw(password.encode("utf-8"), entry.password_hash)
+
+    with _lock:
+        if not accepted:
+            entry.failed_unlocks += 1
+            if entry.failed_unlocks >= _MAX_FAILED_UNLOCKS:
+                entry.failed_unlocks = 0
+                entry.locked_until = _now() + _UNLOCK_COOLDOWN
+            return None
+        entry.failed_unlocks = 0
+        entry.locked_until = None
+
+    return _unlock_signature(entry.token, entry.password_hash)
+
+
+def share_registry_is_unlocked(entry: ShareEntry, cookie: Optional[str]) -> bool:
+    """
+    Whether a visitor holding this cookie may see the album.
+
+    The cookie is a signature rather than a stored session id, so nothing here
+    grows with the number of devices that open a share.
+    """
+    if entry.password_hash is None:
+        return True
+    if not cookie:
+        return False
+    return hmac.compare_digest(
+        cookie, _unlock_signature(entry.token, entry.password_hash)
+    )
+
+
+def _unlock_signature(token: str, password_hash: bytes) -> str:
+    """
+    The cookie value proving one password check succeeded.
+
+    Bound to both the share token and its hash, so a cookie cannot be replayed
+    against another share and stops working if the password is ever changed.
+    """
+    message = token.encode("utf-8") + b":" + password_hash
+    return hmac.new(_unlock_secret, message, hashlib.sha256).hexdigest()
 
 
 def share_registry_clear() -> None:

--- a/backend/app/share/registry.py
+++ b/backend/app/share/registry.py
@@ -46,6 +46,9 @@ class ShareEntry:
     expires_at: Optional[datetime] = None
     password_hash: Optional[bytes] = None
     failed_unlocks: int = 0
+    # Attempts admitted but still being hashed; counted so concurrent requests
+    # cannot collectively overshoot the limit.
+    pending_unlocks: int = 0
     locked_until: Optional[datetime] = None
 
     @property
@@ -146,29 +149,72 @@ def share_registry_unlock(entry: ShareEntry, password: str) -> Optional[str]:
     """
     Check a password and, on success, mint the value for the unlock cookie.
 
-    None means the visitor stays locked out, whether the password was wrong or
-    too many attempts have already been made.
+    None means the visitor stays locked out, whether the password was wrong, was
+    longer than one could ever have been set, or too many attempts have already
+    been made.
     """
     if entry.password_hash is None:
         return None
-    if share_registry_is_throttled(entry):
+
+    candidate = password.encode("utf-8")
+    # Creating a share refuses anything longer, so this cannot be the password.
+    # Checking before hashing also keeps oversized form input away from bcrypt,
+    # which truncates at this limit here and rejects it outright in 4.x.
+    if len(candidate) > PASSWORD_MAX_BYTES:
         return None
 
-    # Deliberately outside the lock: bcrypt takes a few hundred milliseconds and
-    # holding the registry for that long would serialise every other request.
-    accepted = bcrypt.checkpw(password.encode("utf-8"), entry.password_hash)
+    if not _reserve_attempt(entry):
+        return None
 
-    with _lock:
-        if not accepted:
-            entry.failed_unlocks += 1
-            if entry.failed_unlocks >= _MAX_FAILED_UNLOCKS:
-                entry.failed_unlocks = 0
-                entry.locked_until = _now() + _UNLOCK_COOLDOWN
-            return None
-        entry.failed_unlocks = 0
-        entry.locked_until = None
+    accepted = False
+    try:
+        # Deliberately outside the lock: bcrypt takes a few hundred milliseconds
+        # and holding the registry that long would serialise every request.
+        accepted = bcrypt.checkpw(candidate, entry.password_hash)
+    finally:
+        _release_attempt(entry, accepted)
 
+    if not accepted:
+        return None
     return _unlock_signature(entry.token, entry.password_hash)
+
+
+def _reserve_attempt(entry: ShareEntry) -> bool:
+    """
+    Claim one of the share's unlock attempts, or refuse.
+
+    Admission is decided before the password is checked rather than after. Sync
+    handlers run in uvicorn's threadpool, so a burst of requests would otherwise
+    all read the same attempt count and hash concurrently, and the limit would
+    only bound how many rounds an attacker needs rather than how many guesses.
+    """
+    with _lock:
+        if entry.locked_until is not None:
+            if _now() < entry.locked_until:
+                return False
+            entry.locked_until = None
+            entry.failed_unlocks = 0
+        if entry.pending_unlocks + entry.failed_unlocks >= _MAX_FAILED_UNLOCKS:
+            return False
+        entry.pending_unlocks += 1
+        return True
+
+
+def _release_attempt(entry: ShareEntry, accepted: bool) -> None:
+    """
+    Record how a claimed attempt turned out.
+
+    Only failures count towards the cooldown, so a share stays open however many
+    people unlock it correctly.
+    """
+    with _lock:
+        entry.pending_unlocks -= 1
+        if accepted:
+            entry.failed_unlocks = 0
+            return
+        entry.failed_unlocks += 1
+        if entry.failed_unlocks >= _MAX_FAILED_UNLOCKS:
+            entry.locked_until = _now() + _UNLOCK_COOLDOWN
 
 
 def share_registry_is_unlocked(entry: ShareEntry, cookie: Optional[str]) -> bool:

--- a/backend/app/share/routes.py
+++ b/backend/app/share/routes.py
@@ -6,9 +6,10 @@ apart from the token in the path, so keep the surface exactly this small.
 from __future__ import annotations
 
 import os
+from typing import Optional
 
-from fastapi import APIRouter, HTTPException, Path, Request, status
-from fastapi.responses import FileResponse, HTMLResponse
+from fastapi import APIRouter, Form, HTTPException, Path, Request, Response, status
+from fastapi.responses import FileResponse, HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 
 from app.logging.setup_logging import get_logger
@@ -17,7 +18,13 @@ from app.share.media import (
     share_media_image_ids,
     share_media_resolve_path,
 )
-from app.share.registry import ShareEntry, share_registry_get
+from app.share.registry import (
+    ShareEntry,
+    share_registry_get,
+    share_registry_is_throttled,
+    share_registry_is_unlocked,
+    share_registry_unlock,
+)
 
 logger = get_logger(__name__)
 
@@ -26,6 +33,10 @@ router = APIRouter()
 templates = Jinja2Templates(
     directory=os.path.join(os.path.dirname(__file__), "templates")
 )
+
+# Scoped to the share's own path so one album's unlock is never sent to another,
+# and left as a session cookie so closing the browser ends the visit.
+_UNLOCK_COOKIE = "pictopy_share_unlock"
 
 
 def _not_found() -> HTTPException:
@@ -45,9 +56,40 @@ def _require_share(token: str) -> ShareEntry:
     return entry
 
 
+def _is_unlocked(request: Request, entry: ShareEntry) -> bool:
+    return share_registry_is_unlocked(entry, request.cookies.get(_UNLOCK_COOKIE))
+
+
+def _to_album(token: str) -> RedirectResponse:
+    """See-other, so refreshing the album does not repost the password."""
+    return RedirectResponse(f"/s/{token}", status_code=status.HTTP_303_SEE_OTHER)
+
+
+def _unlock_page(
+    request: Request,
+    token: str,
+    error: Optional[str] = None,
+    status_code: int = status.HTTP_200_OK,
+) -> HTMLResponse:
+    """
+    The gate a visitor meets before the album exists to them.
+
+    It names nothing about the album — not the title, not the photo count — so a
+    link that leaks tells its finder only that some album is being shared.
+    """
+    return templates.TemplateResponse(
+        request,
+        "unlock.html",
+        {"token": token, "error": error},
+        status_code=status_code,
+    )
+
+
 @router.get("/s/{token}", response_class=HTMLResponse)
 def view_share(request: Request, token: str = Path(...)) -> HTMLResponse:
     entry = _require_share(token)
+    if not _is_unlocked(request, entry):
+        return _unlock_page(request, entry.token)
 
     album_name = share_media_album_name(entry.album_id)
     if album_name is None:
@@ -67,9 +109,44 @@ def view_share(request: Request, token: str = Path(...)) -> HTMLResponse:
     )
 
 
-@router.get("/s/{token}/thumb/{image_id}")
-def share_thumbnail(token: str = Path(...), image_id: str = Path(...)) -> FileResponse:
+@router.post("/s/{token}/unlock")
+def unlock_share(
+    request: Request, token: str = Path(...), password: str = Form(...)
+) -> Response:
     entry = _require_share(token)
+    if not entry.is_protected:
+        return _to_album(entry.token)
+
+    # Advisory only: the refusal itself is enforced inside the registry, this
+    # just tells the visitor which of the two refusals they are looking at.
+    throttled = share_registry_is_throttled(entry)
+    cookie = share_registry_unlock(entry, password)
+    if cookie is None:
+        message = (
+            "Too many attempts. Wait half a minute and try again."
+            if throttled
+            else "That password is not right."
+        )
+        return _unlock_page(request, entry.token, message, status.HTTP_401_UNAUTHORIZED)
+
+    response = _to_album(entry.token)
+    response.set_cookie(
+        _UNLOCK_COOKIE,
+        cookie,
+        path=f"/s/{entry.token}",
+        httponly=True,
+        samesite="lax",
+    )
+    return response
+
+
+@router.get("/s/{token}/thumb/{image_id}")
+def share_thumbnail(
+    request: Request, token: str = Path(...), image_id: str = Path(...)
+) -> FileResponse:
+    entry = _require_share(token)
+    if not _is_unlocked(request, entry):
+        raise _not_found()
     path = share_media_resolve_path(entry.album_id, image_id, thumbnail=True)
     if path is None:
         raise _not_found()
@@ -77,8 +154,12 @@ def share_thumbnail(token: str = Path(...), image_id: str = Path(...)) -> FileRe
 
 
 @router.get("/s/{token}/photo/{image_id}")
-def share_photo(token: str = Path(...), image_id: str = Path(...)) -> FileResponse:
+def share_photo(
+    request: Request, token: str = Path(...), image_id: str = Path(...)
+) -> FileResponse:
     entry = _require_share(token)
+    if not _is_unlocked(request, entry):
+        raise _not_found()
     path = share_media_resolve_path(entry.album_id, image_id, thumbnail=False)
     if path is None:
         raise _not_found()

--- a/backend/app/share/templates/unlock.html
+++ b/backend/app/share/templates/unlock.html
@@ -116,11 +116,11 @@
     background: var(--background);
     border: 1px solid var(--border);
     border-radius: var(--radius);
-    outline: none;
   }
   input[type="password"]:focus {
     border-color: var(--primary);
-    box-shadow: 0 0 0 3px color-mix(in oklch, var(--primary) 25%, transparent);
+    outline: 2px solid var(--primary);
+    outline-offset: 1px;
   }
 
   button {

--- a/backend/app/share/templates/unlock.html
+++ b/backend/app/share/templates/unlock.html
@@ -1,0 +1,184 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<meta name="robots" content="noindex, nofollow">
+<title>Protected album · PictoPy</title>
+<script>
+  // Applied before first paint so a dark-theme viewer never flashes light.
+  (function () {
+    try {
+      var saved = localStorage.getItem('pictopy-share-theme') || 'auto';
+      var dark = saved === 'dark' || (saved === 'auto' &&
+        window.matchMedia('(prefers-color-scheme: dark)').matches);
+      document.documentElement.classList.toggle('dark', dark);
+    } catch (e) { /* private mode blocks localStorage; system theme still works */ }
+  })();
+</script>
+<style>
+  /* Only the tokens this page uses; the album view carries the full set. */
+  :root {
+    --font-sans: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    --radius: 0.675rem;
+    --background: oklch(1 0 0);
+    --foreground: oklch(0.3211 0 0);
+    --card: oklch(1 0 0);
+    --primary: oklch(0.6231 0.188 259.8145);
+    --primary-foreground: oklch(1 0 0);
+    --secondary: oklch(0.967 0.0029 264.5419);
+    --muted-foreground: oklch(0.551 0.0234 264.3637);
+    --border: oklch(0.9276 0.0058 264.5313);
+    --destructive: oklch(0.5771 0.2152 27.325);
+    --shadow-lg: 0 1px 3px 0 hsl(0 0% 0% / 0.1), 0 4px 6px -1px hsl(0 0% 0% / 0.1);
+  }
+
+  html.dark {
+    --background: oklch(0.2046 0 0);
+    --foreground: oklch(0.9219 0 0);
+    --card: oklch(0.2686 0 0);
+    --secondary: oklch(0.2686 0 0);
+    --muted-foreground: oklch(0.7155 0 0);
+    --border: oklch(0.3715 0 0);
+    --destructive: oklch(0.7106 0.1661 22.2162);
+  }
+
+  * { box-sizing: border-box; }
+  html, body { width: 100%; }
+  body {
+    margin: 0;
+    min-height: 100vh;
+    min-height: 100dvh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1.5rem;
+    font-family: var(--font-sans);
+    background: var(--background);
+    color: var(--foreground);
+    line-height: 1.5;
+    -webkit-text-size-adjust: 100%;
+  }
+
+  .brand {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    font-size: 1.125rem;
+    font-weight: 700;
+  }
+  .brand svg { width: 1.5rem; height: 1.5rem; color: var(--primary); }
+  .brand .accent { color: var(--primary); }
+
+  .card {
+    width: 100%;
+    max-width: 24rem;
+    padding: 2rem 1.75rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--card);
+    box-shadow: var(--shadow-lg);
+    text-align: center;
+  }
+
+  .lock {
+    width: 3rem;
+    height: 3rem;
+    margin: 1.75rem auto 1rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    background: var(--secondary);
+    color: var(--muted-foreground);
+  }
+  .lock svg { width: 1.5rem; height: 1.5rem; }
+
+  h1 {
+    margin: 0 0 0.375rem;
+    font-size: 1.125rem;
+    font-weight: 600;
+  }
+
+  .hint {
+    margin: 0 0 1.5rem;
+    font-size: 0.875rem;
+    color: var(--muted-foreground);
+  }
+
+  input[type="password"] {
+    width: 100%;
+    padding: 0.625rem 0.75rem;
+    font: inherit;
+    font-size: 1rem;
+    color: var(--foreground);
+    background: var(--background);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    outline: none;
+  }
+  input[type="password"]:focus {
+    border-color: var(--primary);
+    box-shadow: 0 0 0 3px color-mix(in oklch, var(--primary) 25%, transparent);
+  }
+
+  button {
+    width: 100%;
+    margin-top: 0.75rem;
+    padding: 0.625rem 0.75rem;
+    font: inherit;
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--primary-foreground);
+    background: var(--primary);
+    border: none;
+    border-radius: var(--radius);
+    cursor: pointer;
+  }
+  button:hover { filter: brightness(1.08); }
+
+  .error {
+    margin: 0 0 0.75rem;
+    font-size: 0.875rem;
+    color: var(--destructive);
+  }
+</style>
+</head>
+<body>
+
+<main class="card">
+  <div class="brand">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+         stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <rect x="3" y="3" width="18" height="18" rx="2"></rect>
+      <circle cx="8.5" cy="8.5" r="1.5"></circle>
+      <path d="m21 15-4.35-4.35a2 2 0 0 0-2.83 0L3 21"></path>
+    </svg>
+    <span><span class="accent">Picto</span>Py</span>
+  </div>
+
+  <div class="lock">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+         stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <rect x="3" y="11" width="18" height="11" rx="2"></rect>
+      <path d="M7 11V7a5 5 0 0 1 10 0v4"></path>
+    </svg>
+  </div>
+
+  <h1>This album is protected</h1>
+  <p class="hint">Enter the password you were given to view the photos.</p>
+
+  {% if error %}
+  <p class="error" role="alert">{{ error }}</p>
+  {% endif %}
+
+  <form method="post" action="/s/{{ token }}/unlock">
+    <input type="password" name="password" required autofocus
+           autocomplete="current-password" aria-label="Password">
+    <button type="submit">View album</button>
+  </form>
+</main>
+
+</body>
+</html>

--- a/backend/app/utils/share.py
+++ b/backend/app/utils/share.py
@@ -40,6 +40,7 @@ class ShareDescription(TypedDict):
     port: int
     created_at: str
     expires_at: Optional[str]
+    is_protected: bool
     urls: List[ShareUrlRecord]
 
 
@@ -50,12 +51,16 @@ _orchestration_lock = asyncio.Lock()
 
 
 async def share_util_create(
-    album_id: str, expires_in_minutes: Optional[int] = None
+    album_id: str,
+    expires_in_minutes: Optional[int] = None,
+    password: Optional[str] = None,
 ) -> ShareEntry:
     """Issue a token for an album and make sure the listener is up."""
     async with _orchestration_lock:
         await share_server_start()
-        return share_registry_create(album_id, expires_in_minutes=expires_in_minutes)
+        return share_registry_create(
+            album_id, expires_in_minutes=expires_in_minutes, password=password
+        )
 
 
 async def share_util_revoke(token: str) -> bool:
@@ -90,6 +95,7 @@ def share_util_describe(entry: ShareEntry, port: int) -> ShareDescription:
         "port": port,
         "created_at": entry.created_at.isoformat(),
         "expires_at": entry.expires_at.isoformat() if entry.expires_at else None,
+        "is_protected": entry.is_protected,
         "urls": [
             {
                 "interface": candidate.interface,

--- a/backend/tests/test_share_control.py
+++ b/backend/tests/test_share_control.py
@@ -29,11 +29,15 @@ PORT = 52125
 
 
 @pytest.fixture(autouse=True)
-def album_db(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
-    """One album in a throwaway database, which is all describing a share reads."""
+def cheap_hashing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """bcrypt's default work factor is the point in production, waste here."""
     gensalt = bcrypt.gensalt
     monkeypatch.setattr(bcrypt, "gensalt", lambda: gensalt(4))
 
+
+@pytest.fixture(autouse=True)
+def album_db(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """One album in a throwaway database, which is all describing a share reads."""
     db_fd, db_path = tempfile.mkstemp()
     os.close(db_fd)
     monkeypatch.setattr("app.database.albums.DATABASE_PATH", db_path)

--- a/backend/tests/test_share_control.py
+++ b/backend/tests/test_share_control.py
@@ -1,0 +1,98 @@
+"""
+The localhost control surface: what the desktop UI sends and is told back.
+
+The public viewer is covered separately in test_share_routes.py.
+"""
+
+import os
+import tempfile
+from typing import Iterator
+
+import bcrypt
+import pytest
+from pydantic import ValidationError
+
+from app.database.albums import (
+    db_create_album_images_table,
+    db_create_albums_table,
+    db_insert_album,
+)
+from app.schemas.share import CreateShareRequest, Share
+from app.share.registry import (
+    PASSWORD_MAX_BYTES,
+    share_registry_clear,
+    share_registry_create,
+)
+from app.utils.share import share_util_describe
+
+PORT = 52125
+
+
+@pytest.fixture(autouse=True)
+def album_db(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """One album in a throwaway database, which is all describing a share reads."""
+    gensalt = bcrypt.gensalt
+    monkeypatch.setattr(bcrypt, "gensalt", lambda: gensalt(4))
+
+    db_fd, db_path = tempfile.mkstemp()
+    os.close(db_fd)
+    monkeypatch.setattr("app.database.albums.DATABASE_PATH", db_path)
+    monkeypatch.setattr("app.database.connection.DATABASE_PATH", db_path)
+
+    db_create_albums_table()
+    db_create_album_images_table()
+    db_insert_album("album-1", "Trip to Goa", "", False, None)
+    share_registry_clear()
+
+    yield
+
+    share_registry_clear()
+    os.unlink(db_path)
+
+
+class TestDescription:
+    def test_an_open_share_is_reported_as_open(self) -> None:
+        entry = share_registry_create("album-1")
+        assert share_util_describe(entry, PORT)["is_protected"] is False
+
+    def test_a_protected_share_is_flagged(self) -> None:
+        entry = share_registry_create("album-1", password="hunter-two-two")
+        assert share_util_describe(entry, PORT)["is_protected"] is True
+
+    def test_the_description_fills_the_response_model(self) -> None:
+        """
+        Catches the two halves of a share drifting apart: the TypedDict the
+        backend builds and the model the UI is promised.
+        """
+        entry = share_registry_create("album-1", password="hunter-two-two")
+        share = Share(**share_util_describe(entry, PORT))
+        assert share.token == entry.token
+        assert share.is_protected is True
+
+    def test_no_password_material_is_returned(self) -> None:
+        entry = share_registry_create("album-1", password="hunter-two-two")
+        described = share_util_describe(entry, PORT)
+        assert "password" not in described
+        assert "hunter-two-two" not in str(described)
+
+
+class TestCreateRequest:
+    def test_password_is_optional(self) -> None:
+        assert CreateShareRequest().password is None
+
+    def test_a_trivial_password_is_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            CreateShareRequest(password="ab")
+
+    def test_a_password_past_the_bcrypt_limit_is_rejected(self) -> None:
+        """
+        Silently truncating at 72 bytes would set a password the user never
+        typed, so it has to be refused at the door.
+        """
+        with pytest.raises(ValidationError):
+            CreateShareRequest(password="a" * (PASSWORD_MAX_BYTES + 1))
+
+    def test_the_limit_counts_bytes_not_characters(self) -> None:
+        # Well under 72 characters, comfortably over 72 bytes.
+        with pytest.raises(ValidationError):
+            CreateShareRequest(password="é" * 40)

--- a/backend/tests/test_share_registry.py
+++ b/backend/tests/test_share_registry.py
@@ -1,3 +1,5 @@
+import threading
+import time
 from datetime import datetime, timedelta, timezone
 from typing import Iterator
 
@@ -5,6 +7,7 @@ import bcrypt
 import pytest
 
 from app.share.registry import (
+    PASSWORD_MAX_BYTES,
     share_registry_clear,
     share_registry_count,
     share_registry_create,
@@ -178,6 +181,59 @@ class TestPassword:
         share_registry_unlock(entry, "guess")
         share_registry_unlock(entry, "guess")
         assert share_registry_is_throttled(entry) is False
+
+    def test_a_burst_of_attempts_cannot_outrun_the_limit(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        Sync handlers run in a threadpool, so the limit has to hold against
+        requests arriving together rather than one after another.
+        """
+        monkeypatch.setattr("app.share.registry._MAX_FAILED_UNLOCKS", 3)
+        entry = share_registry_create("album-1", password=PASSWORD)
+
+        checkpw = bcrypt.checkpw
+        hashed = threading.Semaphore(0)
+
+        def slow_checkpw(candidate: bytes, stored: bytes) -> bool:
+            hashed.release()
+            # Long enough that every thread is inside this call at once if the
+            # limit is not enforced before hashing starts.
+            time.sleep(0.05)
+            return checkpw(candidate, stored)
+
+        monkeypatch.setattr(bcrypt, "checkpw", slow_checkpw)
+
+        threads = [
+            threading.Thread(target=share_registry_unlock, args=(entry, "guess"))
+            for _ in range(12)
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        reached_bcrypt = sum(1 for _ in iter(lambda: hashed.acquire(False), False))
+        assert reached_bcrypt <= 3
+        assert share_registry_is_throttled(entry) is True
+
+    def test_a_password_too_long_to_have_been_set_is_refused(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        bcrypt truncates past its limit and raises in later releases, so an
+        oversized submission must never reach it.
+        """
+        entry = share_registry_create("album-1", password=PASSWORD)
+
+        def unreachable(candidate: bytes, stored: bytes) -> bool:
+            raise AssertionError("an over-long password reached bcrypt")
+
+        monkeypatch.setattr(bcrypt, "checkpw", unreachable)
+
+        assert share_registry_unlock(entry, "x" * (PASSWORD_MAX_BYTES + 1)) is None
+        # Refused for free, so it costs the visitor none of their attempts.
+        assert entry.failed_unlocks == 0
 
     def test_the_cooldown_expires(self) -> None:
         entry = share_registry_create("album-1", password=PASSWORD)

--- a/backend/tests/test_share_registry.py
+++ b/backend/tests/test_share_registry.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta, timezone
 from typing import Iterator
 
+import bcrypt
 import pytest
 
 from app.share.registry import (
@@ -8,9 +9,14 @@ from app.share.registry import (
     share_registry_count,
     share_registry_create,
     share_registry_get,
+    share_registry_is_throttled,
+    share_registry_is_unlocked,
     share_registry_list,
     share_registry_revoke,
+    share_registry_unlock,
 )
+
+PASSWORD = "correct-horse-battery"
 
 
 @pytest.fixture(autouse=True)
@@ -19,6 +25,18 @@ def empty_registry() -> Iterator[None]:
     share_registry_clear()
     yield
     share_registry_clear()
+
+
+@pytest.fixture(autouse=True)
+def cheap_hashing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    Hash at the minimum cost.
+
+    bcrypt's default work factor is the point in production and pure waste here,
+    where the tests only care that the algorithm is wired up correctly.
+    """
+    gensalt = bcrypt.gensalt
+    monkeypatch.setattr(bcrypt, "gensalt", lambda: gensalt(4))
 
 
 def expire(token: str) -> None:
@@ -88,6 +106,84 @@ class TestRevoke:
         drop = share_registry_create("album-2")
         share_registry_revoke(drop.token)
         assert share_registry_get(keep.token) is not None
+
+
+class TestPassword:
+    def test_a_share_is_open_by_default(self) -> None:
+        entry = share_registry_create("album-1")
+        assert entry.is_protected is False
+        assert share_registry_is_unlocked(entry, None) is True
+
+    def test_only_a_hash_is_kept(self) -> None:
+        """The plaintext must not survive anywhere on the entry."""
+        entry = share_registry_create("album-1", password=PASSWORD)
+        assert entry.is_protected is True
+        assert entry.password_hash is not None
+        assert PASSWORD.encode("utf-8") not in entry.password_hash
+
+    def test_the_right_password_opens_the_share(self) -> None:
+        entry = share_registry_create("album-1", password=PASSWORD)
+        cookie = share_registry_unlock(entry, PASSWORD)
+        assert cookie is not None
+        assert share_registry_is_unlocked(entry, cookie) is True
+
+    def test_the_wrong_password_does_not(self) -> None:
+        entry = share_registry_create("album-1", password=PASSWORD)
+        assert share_registry_unlock(entry, "guess") is None
+
+    def test_a_protected_share_is_locked_without_a_cookie(self) -> None:
+        entry = share_registry_create("album-1", password=PASSWORD)
+        assert share_registry_is_unlocked(entry, None) is False
+        assert share_registry_is_unlocked(entry, "forged") is False
+
+    def test_a_cookie_does_not_carry_to_another_share(self) -> None:
+        """
+        The invariant that keeps one unlocked album from unlocking the rest,
+        including a second share of the same album under the same password.
+        """
+        first = share_registry_create("album-1", password=PASSWORD)
+        second = share_registry_create("album-1", password=PASSWORD)
+        cookie = share_registry_unlock(first, PASSWORD)
+        assert share_registry_is_unlocked(second, cookie) is False
+
+    def test_an_open_share_cannot_be_unlocked(self) -> None:
+        """Nothing to check against, so no cookie should ever be minted."""
+        entry = share_registry_create("album-1")
+        assert share_registry_unlock(entry, PASSWORD) is None
+
+    def test_repeated_failures_stop_further_attempts(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("app.share.registry._MAX_FAILED_UNLOCKS", 3)
+        entry = share_registry_create("album-1", password=PASSWORD)
+
+        for _ in range(3):
+            assert share_registry_unlock(entry, "guess") is None
+
+        assert share_registry_is_throttled(entry) is True
+        # The cooldown has to bite regardless of what is guessed next, or it
+        # would only be slowing an attacker down between wrong answers.
+        assert share_registry_unlock(entry, PASSWORD) is None
+
+    def test_getting_it_right_clears_earlier_failures(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("app.share.registry._MAX_FAILED_UNLOCKS", 3)
+        entry = share_registry_create("album-1", password=PASSWORD)
+
+        share_registry_unlock(entry, "guess")
+        share_registry_unlock(entry, "guess")
+        assert share_registry_unlock(entry, PASSWORD) is not None
+
+        share_registry_unlock(entry, "guess")
+        share_registry_unlock(entry, "guess")
+        assert share_registry_is_throttled(entry) is False
+
+    def test_the_cooldown_expires(self) -> None:
+        entry = share_registry_create("album-1", password=PASSWORD)
+        entry.locked_until = datetime.now(timezone.utc) - timedelta(seconds=1)
+        assert share_registry_is_throttled(entry) is False
+        assert share_registry_unlock(entry, PASSWORD) is not None
 
 
 class TestListing:

--- a/backend/tests/test_share_routes.py
+++ b/backend/tests/test_share_routes.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Iterator, List, TypedDict
 
+import bcrypt
 import pytest
 from fastapi.testclient import TestClient
 
@@ -24,6 +25,14 @@ from app.share.registry import (
 
 JPEG_BYTES = b"\xff\xd8\xff\xe0fake-jpeg-body\xff\xd9"
 THUMB_BYTES = b"\xff\xd8\xff\xe0fake-thumb-body\xff\xd9"
+PASSWORD = "correct-horse-battery"
+
+
+@pytest.fixture(autouse=True)
+def cheap_hashing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """bcrypt's default work factor is the point in production, waste here."""
+    gensalt = bcrypt.gensalt
+    monkeypatch.setattr(bcrypt, "gensalt", lambda: gensalt(4))
 
 
 class ShareEnv(TypedDict):
@@ -219,6 +228,85 @@ class TestViewerChrome:
         body = share_env["client"].get(f"/s/{share_env['token']}").text
         assert "<script>alert(1)</script>" not in body
         assert "&lt;script&gt;" in body
+
+
+class TestPasswordGate:
+    def test_a_protected_share_asks_for_the_password(self, share_env: ShareEnv) -> None:
+        entry = share_registry_create("album-1", password=PASSWORD)
+        response = share_env["client"].get(f"/s/{entry.token}")
+        assert response.status_code == 200
+        assert 'name="password"' in response.text
+
+    def test_the_gate_says_nothing_about_the_album(self, share_env: ShareEnv) -> None:
+        """
+        A link that reaches the wrong person should tell them only that some
+        album exists — not its name, its size, or any of its photos.
+        """
+        entry = share_registry_create("album-1", password=PASSWORD)
+        body = share_env["client"].get(f"/s/{entry.token}").text
+        assert "Trip to Goa" not in body
+        assert "2 photos" not in body
+        assert "img-1" not in body
+
+    def test_media_is_refused_while_locked(self, share_env: ShareEnv) -> None:
+        entry = share_registry_create("album-1", password=PASSWORD)
+        client = share_env["client"]
+        assert client.get(f"/s/{entry.token}/thumb/img-1").status_code == 404
+        assert client.get(f"/s/{entry.token}/photo/img-1").status_code == 404
+
+    def test_the_right_password_opens_the_album(self, share_env: ShareEnv) -> None:
+        entry = share_registry_create("album-1", password=PASSWORD)
+        client = share_env["client"]
+
+        response = client.post(
+            f"/s/{entry.token}/unlock",
+            data={"password": PASSWORD},
+            follow_redirects=False,
+        )
+        assert response.status_code == 303
+        assert response.headers["location"] == f"/s/{entry.token}"
+
+        assert "Trip to Goa" in client.get(f"/s/{entry.token}").text
+        assert client.get(f"/s/{entry.token}/photo/img-1").status_code == 200
+
+    def test_the_wrong_password_is_refused(self, share_env: ShareEnv) -> None:
+        entry = share_registry_create("album-1", password=PASSWORD)
+        client = share_env["client"]
+
+        response = client.post(
+            f"/s/{entry.token}/unlock",
+            data={"password": "guess"},
+            follow_redirects=False,
+        )
+        assert response.status_code == 401
+        assert 'name="password"' in response.text
+        assert "Trip to Goa" not in client.get(f"/s/{entry.token}").text
+
+    def test_unlocking_one_share_leaves_the_others_locked(
+        self, share_env: ShareEnv
+    ) -> None:
+        opened = share_registry_create("album-1", password=PASSWORD)
+        other = share_registry_create("album-1", password=PASSWORD)
+        client = share_env["client"]
+
+        client.post(f"/s/{opened.token}/unlock", data={"password": PASSWORD})
+
+        assert 'name="password"' in client.get(f"/s/{other.token}").text
+        assert client.get(f"/s/{other.token}/photo/img-1").status_code == 404
+
+    def test_an_open_share_needs_no_unlocking(self, share_env: ShareEnv) -> None:
+        response = share_env["client"].post(
+            f"/s/{share_env['token']}/unlock",
+            data={"password": "anything"},
+            follow_redirects=False,
+        )
+        assert response.status_code == 303
+
+    def test_unlocking_an_unknown_token_is_404(self, share_env: ShareEnv) -> None:
+        response = share_env["client"].post(
+            "/s/made-up-token/unlock", data={"password": PASSWORD}
+        )
+        assert response.status_code == 404
 
 
 class TestSurface:


### PR DESCRIPTION
Part of #1468

Adds optional password protection to a network share, following the sharing backend that landed in #1469.

A share can now be created with a password. The recipient meets an unlock page first, and both the viewer and the image routes stay closed until the password is entered. Gating only the page would have left the image URLs readable by anyone holding the link, which is the thing the password exists to prevent.

The unlock cookie is an HMAC over the share token and the password hash rather than a stored session. Nothing accumulates as more devices open a share, a cookie from one share cannot be replayed against another, and the cookie is scoped to that share's own path. The bcrypt check runs outside the registry lock, since holding it for the length of a hash comparison would serialise every other request on the listener.

The unlock page names nothing about the album, neither its title nor its size, so a link that reaches the wrong person reveals only that some album is being shared. Ten wrong attempts put the share into a short cooldown; bcrypt already makes guessing slow, and the cooldown is what stops an unattended script.

Password length is bounded in bytes rather than characters, because that is where bcrypt truncates. A forty character accented password would otherwise be accepted as something the user never typed.

No new dependencies, and the page is a plain HTML form, so it needs no JavaScript.

## Testing

26 new tests, with the full suite at 1086 passing. The control surface had no coverage before this, and since this change adds a field to both the request and the response, a first pass over it is included. The flow was also driven end to end in a browser.

## Not included

The desktop UI has no way to set a password yet. That arrives with the share dialog, together with the QR code and the interface picker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional password protection for shared albums.
  * Added a responsive unlock page with light and dark theme support.
  * Protected albums, photos, and thumbnails require successful unlocking.
  * Added indicators showing whether a share is protected.
  * Added safeguards against repeated failed password attempts.

* **Bug Fixes**
  * Improved access handling to avoid revealing details for locked or unavailable shares.

* **Tests**
  * Added coverage for password validation, unlocking, access isolation, throttling, and protected media.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->