### PR TITLE
fix(frontend): reset scroll position to top on new search (#1461)

### DIFF
--- a/frontend/src/layout/layout.tsx
+++ b/frontend/src/layout/layout.tsx
@@ -22,7 +22,10 @@ const Layout: React.FC = () => {
           <AppSidebar />
           {/* Contain scrolling here so Navbar's parent height never exceeds 100vh — now the navbar is stuck it will not go away.
               hide-scrollbar keeps overflow-y-auto (needed for the sticky navbar) from painting a second, default scrollbar on Windows/WebView2. */}
-          <div className="hide-scrollbar m-4 w-full overflow-y-auto">
+          <div
+            id="main-scroll-container"
+            className="hide-scrollbar m-4 w-full overflow-y-auto"
+          >
             <Outlet />
           </div>
         </div>

--- a/frontend/src/pages/SearchResults/SearchResults.tsx
+++ b/frontend/src/pages/SearchResults/SearchResults.tsx
@@ -94,6 +94,11 @@ export const SearchResults = () => {
   }
   const currentSearchGeneration = searchGenerationRef.current;
 
+  // Reset the scroll position to the top whenever the search changes
+  useEffect(() => {
+    document.getElementById('main-scroll-container')?.scrollTo({ top: 0 });
+  }, [query, mode]);
+
   const { data: statusData, isSuccess: isStatusSuccess } = usePictoQuery({
     queryKey: ['models', 'status'],
     queryFn: fetchModelStatus,

--- a/frontend/src/pages/__tests__/SearchResults.test.tsx
+++ b/frontend/src/pages/__tests__/SearchResults.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, waitFor } from '@/test-utils';
+import { render, screen, waitFor, fireEvent } from '@/test-utils';
+import { useNavigate } from 'react-router';
 import { SearchResults } from '../SearchResults/SearchResults';
 import {
   searchImagesByTag,
@@ -372,5 +373,85 @@ describe('SearchResults Page', () => {
       },
       { timeout: 3000 },
     );
+  });
+
+  test('resets the main scroll container to the top on a new search', async () => {
+    // The real scroll container lives in the layout, which this page-level
+    // test does not mount. Stand one in and give its scrollTo the same
+    // observable effect a browser has -- it updates scrollTop -- so the test
+    // can assert the user-visible scroll state rather than a spy call.
+    const scrollContainer = document.createElement('div');
+    scrollContainer.id = 'main-scroll-container';
+    const scrollTo = jest.fn((options?: ScrollToOptions) => {
+      if (typeof options?.top === 'number') {
+        scrollContainer.scrollTop = options.top;
+      }
+    });
+    // Define the property directly instead of casting a jest.fn onto the
+    // read-only overloaded HTMLElement['scrollTo'] signature.
+    Object.defineProperty(scrollContainer, 'scrollTo', {
+      value: scrollTo,
+      writable: true,
+      configurable: true,
+    });
+    document.body.appendChild(scrollContainer);
+
+    // Navigate within the same mounted SearchResults so the transition mirrors
+    // a real new search (query param changes, component stays mounted) rather
+    // than a fresh mount whose effect would trivially fire once.
+    const GoToSearch = ({ to }: { to: string }) => {
+      const navigate = useNavigate();
+      return (
+        <button type="button" onClick={() => navigate(to)}>
+          go to {to}
+        </button>
+      );
+    };
+
+    try {
+      (searchImagesByTag as jest.Mock).mockResolvedValue({
+        success: true,
+        data: [
+          {
+            id: '1',
+            path: '/img1.jpg',
+            thumbnailPath: '/thumb1.jpg',
+            tags: ['cat'],
+          },
+        ],
+      });
+
+      render(
+        <>
+          <GoToSearch to="/search?value=motorcycle" />
+          <SearchResults />
+        </>,
+        { initialRoutes: ['/search?value=cat'] },
+      );
+
+      // Let the initial search settle so we isolate the new-search transition.
+      await waitFor(() => {
+        expect(screen.getByText('Results for "cat"')).toBeInTheDocument();
+      });
+
+      // Simulate the user having scrolled the previous, longer result set to
+      // the bottom, then start observing from a clean slate.
+      scrollContainer.scrollTop = 500;
+      scrollTo.mockClear();
+
+      // Run the new search on the still-mounted component.
+      fireEvent.click(screen.getByRole('button', { name: /motorcycle/i }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Results for "motorcycle"'),
+        ).toBeInTheDocument();
+        // The user-visible result: the viewport is back at the top.
+        expect(scrollContainer.scrollTop).toBe(0);
+      });
+      expect(scrollTo).toHaveBeenCalledWith({ top: 0 });
+    } finally {
+      document.body.removeChild(scrollContainer);
+    }
   });
 });


### PR DESCRIPTION
###  Addressed Issues:

Fixes #1461

###  Screenshots/Recordings:

[DRIVE LINK](https://drive.google.com/file/d/1SIHNJcOgkK0hvX4E_bcb8t8DhfJAhfkz/view?usp=sharing)
###  Additional Notes:

**Root cause**

The app has a single scroll container in `layout.tsx` (the `overflow-y-auto` div that wraps `<Outlet />`). Running a new search only changes the `value`/`mode` query params on `/search`, so the `SearchResults` page stays mounted and that container keeps its previous `scrollTop`. If the user had scrolled a long result set to the bottom and then ran a search that returns fewer items, the new results render at the top but the viewport stays parked below them, leaving the user looking at an empty area.

**Fix (scroll-restoration only, as requested in the issue)**

1. `layout.tsx`: gave the scroll container a stable `id="main-scroll-container"` so it is addressable.
2. `SearchResults.tsx`: added an effect that scrolls that container to the top whenever the search changes:

   ```tsx
   useEffect(() => {
     document.getElementById('main-scroll-container')?.scrollTo({ top: 0 });
   }, [query, mode]);
   ```

   Keyed on `[query, mode]` so it fires for query changes, category changes, and mode switches (tag / semantic / people). It is a no-op if the container is not present. No changes to search logic, pagination, or caching.
3. `SearchResults.test.tsx`: added a regression test asserting `scrollTo({ top: 0 })` is called on a new search.

**Verification (run locally on latest `main`)**

- `npm test -- SearchResults` -> 14/14 pass (incl. the new regression test)
- `npx jest allPages + PageSanity + Navbar` -> 20/20 pass
- `npx tsc --noEmit` -> clean
- `npx eslint --max-warnings 0` on the touched files -> clean
- `npx prettier --check` on the touched files -> clean

### AI Usage Disclosure:

We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact. AI slop is strongly discouraged and may lead to banning and blocking. Do not spam our repos with AI slop.

Check one of the checkboxes below:

- [ ] This PR does not contain AI-generated code at all.
- [x] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools: ChatGPT

## Checklist
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [ ] If applicable, I have made corresponding changes or additions to the documentation
- [x] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [ ] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Search results now automatically return to the top when the search query or search mode changes.
- Improved scrolling behavior in the main content area for a smoother browsing experience.
- Search navigation now displays newly selected results from the beginning of the results view, making it easier to understand and review results when switching between searches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->