### PR TITLE
feat: share an album from the desktop app

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -38,6 +38,7 @@
         "framer-motion": "^11.16.3",
         "ldrs": "^1.0.2",
         "lucide-react": "^0.513.0",
+        "qrcode.react": "^4.2.0",
         "react": "19.1.0",
         "react-colorful": "^5.6.1",
         "react-dnd": "^16.0.1",
@@ -12144,6 +12145,15 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/querystringify": {
       "version": "2.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -53,6 +53,7 @@
     "framer-motion": "^11.16.3",
     "ldrs": "^1.0.2",
     "lucide-react": "^0.513.0",
+    "qrcode.react": "^4.2.0",
     "react": "19.1.0",
     "react-colorful": "^5.6.1",
     "react-dnd": "^16.0.1",

--- a/frontend/src/api/api-functions/index.ts
+++ b/frontend/src/api/api-functions/index.ts
@@ -7,4 +7,5 @@ export * from './user_preferences';
 export * from './health';
 export * from './albums';
 export * from './memories';
+export * from './share';
 export * from './models';

--- a/frontend/src/api/api-functions/share.ts
+++ b/frontend/src/api/api-functions/share.ts
@@ -1,0 +1,37 @@
+import { shareEndpoints } from '../apiEndpoints';
+import { apiClient } from '../axiosConfig';
+import type { BackendRes } from '@/hooks/useQueryExtension';
+import { CreateShareRequest, Share } from '@/types/Share';
+
+/**
+ * Every album currently being served on the local network
+ */
+export const getShares = async (): Promise<BackendRes<Share[]>> => {
+  const response = await apiClient.get(shareEndpoints.getShares);
+  return response.data;
+};
+
+/**
+ * Start serving an album on the local network
+ * @param albumId - Album UUID
+ * @param data - Optional expiry and password
+ */
+export const createShare = async (
+  albumId: string,
+  data: CreateShareRequest = {},
+): Promise<BackendRes<Share>> => {
+  const response = await apiClient.post(
+    shareEndpoints.createShare(albumId),
+    data,
+  );
+  return response.data;
+};
+
+/**
+ * Stop serving a share. The network listener closes with the last one.
+ * @param token - The share's token
+ */
+export const revokeShare = async (token: string): Promise<BackendRes<null>> => {
+  const response = await apiClient.delete(shareEndpoints.revokeShare(token));
+  return response.data;
+};

--- a/frontend/src/api/apiEndpoints.ts
+++ b/frontend/src/api/apiEndpoints.ts
@@ -59,6 +59,14 @@ export const albumsEndpoints = {
     `/albums/${albumId}/images`,
 };
 
+export const shareEndpoints = {
+  getShares: '/share/',
+  getInterfaces: '/share/interfaces',
+  createShare: (albumId: string) =>
+    `/share/albums/${encodeURIComponent(albumId)}`,
+  revokeShare: (token: string) => `/share/${encodeURIComponent(token)}`,
+};
+
 export const memoriesEndpoints = {
   list: '/memories',
   generate: '/memories/generate',

--- a/frontend/src/components/Albums/AlbumCard.tsx
+++ b/frontend/src/components/Albums/AlbumCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { MoreVertical, Lock, Pencil, Trash2 } from 'lucide-react';
+import { MoreVertical, Lock, Pencil, Share2, Trash2 } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
 import {
   DropdownMenu,
@@ -9,6 +9,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Button } from '@/components/ui/button';
 import { AlbumCardProps } from '@/types/Album';
+import { cn } from '@/lib/utils';
 import { useTheme } from '@/contexts/ThemeContext';
 import { convertFileSrc } from '@tauri-apps/api/core';
 
@@ -17,6 +18,8 @@ export const AlbumCard: React.FC<AlbumCardProps> = ({
   onClick,
   onEdit,
   onDelete,
+  onShare,
+  isSharing,
 }) => {
   const handleMenuAction = (e: React.MouseEvent, action: () => void): void => {
     e.stopPropagation();
@@ -37,7 +40,10 @@ export const AlbumCard: React.FC<AlbumCardProps> = ({
 
   return (
     <Card
-      className="group relative cursor-pointer overflow-hidden py-0 transition-all"
+      className={cn(
+        'group relative cursor-pointer overflow-hidden py-0 transition-all',
+        isSharing && 'ring-primary ring-2',
+      )}
       onClick={onClick}
     >
       <CardContent className="p-0">
@@ -59,6 +65,13 @@ export const AlbumCard: React.FC<AlbumCardProps> = ({
               <Lock className="text-foreground h-5 w-5" />
             </div>
           )}
+          {/* Sharing Badge */}
+          {isSharing && (
+            <div className="bg-primary text-primary-foreground absolute bottom-3 left-3 flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium shadow-lg">
+              <Share2 className="h-3.5 w-3.5" />
+              Sharing
+            </div>
+          )}
           {/* Actions Menu */}
           <div className="absolute top-3 right-3">
             <DropdownMenu>
@@ -76,6 +89,10 @@ export const AlbumCard: React.FC<AlbumCardProps> = ({
                 <DropdownMenuItem onClick={(e) => handleMenuAction(e, onEdit)}>
                   <Pencil className="mr-2 h-4 w-4" />
                   Edit Album
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={(e) => handleMenuAction(e, onShare)}>
+                  <Share2 className="mr-2 h-4 w-4" />
+                  {isSharing ? 'Manage Share' : 'Share Album'}
                 </DropdownMenuItem>
                 <DropdownMenuItem
                   onClick={(e) => handleMenuAction(e, onDelete)}

--- a/frontend/src/components/Albums/ShareAlbumDialog.tsx
+++ b/frontend/src/components/Albums/ShareAlbumDialog.tsx
@@ -1,0 +1,354 @@
+import React, { useEffect, useState } from 'react';
+import { QRCodeSVG } from 'qrcode.react';
+import { Check, Copy, Share2, Wifi } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import { usePictoMutation } from '@/hooks/useQueryExtension';
+import { createShare, revokeShare } from '@/api/api-functions';
+import { useMutationFeedback } from '@/hooks/useMutationFeedback';
+import { cn } from '@/lib/utils';
+import { Share, ShareAlbumDialogProps, ShareUrl } from '@/types/Share';
+
+const EXPIRY_OPTIONS = [
+  { value: '60', label: 'For 1 hour' },
+  { value: '360', label: 'For 6 hours' },
+  { value: '1440', label: 'For 24 hours' },
+  { value: 'never', label: 'Until I stop it' },
+] as const;
+
+// The backend hashes with bcrypt and refuses anything shorter.
+const MIN_PASSWORD_LENGTH = 4;
+
+const formatExpiry = (expiresAt: string | null): string =>
+  expiresAt ? new Date(expiresAt).toLocaleString() : 'Until you stop it';
+
+export const ShareAlbumDialog: React.FC<ShareAlbumDialogProps> = ({
+  album,
+  share,
+  isOpen,
+  onClose,
+  onChanged,
+}) => {
+  const [expiry, setExpiry] = useState<string>('1440');
+  const [withPassword, setWithPassword] = useState(false);
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [createdShare, setCreatedShare] = useState<Share | null>(null);
+  const [selectedUrl, setSelectedUrl] = useState('');
+  const [copied, setCopied] = useState(false);
+
+  // The share this dialog is showing: the one just made, or one already running.
+  const activeShare = createdShare ?? share;
+  const urls = activeShare?.urls ?? [];
+  const shareUrl = urls.find((entry) => entry.url === selectedUrl) ?? urls[0];
+
+  const createShareMutation = usePictoMutation({
+    mutationFn: (variables: { albumId: string; password?: string }) =>
+      createShare(variables.albumId, {
+        ...(expiry !== 'never' && { expires_in_minutes: Number(expiry) }),
+        ...(variables.password && { password: variables.password }),
+      }),
+    // Handled here rather than through the feedback hook so the new share
+    // arrives typed rather than as the hook's untyped success payload.
+    onSuccess: (response) => {
+      if (response.data) {
+        setCreatedShare(response.data);
+      }
+      onChanged();
+    },
+    autoInvalidateTags: ['shares'],
+  });
+
+  const revokeShareMutation = usePictoMutation({
+    // Wrapped rather than passed directly: react-query hands the mutation
+    // function a context object as a second argument.
+    mutationFn: (token: string) => revokeShare(token),
+    autoInvalidateTags: ['shares'],
+  });
+
+  useMutationFeedback(createShareMutation, {
+    loadingMessage: 'Starting the share...',
+    // The link and QR code are the confirmation; a dialog on top of them would
+    // only be in the way.
+    showSuccess: false,
+    errorTitle: 'Error',
+    errorMessage: 'Could not share this album. Please try again.',
+  });
+
+  useMutationFeedback(revokeShareMutation, {
+    loadingMessage: 'Stopping the share...',
+    successTitle: 'Sharing stopped',
+    successMessage: 'The album is no longer on the local network.',
+    errorTitle: 'Error',
+    errorMessage: 'Could not stop this share. Please try again.',
+    onSuccess: () => {
+      onChanged();
+      onClose();
+    },
+  });
+
+  // Reopening has to start clean, including after sharing a different album.
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    setExpiry('1440');
+    setWithPassword(false);
+    setPassword('');
+    setError('');
+    setCreatedShare(null);
+    setSelectedUrl('');
+    setCopied(false);
+  }, [isOpen, album?.id]);
+
+  const handleCreate = (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!album) {
+      return;
+    }
+    if (withPassword && password.trim().length < MIN_PASSWORD_LENGTH) {
+      setError(`Use at least ${MIN_PASSWORD_LENGTH} characters.`);
+      return;
+    }
+    createShareMutation.mutate({
+      albumId: album.id,
+      ...(withPassword && { password: password.trim() }),
+    });
+  };
+
+  const handleCopy = async () => {
+    if (!shareUrl || !navigator.clipboard) {
+      return;
+    }
+    await navigator.clipboard.writeText(shareUrl.url);
+    setCopied(true);
+  };
+
+  const renderAddress = (entry: ShareUrl) => (
+    <button
+      key={entry.url}
+      type="button"
+      onClick={() => {
+        setSelectedUrl(entry.url);
+        setCopied(false);
+      }}
+      className={cn(
+        'flex w-full items-center justify-between rounded-md border px-3 py-2 text-left text-sm',
+        entry.url === shareUrl?.url
+          ? 'border-primary bg-primary/5'
+          : 'border-border hover:bg-muted',
+      )}
+    >
+      <span className="truncate font-medium">{entry.interface}</span>
+      <span className="text-muted-foreground ml-3 shrink-0 font-mono text-xs">
+        {entry.ip}
+      </span>
+    </button>
+  );
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="sm:max-w-[480px]">
+        {activeShare ? (
+          <>
+            <DialogHeader>
+              <DialogTitle>Sharing "{activeShare.album_name}"</DialogTitle>
+              <DialogDescription>
+                Anyone on this network can open the link while PictoPy is
+                running. Nothing is uploaded.
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="grid gap-4 py-4">
+              {shareUrl ? (
+                <>
+                  <div className="flex justify-center">
+                    {/* Always on white: a QR code needs the light quiet zone to
+                        stay scannable in dark mode. */}
+                    <div className="rounded-xl bg-white p-3 shadow-sm">
+                      <QRCodeSVG value={shareUrl.url} size={168} />
+                    </div>
+                  </div>
+
+                  <div className="grid gap-2">
+                    <Label htmlFor="share-link">Link</Label>
+                    <div className="flex gap-2">
+                      <Input
+                        id="share-link"
+                        readOnly
+                        value={shareUrl.url}
+                        className="font-mono text-xs"
+                      />
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="icon"
+                        onClick={handleCopy}
+                        aria-label="Copy link"
+                      >
+                        {copied ? (
+                          <Check className="h-4 w-4" />
+                        ) : (
+                          <Copy className="h-4 w-4" />
+                        )}
+                      </Button>
+                    </div>
+                  </div>
+
+                  {urls.length > 1 && (
+                    <div className="grid gap-2">
+                      <Label className="flex items-center gap-2">
+                        <Wifi className="text-primary h-4 w-4" />
+                        Address
+                      </Label>
+                      <p className="text-muted-foreground text-xs">
+                        This machine has more than one. If the first does not
+                        work, try another.
+                      </p>
+                      <div className="grid gap-1.5">
+                        {urls.map(renderAddress)}
+                      </div>
+                    </div>
+                  )}
+                </>
+              ) : (
+                <p className="text-muted-foreground text-sm">
+                  No local network address was found, so the album cannot be
+                  reached from another device. Connect to a network and share
+                  again.
+                </p>
+              )}
+
+              <div className="bg-muted grid gap-1 rounded-md p-3 text-sm">
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Photos</span>
+                  <span className="font-medium">{activeShare.image_count}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Expires</span>
+                  <span className="font-medium">
+                    {formatExpiry(activeShare.expires_at)}
+                  </span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Password</span>
+                  <span className="font-medium">
+                    {activeShare.is_protected ? 'Required' : 'None'}
+                  </span>
+                </div>
+              </div>
+            </div>
+
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                className="text-destructive"
+                onClick={() => revokeShareMutation.mutate(activeShare.token)}
+                disabled={revokeShareMutation.isPending}
+              >
+                Stop sharing
+              </Button>
+              <Button type="button" onClick={onClose}>
+                Done
+              </Button>
+            </DialogFooter>
+          </>
+        ) : (
+          <form onSubmit={handleCreate}>
+            <DialogHeader>
+              <DialogTitle>Share "{album?.name}"</DialogTitle>
+              <DialogDescription>
+                Serve this album to other devices on your network. The photos
+                stay on this machine.
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="grid gap-4 py-4">
+              <div className="grid gap-2">
+                <Label>Keep sharing</Label>
+                <RadioGroup value={expiry} onValueChange={setExpiry}>
+                  {EXPIRY_OPTIONS.map((option) => (
+                    <div key={option.value} className="flex items-center gap-2">
+                      <RadioGroupItem
+                        value={option.value}
+                        id={`expiry-${option.value}`}
+                      />
+                      <Label
+                        htmlFor={`expiry-${option.value}`}
+                        className="font-normal"
+                      >
+                        {option.label}
+                      </Label>
+                    </div>
+                  ))}
+                </RadioGroup>
+                <p className="text-muted-foreground text-xs">
+                  Sharing always stops when PictoPy closes.
+                </p>
+              </div>
+
+              <div className="flex items-center justify-between">
+                <div className="space-y-0.5">
+                  <Label htmlFor="share-password-toggle">
+                    Require a password
+                  </Label>
+                  <p className="text-muted-foreground text-sm">
+                    Asked for before any photo loads
+                  </p>
+                </div>
+                <Switch
+                  id="share-password-toggle"
+                  checked={withPassword}
+                  onCheckedChange={(checked) => {
+                    setWithPassword(checked);
+                    setError('');
+                  }}
+                />
+              </div>
+
+              {withPassword && (
+                <div className="grid gap-2">
+                  <Label htmlFor="share-password">Password</Label>
+                  <Input
+                    id="share-password"
+                    type="password"
+                    placeholder="Enter a password"
+                    value={password}
+                    onChange={(event) => {
+                      setPassword(event.target.value);
+                      setError('');
+                    }}
+                    className={error ? 'border-destructive' : ''}
+                  />
+                  {error && <p className="text-destructive text-sm">{error}</p>}
+                </div>
+              )}
+            </div>
+
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={onClose}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={createShareMutation.isPending}>
+                <Share2 className="mr-2 h-4 w-4" />
+                Start sharing
+              </Button>
+            </DialogFooter>
+          </form>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/frontend/src/components/Albums/ShareAlbumDialog.tsx
+++ b/frontend/src/components/Albums/ShareAlbumDialog.tsx
@@ -15,7 +15,7 @@ import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { Separator } from '@/components/ui/separator';
-import { usePictoMutation } from '@/hooks/useQueryExtension';
+import { usePictoMutation, type BackendRes } from '@/hooks/useQueryExtension';
 import { createShare, revokeShare } from '@/api/api-functions';
 import { useMutationFeedback } from '@/hooks/useMutationFeedback';
 import { cn } from '@/lib/utils';
@@ -36,7 +36,7 @@ const formatExpiry = (expiresAt: string | null): string =>
 
 export const ShareAlbumDialog: React.FC<ShareAlbumDialogProps> = ({
   album,
-  share,
+  shares,
   isOpen,
   onClose,
   onChanged,
@@ -49,10 +49,20 @@ export const ShareAlbumDialog: React.FC<ShareAlbumDialogProps> = ({
   const [selectedUrl, setSelectedUrl] = useState('');
   const [copied, setCopied] = useState(false);
 
-  // The share this dialog is showing: the one just made, or one already running.
-  const activeShare = createdShare ?? share;
+  // The share this dialog is showing: the one just made, or the newest already
+  // running. Older ones stay out of the way until sharing is stopped.
+  const activeShare = createdShare ?? shares[0] ?? null;
   const urls = activeShare?.urls ?? [];
   const shareUrl = urls.find((entry) => entry.url === selectedUrl) ?? urls[0];
+
+  // Every token that would still serve this album. Creating leaves earlier
+  // shares valid, so stopping has to take them all down together.
+  const activeTokens = Array.from(
+    new Set([
+      ...(createdShare ? [createdShare.token] : []),
+      ...shares.map((entry) => entry.token),
+    ]),
+  );
 
   const createShareMutation = usePictoMutation({
     mutationFn: (variables: { albumId: string; password?: string }) =>
@@ -72,9 +82,13 @@ export const ShareAlbumDialog: React.FC<ShareAlbumDialogProps> = ({
   });
 
   const revokeShareMutation = usePictoMutation({
-    // Wrapped rather than passed directly: react-query hands the mutation
-    // function a context object as a second argument.
-    mutationFn: (token: string) => revokeShare(token),
+    // Takes every token rather than one, so "stop sharing" leaves nothing
+    // serving the album. Wrapped rather than passed straight through because
+    // react-query hands the mutation function a context as a second argument.
+    mutationFn: async (tokens: string[]): Promise<BackendRes<null>> => {
+      await Promise.all(tokens.map((token) => revokeShare(token)));
+      return { success: true };
+    },
     autoInvalidateTags: ['shares'],
   });
 
@@ -275,9 +289,7 @@ export const ShareAlbumDialog: React.FC<ShareAlbumDialogProps> = ({
                     type="button"
                     variant="outline"
                     className="text-destructive flex-1"
-                    onClick={() =>
-                      revokeShareMutation.mutate(activeShare.token)
-                    }
+                    onClick={() => revokeShareMutation.mutate(activeTokens)}
                     disabled={revokeShareMutation.isPending}
                   >
                     Stop sharing

--- a/frontend/src/components/Albums/ShareAlbumDialog.tsx
+++ b/frontend/src/components/Albums/ShareAlbumDialog.tsx
@@ -14,6 +14,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import { Separator } from '@/components/ui/separator';
 import { usePictoMutation } from '@/hooks/useQueryExtension';
 import { createShare, revokeShare } from '@/api/api-functions';
 import { useMutationFeedback } from '@/hooks/useMutationFeedback';
@@ -159,7 +160,14 @@ export const ShareAlbumDialog: React.FC<ShareAlbumDialogProps> = ({
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="sm:max-w-[480px]">
+      <DialogContent
+        className={cn(
+          // Nothing caps a dialog's height by default, so a tall one runs off
+          // the screen with its buttons out of reach.
+          'max-h-[90vh] overflow-y-auto',
+          activeShare ? 'sm:max-w-3xl' : 'sm:max-w-[480px]',
+        )}
+      >
         {activeShare ? (
           <>
             <DialogHeader>
@@ -170,100 +178,116 @@ export const ShareAlbumDialog: React.FC<ShareAlbumDialogProps> = ({
               </DialogDescription>
             </DialogHeader>
 
-            <div className="grid gap-4 py-4">
-              {shareUrl ? (
-                <>
-                  <div className="flex justify-center">
-                    {/* Always on white: a QR code needs the light quiet zone to
-                        stay scannable in dark mode. */}
-                    <div className="rounded-xl bg-white p-3 shadow-sm">
-                      <QRCodeSVG value={shareUrl.url} size={168} />
-                    </div>
-                  </div>
-
-                  <div className="grid gap-2">
-                    <Label htmlFor="share-link">Link</Label>
-                    <div className="flex gap-2">
-                      <Input
-                        id="share-link"
-                        readOnly
-                        value={shareUrl.url}
-                        className="font-mono text-xs"
-                      />
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="icon"
-                        onClick={handleCopy}
-                        aria-label="Copy link"
-                      >
-                        {copied ? (
-                          <Check className="h-4 w-4" />
-                        ) : (
-                          <Copy className="h-4 w-4" />
-                        )}
-                      </Button>
-                    </div>
-                  </div>
-
-                  {urls.length > 1 && (
-                    <div className="grid gap-2">
-                      <Label className="flex items-center gap-2">
-                        <Wifi className="text-primary h-4 w-4" />
-                        Address
-                      </Label>
-                      <p className="text-muted-foreground text-xs">
-                        This machine has more than one. If the first does not
-                        work, try another.
-                      </p>
-                      <div className="grid gap-1.5">
-                        {urls.map(renderAddress)}
+            {/* Two columns rather than one card taller than the window: what
+                you hand to someone on the left, what you manage on the right. */}
+            <div className="grid gap-6 py-2 md:grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)]">
+              <div className="flex flex-col gap-4">
+                {shareUrl ? (
+                  <>
+                    <div className="flex justify-center">
+                      {/* Always on white: a QR code needs the light quiet zone
+                          to stay scannable in dark mode. */}
+                      <div className="rounded-xl bg-white p-3 shadow-sm">
+                        <QRCodeSVG value={shareUrl.url} size={168} />
                       </div>
                     </div>
-                  )}
-                </>
-              ) : (
-                <p className="text-muted-foreground text-sm">
-                  No local network address was found, so the album cannot be
-                  reached from another device. Connect to a network and share
-                  again.
-                </p>
-              )}
 
-              <div className="bg-muted grid gap-1 rounded-md p-3 text-sm">
-                <div className="flex justify-between">
-                  <span className="text-muted-foreground">Photos</span>
-                  <span className="font-medium">{activeShare.image_count}</span>
+                    <div className="grid gap-2">
+                      <Label htmlFor="share-link">Link</Label>
+                      <div className="flex gap-2">
+                        <Input
+                          id="share-link"
+                          readOnly
+                          value={shareUrl.url}
+                          className="font-mono text-xs"
+                        />
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="icon"
+                          onClick={handleCopy}
+                          aria-label="Copy link"
+                        >
+                          {copied ? (
+                            <Check className="h-4 w-4" />
+                          ) : (
+                            <Copy className="h-4 w-4" />
+                          )}
+                        </Button>
+                      </div>
+                    </div>
+                  </>
+                ) : (
+                  <p className="text-muted-foreground text-sm">
+                    No local network address was found, so the album cannot be
+                    reached from another device. Connect to a network and share
+                    again.
+                  </p>
+                )}
+                <div className="bg-muted grid gap-1 rounded-md p-3 text-sm">
+                  <div className="flex justify-between">
+                    <span className="text-muted-foreground">Photos</span>
+                    <span className="font-medium">
+                      {activeShare.image_count}
+                    </span>
+                  </div>
+                  <div className="flex justify-between">
+                    <span className="text-muted-foreground">Expires</span>
+                    <span className="font-medium">
+                      {formatExpiry(activeShare.expires_at)}
+                    </span>
+                  </div>
+                  <div className="flex justify-between">
+                    <span className="text-muted-foreground">Password</span>
+                    <span className="font-medium">
+                      {activeShare.is_protected ? 'Required' : 'None'}
+                    </span>
+                  </div>
                 </div>
-                <div className="flex justify-between">
-                  <span className="text-muted-foreground">Expires</span>
-                  <span className="font-medium">
-                    {formatExpiry(activeShare.expires_at)}
-                  </span>
-                </div>
-                <div className="flex justify-between">
-                  <span className="text-muted-foreground">Password</span>
-                  <span className="font-medium">
-                    {activeShare.is_protected ? 'Required' : 'None'}
-                  </span>
+              </div>
+
+              <Separator orientation="vertical" className="hidden md:block" />
+
+              <div className="flex min-w-0 flex-col gap-4">
+                {urls.length > 1 && (
+                  <div className="grid gap-2">
+                    <Label className="flex items-center gap-2">
+                      <Wifi className="text-primary h-4 w-4" />
+                      Address
+                    </Label>
+                    <p className="text-muted-foreground text-xs">
+                      This machine has more than one. If the first does not
+                      work, try another.
+                    </p>
+                    {/* Scrolls on its own: a machine with a stack of virtual
+                        adapters can list a lot of these. Capped rather than
+                        fixed so two addresses do not sit in an empty box. */}
+                    <div className="grid max-h-62 gap-1.5 overflow-y-auto pr-1">
+                      {urls.map(renderAddress)}
+                    </div>
+                  </div>
+                )}
+
+                {/* Pushed down so the buttons line up with the bottom of the
+                    QR column instead of floating mid-panel. */}
+                <div className="mt-auto flex gap-2 pt-2">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    className="text-destructive flex-1"
+                    onClick={() =>
+                      revokeShareMutation.mutate(activeShare.token)
+                    }
+                    disabled={revokeShareMutation.isPending}
+                  >
+                    Stop sharing
+                  </Button>
+                  <Button type="button" className="flex-1" onClick={onClose}>
+                    Done
+                  </Button>
                 </div>
               </div>
             </div>
-
-            <DialogFooter>
-              <Button
-                type="button"
-                variant="outline"
-                className="text-destructive"
-                onClick={() => revokeShareMutation.mutate(activeShare.token)}
-                disabled={revokeShareMutation.isPending}
-              >
-                Stop sharing
-              </Button>
-              <Button type="button" onClick={onClose}>
-                Done
-              </Button>
-            </DialogFooter>
           </>
         ) : (
           <form onSubmit={handleCreate}>

--- a/frontend/src/components/Albums/__tests__/ShareAlbumDialog.test.tsx
+++ b/frontend/src/components/Albums/__tests__/ShareAlbumDialog.test.tsx
@@ -1,0 +1,159 @@
+import userEvent from '@testing-library/user-event';
+import { render, screen, waitFor } from '@/test-utils';
+import { createShare, revokeShare } from '@/api/api-functions';
+import { Album } from '@/types/Album';
+import { Share } from '@/types/Share';
+import { ShareAlbumDialog } from '../ShareAlbumDialog';
+
+jest.mock('@/api/api-functions', () => ({
+  createShare: jest.fn(),
+  revokeShare: jest.fn(),
+}));
+
+const mockCreateShare = createShare as jest.Mock;
+const mockRevokeShare = revokeShare as jest.Mock;
+
+const album: Album = {
+  id: 'a1',
+  name: 'Trip to Goa',
+  description: '',
+  is_locked: false,
+  image_count: 2,
+  created_at: null,
+  updated_at: null,
+};
+
+const share: Share = {
+  token: 'tok-1',
+  album_id: 'a1',
+  album_name: 'Trip to Goa',
+  image_count: 2,
+  port: 52125,
+  created_at: '2026-08-07T10:00:00+00:00',
+  expires_at: null,
+  is_protected: false,
+  urls: [
+    {
+      interface: 'Wi-Fi',
+      ip: '192.168.1.5',
+      url: 'http://192.168.1.5:52125/s/tok-1',
+    },
+    {
+      interface: 'Ethernet',
+      ip: '10.0.0.4',
+      url: 'http://10.0.0.4:52125/s/tok-1',
+    },
+  ],
+};
+
+const renderDialog = (existing: Share | null = null, onChanged = jest.fn()) =>
+  render(
+    <ShareAlbumDialog
+      album={album}
+      share={existing}
+      isOpen={true}
+      onClose={jest.fn()}
+      onChanged={onChanged}
+    />,
+  );
+
+describe('ShareAlbumDialog', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCreateShare.mockResolvedValue({ success: true, data: share });
+    mockRevokeShare.mockResolvedValue({ success: true });
+  });
+
+  it('shares without a password by default', async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.click(screen.getByRole('button', { name: /start sharing/i }));
+
+    await waitFor(() => expect(mockCreateShare).toHaveBeenCalled());
+    expect(mockCreateShare).toHaveBeenCalledWith('a1', {
+      expires_in_minutes: 1440,
+    });
+  });
+
+  it('sends the password when one is asked for', async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.click(
+      screen.getByRole('switch', { name: /require a password/i }),
+    );
+    await user.type(screen.getByLabelText('Password'), 'beach-house');
+    await user.click(screen.getByRole('button', { name: /start sharing/i }));
+
+    await waitFor(() => expect(mockCreateShare).toHaveBeenCalled());
+    expect(mockCreateShare).toHaveBeenCalledWith('a1', {
+      expires_in_minutes: 1440,
+      password: 'beach-house',
+    });
+  });
+
+  it('refuses a password the backend would reject', async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.click(
+      screen.getByRole('switch', { name: /require a password/i }),
+    );
+    await user.type(screen.getByLabelText('Password'), 'ab');
+    await user.click(screen.getByRole('button', { name: /start sharing/i }));
+
+    expect(
+      await screen.findByText(/at least 4 characters/i),
+    ).toBeInTheDocument();
+    expect(mockCreateShare).not.toHaveBeenCalled();
+  });
+
+  it('drops the expiry when the share should last until stopped', async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.click(screen.getByRole('radio', { name: /until i stop it/i }));
+    await user.click(screen.getByRole('button', { name: /start sharing/i }));
+
+    await waitFor(() => expect(mockCreateShare).toHaveBeenCalledWith('a1', {}));
+  });
+
+  it('shows the link once the share exists', async () => {
+    renderDialog(share);
+
+    expect(screen.getByLabelText('Link')).toHaveValue(
+      'http://192.168.1.5:52125/s/tok-1',
+    );
+  });
+
+  it('switches the link to another address', async () => {
+    const user = userEvent.setup();
+    renderDialog(share);
+
+    await user.click(screen.getByRole('button', { name: /ethernet/i }));
+
+    expect(screen.getByLabelText('Link')).toHaveValue(
+      'http://10.0.0.4:52125/s/tok-1',
+    );
+  });
+
+  it('says so when the machine has no network address', () => {
+    renderDialog({ ...share, urls: [] });
+
+    expect(
+      screen.getByText(/no local network address was found/i),
+    ).toBeInTheDocument();
+  });
+
+  it('revokes the share and tells the parent', async () => {
+    const user = userEvent.setup();
+    const onChanged = jest.fn();
+    renderDialog(share, onChanged);
+
+    await user.click(screen.getByRole('button', { name: /stop sharing/i }));
+
+    await waitFor(() => expect(mockRevokeShare).toHaveBeenCalledWith('tok-1'));
+    await waitFor(() => expect(onChanged).toHaveBeenCalled());
+  });
+});

--- a/frontend/src/components/Albums/__tests__/ShareAlbumDialog.test.tsx
+++ b/frontend/src/components/Albums/__tests__/ShareAlbumDialog.test.tsx
@@ -46,11 +46,11 @@ const share: Share = {
   ],
 };
 
-const renderDialog = (existing: Share | null = null, onChanged = jest.fn()) =>
+const renderDialog = (existing: Share[] = [], onChanged = jest.fn()) =>
   render(
     <ShareAlbumDialog
       album={album}
-      share={existing}
+      shares={existing}
       isOpen={true}
       onClose={jest.fn()}
       onChanged={onChanged}
@@ -120,7 +120,7 @@ describe('ShareAlbumDialog', () => {
   });
 
   it('shows the link once the share exists', async () => {
-    renderDialog(share);
+    renderDialog([share]);
 
     expect(screen.getByLabelText('Link')).toHaveValue(
       'http://192.168.1.5:52125/s/tok-1',
@@ -129,7 +129,7 @@ describe('ShareAlbumDialog', () => {
 
   it('switches the link to another address', async () => {
     const user = userEvent.setup();
-    renderDialog(share);
+    renderDialog([share]);
 
     await user.click(screen.getByRole('button', { name: /ethernet/i }));
 
@@ -139,7 +139,7 @@ describe('ShareAlbumDialog', () => {
   });
 
   it('says so when the machine has no network address', () => {
-    renderDialog({ ...share, urls: [] });
+    renderDialog([{ ...share, urls: [] }]);
 
     expect(
       screen.getByText(/no local network address was found/i),
@@ -149,11 +149,56 @@ describe('ShareAlbumDialog', () => {
   it('revokes the share and tells the parent', async () => {
     const user = userEvent.setup();
     const onChanged = jest.fn();
-    renderDialog(share, onChanged);
+    renderDialog([share], onChanged);
 
     await user.click(screen.getByRole('button', { name: /stop sharing/i }));
 
     await waitFor(() => expect(mockRevokeShare).toHaveBeenCalledWith('tok-1'));
     await waitFor(() => expect(onChanged).toHaveBeenCalled());
+  });
+
+  // Creating a share leaves earlier ones valid, so stopping has to take down
+  // every token or the album stays reachable after the UI says it stopped.
+  it('stops every share the album has, not just the newest', async () => {
+    const user = userEvent.setup();
+    const older: Share = { ...share, token: 'tok-0' };
+    renderDialog([share, older]);
+
+    await user.click(screen.getByRole('button', { name: /stop sharing/i }));
+
+    await waitFor(() => expect(mockRevokeShare).toHaveBeenCalledTimes(2));
+    expect(mockRevokeShare).toHaveBeenCalledWith('tok-1');
+    expect(mockRevokeShare).toHaveBeenCalledWith('tok-0');
+  });
+
+  it('stops the share it just created along with any earlier one', async () => {
+    const user = userEvent.setup();
+    const older: Share = { ...share, token: 'tok-0' };
+    mockCreateShare.mockResolvedValue({
+      success: true,
+      data: { ...share, token: 'tok-new' },
+    });
+    const { rerender } = renderDialog([]);
+
+    await user.click(screen.getByRole('button', { name: /start sharing/i }));
+    await screen.findByLabelText('Link');
+
+    // What the parent does after the refetch: it hands down the shares the
+    // backend knows about, which need not yet include the one just made.
+    rerender(
+      <ShareAlbumDialog
+        album={album}
+        shares={[older]}
+        isOpen={true}
+        onClose={jest.fn()}
+        onChanged={jest.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /stop sharing/i }));
+
+    await waitFor(() => expect(mockRevokeShare).toHaveBeenCalledTimes(2));
+    expect(mockRevokeShare).toHaveBeenCalledWith('tok-new');
+    expect(mockRevokeShare).toHaveBeenCalledWith('tok-0');
   });
 });

--- a/frontend/src/pages/Album/Album.tsx
+++ b/frontend/src/pages/Album/Album.tsx
@@ -15,9 +15,14 @@ import { CreateAlbumDialog } from '@/components/Albums/CreateAlbumDialog';
 import { EditAlbumDialog } from '@/components/Albums/EditAlbumDialog';
 import { AlbumPasswordDialog } from '@/components/Albums/AlbumPasswordDialog';
 import { DeleteConfirmDialog } from '@/components/Albums/DeleteConfirmDialog';
+import { ShareAlbumDialog } from '@/components/Albums/ShareAlbumDialog';
 import { EmptyAlbumsState } from '@/components/EmptyStates/EmptyAlbumsState';
-import { usePictoQuery, usePictoMutation } from '@/hooks/useQueryExtension';
-import { getAllAlbums, deleteAlbum } from '@/api/api-functions';
+import {
+  usePictoQuery,
+  usePictoMutation,
+  type BackendRes,
+} from '@/hooks/useQueryExtension';
+import { getAllAlbums, deleteAlbum, getShares } from '@/api/api-functions';
 import { setAlbums } from '@/features/albumsSlice';
 import { selectAlbums } from '@/features/albumSelectors';
 import { showInfoDialog } from '@/features/infoDialogSlice';
@@ -26,6 +31,7 @@ import { usePersistedSort } from '@/hooks/usePersistedSort';
 import { MEDIA_GRID_CLASS } from '@/constants/layout';
 import { cn } from '@/lib/utils';
 import { Album } from '@/types/Album';
+import { Share } from '@/types/Share';
 import {
   GallerySortDropdown,
   type SortOption,
@@ -76,6 +82,8 @@ function Albums() {
   const [isPasswordDialogOpen, setIsPasswordDialogOpen] = useState(false);
   const [albumToDelete, setAlbumToDelete] = useState<Album | null>(null);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [albumToShare, setAlbumToShare] = useState<Album | null>(null);
+  const [isShareDialogOpen, setIsShareDialogOpen] = useState(false);
   const [sortBy, setSortBy] = usePersistedSort<AlbumSortValue>(
     ALBUM_SORT_STORAGE_KEY,
     'name',
@@ -93,6 +101,26 @@ function Albums() {
   } = usePictoQuery({
     queryKey: ['albums'],
     queryFn: () => getAllAlbums(),
+  });
+
+  // Shares live in memory in the backend, so this query is the only record of
+  // which albums are currently being served.
+  const { successData: shares, refetch: refetchShares } = usePictoQuery<
+    BackendRes<Share[]>,
+    unknown,
+    Share[]
+  >({
+    queryKey: ['shares'],
+    queryFn: () => getShares(),
+  });
+
+  const sharesByAlbum = new Map<string, Share>();
+  // An album can be shared more than once; the backend lists newest first, so
+  // the first one seen is the share to show.
+  (shares ?? []).forEach((share) => {
+    if (!sharesByAlbum.has(share.album_id)) {
+      sharesByAlbum.set(share.album_id, share);
+    }
   });
 
   const deleteAlbumMutation = usePictoMutation({
@@ -152,6 +180,11 @@ function Albums() {
   const handleEditAlbum = (album: Album) => {
     setSelectedAlbum(album);
     setIsEditDialogOpen(true);
+  };
+
+  const handleShareAlbum = (album: Album) => {
+    setAlbumToShare(album);
+    setIsShareDialogOpen(true);
   };
 
   const handleDeleteAlbum = (album: Album) => {
@@ -241,6 +274,8 @@ function Albums() {
                 onClick={() => handleAlbumClick(album)}
                 onEdit={() => handleEditAlbum(album)}
                 onDelete={() => handleDeleteAlbum(album)}
+                onShare={() => handleShareAlbum(album)}
+                isSharing={sharesByAlbum.has(album.id)}
               />
             ))}
           </div>
@@ -269,6 +304,18 @@ function Albums() {
         }}
         onSubmit={handlePasswordSubmit}
         albumName={albumToAccess?.name || ''}
+      />
+      <ShareAlbumDialog
+        album={albumToShare}
+        share={
+          albumToShare ? (sharesByAlbum.get(albumToShare.id) ?? null) : null
+        }
+        isOpen={isShareDialogOpen}
+        onClose={() => {
+          setIsShareDialogOpen(false);
+          setAlbumToShare(null);
+        }}
+        onChanged={refetchShares}
       />
       <DeleteConfirmDialog
         isOpen={isDeleteDialogOpen}

--- a/frontend/src/pages/Album/Album.tsx
+++ b/frontend/src/pages/Album/Album.tsx
@@ -114,12 +114,15 @@ function Albums() {
     queryFn: () => getShares(),
   });
 
-  const sharesByAlbum = new Map<string, Share>();
-  // An album can be shared more than once; the backend lists newest first, so
-  // the first one seen is the share to show.
+  // Every share an album has, not just its newest: an album can be shared more
+  // than once, and each token serves it until it is revoked.
+  const sharesByAlbum = new Map<string, Share[]>();
   (shares ?? []).forEach((share) => {
-    if (!sharesByAlbum.has(share.album_id)) {
-      sharesByAlbum.set(share.album_id, share);
+    const existing = sharesByAlbum.get(share.album_id);
+    if (existing) {
+      existing.push(share);
+    } else {
+      sharesByAlbum.set(share.album_id, [share]);
     }
   });
 
@@ -307,9 +310,7 @@ function Albums() {
       />
       <ShareAlbumDialog
         album={albumToShare}
-        share={
-          albumToShare ? (sharesByAlbum.get(albumToShare.id) ?? null) : null
-        }
+        shares={albumToShare ? (sharesByAlbum.get(albumToShare.id) ?? []) : []}
         isOpen={isShareDialogOpen}
         onClose={() => {
           setIsShareDialogOpen(false);

--- a/frontend/src/pages/__tests__/Album.test.tsx
+++ b/frontend/src/pages/__tests__/Album.test.tsx
@@ -6,7 +6,7 @@ import { GlobalLoader } from '@/components/Loader/GlobalLoader';
 import { InfoDialog } from '@/components/Dialog/InfoDialog';
 import Albums from '../Album/Album';
 
-import { getAllAlbums, deleteAlbum } from '@/api/api-functions';
+import { getAllAlbums, deleteAlbum, getShares } from '@/api/api-functions';
 
 jest.mock('@/api/api-functions', () => ({
   getAllAlbums: jest.fn(),
@@ -15,10 +15,14 @@ jest.mock('@/api/api-functions', () => ({
   updateAlbum: jest.fn(),
   getAlbumImages: jest.fn(),
   addImagesToAlbum: jest.fn(),
+  getShares: jest.fn(),
+  createShare: jest.fn(),
+  revokeShare: jest.fn(),
 }));
 
 const mockGetAllAlbums = getAllAlbums as jest.Mock;
 const mockDeleteAlbum = deleteAlbum as jest.Mock;
+const mockGetShares = getShares as jest.Mock;
 
 // Mirrors App.tsx, which renders the page beneath the global loader and dialog.
 const AlbumsWithGlobalOverlays = () => {
@@ -73,6 +77,7 @@ describe('Albums page', () => {
       serverAlbums = serverAlbums.filter((a) => a.album_id !== albumId);
       return { success: true, msg: 'deleted' };
     });
+    mockGetShares.mockResolvedValue({ success: true, data: [] });
   });
 
   const openDeleteConfirmation = async (

--- a/frontend/src/types/Album.ts
+++ b/frontend/src/types/Album.ts
@@ -87,4 +87,7 @@ export interface AlbumCardProps {
   onClick: () => void;
   onEdit: () => void;
   onDelete: () => void;
+  onShare: () => void;
+  /** Whether this album is currently being served on the local network. */
+  isSharing: boolean;
 }

--- a/frontend/src/types/Share.ts
+++ b/frontend/src/types/Share.ts
@@ -28,8 +28,11 @@ export interface CreateShareRequest {
 
 export interface ShareAlbumDialogProps {
   album: Album | null;
-  /** The album's existing share, if it is already being shared. */
-  share: Share | null;
+  /**
+   * Every live share for this album, newest first. An album can be shared more
+   * than once, and stopping has to account for all of them.
+   */
+  shares: Share[];
   isOpen: boolean;
   onClose: () => void;
   /** Called after a share is created or revoked, so the list can refetch. */

--- a/frontend/src/types/Share.ts
+++ b/frontend/src/types/Share.ts
@@ -1,0 +1,37 @@
+import { Album } from './Album';
+
+/** One address a share can be reached on. The backend lists these best first. */
+export interface ShareUrl {
+  interface: string;
+  ip: string;
+  url: string;
+}
+
+/** Mirrors the `Share` model in backend/app/schemas/share.py. */
+export interface Share {
+  token: string;
+  album_id: string;
+  album_name: string;
+  image_count: number;
+  port: number;
+  created_at: string;
+  expires_at: string | null;
+  is_protected: boolean;
+  urls: ShareUrl[];
+}
+
+export interface CreateShareRequest {
+  /** Omitted means the share lasts until it is revoked or PictoPy closes. */
+  expires_in_minutes?: number;
+  password?: string;
+}
+
+export interface ShareAlbumDialogProps {
+  album: Album | null;
+  /** The album's existing share, if it is already being shared. */
+  share: Share | null;
+  isOpen: boolean;
+  onClose: () => void;
+  /** Called after a share is created or revoked, so the list can refetch. */
+  onChanged: () => void;
+}


### PR DESCRIPTION
Part of #1468

Adds the desktop side of album sharing, following the backend in #1469 and the password in #1471. An album can now be shared from its card, and the dialog hands back a QR code and a link to open on another device.

Sharing is offered from the album card's menu, and a shared album is ringed and badged in the grid so what is currently reachable on the network is visible without opening anything. The dialog asks for how long to keep sharing and whether to require a password, then shows the QR code, the link, and the addresses the share can be reached on. Reopening a shared album goes straight to that view, where the share can also be stopped.

Machines with more than one usable address get a picker, and the QR code follows the selection. Which address a phone can actually reach depends on the network rather than on anything the host can detect, so the choice belongs to the person sharing. The backend already ranks the candidates, so the first one is selected by default.

Active shares are read through react-query rather than a Redux slice. They exist only in the backend's memory, so the query is the record of them; a slice would have been a second source of truth for the same data. Redux stays where the rest of the codebase puts it, on UI state.

## Not included

The backend counts no views and no downloads, and has no downloads toggle, so none of that is shown. A separate management dashboard is also left out for now: minus those figures it would be a list of shares with copy, QR and stop, which is what this dialog already does per album.

## Dependency

One addition, `qrcode.react`, to render the link as a scannable code. Generating it on the desktop side keeps the backend free of another dependency.

## Testing

Eight new tests covering creating a share with and without a password, rejecting a password the backend would refuse, switching addresses, and revoking, with the full suite at 359 passing. The album page's own tests needed the new query mocked.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added local-network album sharing with optional expiration and password protection.
  - Display shareable links and QR codes, with options to copy links, switch network addresses, and revoke access.
  - Album cards now show active sharing status and provide Share or Manage Share actions.
  - Added validation and feedback for invalid settings or unavailable network addresses.

- **Tests**
  - Added coverage for creating, managing, switching, and revoking album shares.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->