### PR TITLE
feat: share an album beyond the local network

### DIFF
--- a/docs/backend/backend_python/album-sharing.md
+++ b/docs/backend/backend_python/album-sharing.md
@@ -81,12 +81,12 @@ The response carries the token and one candidate URL per network interface:
   "success": true,
   "message": "Album is now shared on the local network",
   "data": {
-    "token": "DTlmfuroeSGItsAAFhd4zOPhjmuBmqQlhBrODb95_3s",
+    "token": "<share_token>",
     "album_name": "The Oddyseys",
     "image_count": 18,
     "port": 52125,
     "urls": [
-      { "interface": "Wi-Fi", "ip": "10.170.93.60", "url": "http://10.170.93.60:52125/s/DTlmf..." }
+      { "interface": "Wi-Fi", "ip": "10.170.93.60", "url": "http://10.170.93.60:52125/s/<share_token>" }
     ]
   }
 }

--- a/docs/backend/backend_python/album-sharing.md
+++ b/docs/backend/backend_python/album-sharing.md
@@ -1,0 +1,150 @@
+# Album Sharing over the Local Network
+
+PictoPy can serve a single album over the local network so that someone on the same Wi-Fi can browse it in a normal browser. Nothing is uploaded anywhere — the photos are streamed straight from the host machine, and the share disappears when PictoPy closes.
+
+This page is for developers: running the backend yourself, driving the share API by hand, and understanding how the pieces fit. If you are looking for what sharing means for your photos and your privacy, read [Sharing Albums](../../overview/sharing-albums.md) instead.
+
+Sharing an album from the desktop app is a menu item on the album card; everything below describes the machinery underneath it.
+
+## Running the backend
+
+Set up the environment once by following the [Manual Setup Guide](../../Manual_Setup_Guide.md) — create the environment, activate it, and `pip install -r requirements.txt` inside `backend/`.
+
+After that there are two ways to start the server, both from the `backend/` directory:
+
+```bash
+python main.py
+```
+
+This is the plain entry point. It binds `localhost:52123` and is exactly what the packaged desktop app runs, so it is the closest match to production behaviour.
+
+```bash
+fastapi dev --port 52123
+```
+
+This adds auto-reload, which is nicer while editing. Both work with album sharing.
+
+Check it came up:
+
+```bash
+curl http://localhost:52123/health
+```
+
+### If `fastapi dev` crashes on Windows
+
+You may see `UnicodeEncodeError: 'charmap' codec can't encode character '\U0001f40d'`. The FastAPI CLI prints an emoji in its banner and the default Windows console codepage cannot encode it. This is unrelated to PictoPy. Either use `python main.py`, or set the encoding first:
+
+```bash
+set PYTHONIOENCODING=utf-8
+```
+
+## How sharing is wired
+
+Three listeners, and only one of them is reachable from the network:
+
+| Process | Address | Reachable from |
+| --- | --- | --- |
+| Main backend | `localhost:52123` | this machine only |
+| Sync microservice | `localhost:52124` | this machine only |
+| Share server | `0.0.0.0:52125` | any device that can route here |
+
+The share server is a **second FastAPI app running inside the backend process**. It starts on demand when the first share is created and stops when the last one is revoked, so no port is left open while nothing is shared. If `52125` is busy it tries the next few ports.
+
+The main backend is never bound beyond localhost, because it exposes shutdown, delete and metadata routes that must not be reachable by other devices. The share server only ever exposes `/s/{token}` and the two media routes beneath it.
+
+Active shares live **in memory only**. There is no table and no file: quitting PictoPy ends every share, and no token is ever written to disk.
+
+## Sharing an album by hand
+
+### Find an album id
+
+```bash
+curl http://localhost:52123/albums/
+```
+
+### Start a share
+
+```bash
+curl -X POST http://localhost:52123/share/albums/<album_id> -H "Content-Type: application/json" -d "{}"
+```
+
+Add an expiry in minutes if you want one:
+
+```bash
+curl -X POST http://localhost:52123/share/albums/<album_id> -H "Content-Type: application/json" -d "{\"expires_in_minutes\": 120}"
+```
+
+The response carries the token and one candidate URL per network interface:
+
+```json
+{
+  "success": true,
+  "message": "Album is now shared on the local network",
+  "data": {
+    "token": "DTlmfuroeSGItsAAFhd4zOPhjmuBmqQlhBrODb95_3s",
+    "album_name": "The Oddyseys",
+    "image_count": 18,
+    "port": 52125,
+    "urls": [
+      { "interface": "Wi-Fi", "ip": "10.170.93.60", "url": "http://10.170.93.60:52125/s/DTlmf..." }
+    ]
+  }
+}
+```
+
+### Pick the right URL
+
+The list is ranked best-guess first — the interface holding the default route wins, virtual adapters such as VMware and WSL sort last, and disconnected interfaces sort below live ones. A machine with virtual adapters can easily surface four candidates, so **the first entry is a ranked guess, not a guarantee**. If the phone cannot load one, try the next.
+
+You can inspect the ranking without creating a share:
+
+```bash
+curl http://localhost:52123/share/interfaces
+```
+
+### Open it
+
+Put the chosen URL into the phone's browser, on the same Wi-Fi. The page needs no app and no account.
+
+### List and revoke
+
+```bash
+curl http://localhost:52123/share/
+```
+
+```bash
+curl -X DELETE http://localhost:52123/share/<token>
+```
+
+Revoking the last share stops the network listener entirely.
+
+## When the phone cannot connect
+
+Work through these in order.
+
+**Check the firewall profile, not just the rule.** Windows commonly creates *Private*-only rules, and most Wi-Fi networks are classified *Public*. A Private-only rule on a Public network fails silently. Rules are per-binary rather than per-port, so a rule covering the
+Python interpreter or `PictoPy_Server` covers whatever port sharing lands on.
+
+```powershell
+Get-NetConnectionProfile | Select-Object Name, NetworkCategory
+```
+
+**Confirm both devices are on the same network.** A laptop on wired Ethernet and a phone on Wi-Fi are often on different subnets. Some networks route between them and some deliberately do not.
+
+**Suspect the network itself.** Many networks block device-to-device traffic — this is called AP or client isolation, and it is close to universal on guest Wi-Fi and common on corporate networks. If it is enabled, nothing on the PictoPy side can work around it.
+
+To tell an isolated network apart from a broken setup, use a phone hotspot: connect the laptop to the phone's hotspot and share again. If it works there, the code is fine and the other network is blocking peer traffic. USB tethering does the same job and is more reliable still.
+
+## Internet mode
+
+Everything above is the local-network path. Reaching a share from outside the network is handled entirely on the Tauri side rather than in this backend: `frontend/src-tauri/src/services/tunnel.rs` spawns the system `ssh` client as a reverse tunnel to the share port, parses the assigned URL from its output, and closes it when PictoPy exits.
+
+The backend needs no changes for this — the share server is already bound to `0.0.0.0`, so a tunnel forwarding to its port reaches it exactly as a phone on the LAN would. Nothing about tokens, passwords or expiry differs between the two modes.
+
+## Running the tests
+
+```bash
+cd backend && pytest tests/test_share_routes.py tests/test_share_registry.py tests/test_network_utils.py
+```
+
+These cover token issue, expiry and revocation, the interface ranking, and the security invariants — most importantly that an image belonging to a different album cannot be fetched through a share token, and that the share server exposes nothing beyond `/s/{token}`.

--- a/docs/overview/sharing-albums.md
+++ b/docs/overview/sharing-albums.md
@@ -1,0 +1,118 @@
+# Sharing Albums
+
+PictoPy can hand someone a link to one of your albums. They open it in an ordinary browser — no account, no app, nothing to install.
+
+Your photos are never uploaded to PictoPy or to anyone else. They are read off your own disk and sent to whoever opens the link, for as long as you leave the share running.
+
+Two things are true of every share, whichever mode you pick:
+
+- **It only works while PictoPy is running.** Close the app and the link stops working immediately.
+- **Nothing is stored anywhere else.** There is no copy on a server to forget about.
+
+## The two modes
+
+When you share an album you choose where the link should work from.
+
+| | This network | Internet |
+| --- | --- | --- |
+| Who can open it | anyone on your Wi-Fi | anyone with the link |
+| Photos pass through | nothing — device to device | a relay service |
+| Needs internet | no | yes |
+| Speed | your Wi-Fi | your home upload speed |
+
+**This network** is the default and the private one. Use it when the person is in the same house, office or café as you.
+
+**Internet** is for when they are not. It comes with a real trade-off, described below — worth reading once before you use it.
+
+## How "this network" works
+
+The link goes straight from your machine to theirs. Nothing in between, nobody else involved.
+
+```mermaid
+flowchart LR
+    P["📱 Their phone<br/>same Wi-Fi"] -- "http://192.168.1.4:52125" --> R{{"🛜 Your router"}}
+    R --> M["💻 Your machine<br/>PictoPy reads the photo"]
+```
+
+This is as private as sharing gets. The only thing that ever sees your photos is the device you sent the link to.
+
+The catch is that both devices must be on the same network, and **some networks refuse to let their own devices talk to each other**. Guest Wi-Fi almost always does this, and plenty of home routers do too. If the link never loads, that is usually why — see [When the link does not load](#when-the-link-does-not-load).
+
+## Internet mode
+
+Internet mode makes your machine reachable from outside by opening a tunnel through a relay service. Your machine still serves every photo; the relay just passes traffic along.
+
+```mermaid
+flowchart TB
+    P["📱 Their phone<br/>anywhere in the world"]
+    R["☁️ Relay service<br/>localhost.run"]
+    S["🔒 Encrypted tunnel"]
+    M["💻 Your machine<br/>PictoPy reads the photo off your disk"]
+
+    P -- "HTTPS request" --> R
+    R --> S
+    S --> M
+    M -. "the photo travels back the same way" .-> P
+
+    style R fill:#fde68a,stroke:#d97706,color:#000
+```
+
+### What this means for your privacy
+
+**The relay can see your photos.** This is the part worth understanding. The connection is encrypted from their phone to the relay, and encrypted again from the relay to you — but the relay sits in the middle and handles your images in readable form. It does not keep them, but it could read them as they pass.
+
+That is the cost of internet mode, and it is why it is never the default.
+
+**Anyone holding the link can open the album.** The link contains a long random code that nobody can guess, but it is not tied to a person. If it gets forwarded, whoever receives it can open the album.
+
+**Chat apps open links by themselves.** Paste the link into WhatsApp, Slack, Discord or iMessage and their servers will fetch it to build a preview — without anyone tapping it. Without a password, that preview request sees your album.
+
+This is why PictoPy turns the password on for you when you choose internet mode. With a password set, anything that fetches the link finds only a password prompt, which reveals nothing at all — not the album name, not how many photos, not a single thumbnail.
+
+You can turn it off. Just know what it changes.
+
+### Speed
+
+Every photo someone views is sent out from your home internet connection, in full, each time. Home connections upload far more slowly than they download, so a large album will feel slower than Google Photos or iCloud — those serve from their own servers, PictoPy serves from your desk.
+
+### Why it works when "this network" does not
+
+Internet mode makes an **outgoing** connection from your machine to the relay. Nothing has to connect *in* to you, so there is no router setting to change and no port to open.
+
+That is also why internet mode still works on networks that block device-to-device traffic: your router is happy to let a connection out, it just will not let two of its own devices talk to each other.
+
+## Passwords
+
+A password can be added in either mode. The person opening the link is asked for it before anything loads.
+
+- The password is optional on your network, and switched on by default for internet mode.
+- Ten wrong guesses puts that share on a short cooldown.
+- The password protects the album *and* the fact that it exists: the prompt page names nothing about it.
+
+## Stopping a share
+
+A share ends when any of these happens:
+
+- You open the album's share dialog and choose **Stop sharing**.
+- The expiry you picked runs out.
+- **You close PictoPy.** Every share ends, always.
+
+There is no way for a share to outlive the app, by design.
+
+## When the link does not load
+
+Work through these in order.
+
+**Check they are on your Wi-Fi.** For "this network" mode both devices have to be on the same network. A laptop on Ethernet and a phone on Wi-Fi are often not.
+
+**Try one of the other addresses.** If your machine has more than one network address, PictoPy shows a list. The first is a ranked guess, not a certainty — if it does not load, try the next.
+
+**Check your firewall.** On Windows, a rule created while you were on a *Private* network does not apply once you join a *Public* one, and most Wi-Fi is classified Public. The connection then fails silently.
+
+**Suspect the network itself.** Many networks block devices from talking to each other — called *AP isolation* or *client isolation*. It is near-universal on guest Wi-Fi. Nothing in PictoPy can work around it.
+
+To tell an isolated network from a broken setup, turn on your phone's hotspot, connect your computer to it, and share again. If it works there, PictoPy is fine and the other network was blocking it. **Internet mode also solves this**, since it does not rely on the two devices reaching each other directly.
+
+## For developers
+
+The API, the process layout and the security invariants are documented in [Album Sharing](../backend/backend_python/album-sharing.md).

--- a/docs/overview/sharing-albums.md
+++ b/docs/overview/sharing-albums.md
@@ -2,9 +2,11 @@
 
 Hand someone a link to one of your albums. They open it in an ordinary browser — no account, no app, nothing to install.
 
-Your photos are never uploaded to PictoPy or to anyone else. They are read off your own disk and sent to whoever opens the link, for as long as you leave the share running.
+Your photos are never *stored* anywhere but your own machine. They are read off your disk and sent to whoever opens the link, for as long as you leave the share running. PictoPy uploads nothing, and keeps no copy on any server.
 
-Two things are true of every share, whichever mode you pick:
+Where they *travel* depends on which mode you pick. On your own network they go straight to the other device. Over the internet they pass through a relay run by someone else, which can read them on the way past — that mode is described in full below.
+
+Two things are true of every share:
 
 - **It only works while PictoPy is running.** Close the app and the link stops working immediately.
 - **Nothing is stored anywhere else.** There is no copy on a server to worry about.
@@ -15,8 +17,9 @@ When you share an album you choose where the link should work from.
 
 | | This network | Internet |
 | --- | --- | --- |
-| Who can open it | anyone on your Wi-Fi | anyone with the link |
-| Photos pass through | nothing — device to device | a relay service |
+| Who can open it | anyone on your Wi-Fi with the link | anyone with the link |
+| Photos pass through | nothing — device to device | a relay that can read them |
+| Connection | plain HTTP, not encrypted | HTTPS, but decrypted at the relay |
 | Needs internet | no | yes |
 | Speed | your Wi-Fi | your home upload speed |
 
@@ -34,7 +37,10 @@ flowchart LR
     R --> M["💻 Your machine<br/>PictoPy reads the photo"]
 ```
 
-This is as private as sharing gets. The only thing that ever sees your photos is the device you sent the link to.
+No outside company is involved, which is what makes this the private option. Two things are still worth knowing:
+
+- **Anyone on the network who has the link can open it.** The link is not tied to a person, so it works from any device that can reach your machine.
+- **The connection is plain HTTP, not encrypted.** On your own home Wi-Fi that is rarely a concern. On a shared or public network, someone able to watch the traffic could read the photos as they pass, so add a password or prefer a network you trust.
 
 The catch is that both devices must be on the same network, and **some networks refuse to let their own devices talk to each other**. Guest Wi-Fi almost always does this, and plenty of home routers do too. If the link never loads, that is usually why — see [When the link does not load](#when-the-link-does-not-load).
 

--- a/docs/overview/sharing-albums.md
+++ b/docs/overview/sharing-albums.md
@@ -1,13 +1,13 @@
 # Sharing Albums
 
-PictoPy can hand someone a link to one of your albums. They open it in an ordinary browser — no account, no app, nothing to install.
+Hand someone a link to one of your albums. They open it in an ordinary browser — no account, no app, nothing to install.
 
 Your photos are never uploaded to PictoPy or to anyone else. They are read off your own disk and sent to whoever opens the link, for as long as you leave the share running.
 
 Two things are true of every share, whichever mode you pick:
 
 - **It only works while PictoPy is running.** Close the app and the link stops working immediately.
-- **Nothing is stored anywhere else.** There is no copy on a server to forget about.
+- **Nothing is stored anywhere else.** There is no copy on a server to worry about.
 
 ## The two modes
 

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -21,7 +21,7 @@ anyhow = "1.0"
 image = "0.24.6"
 ring = "0.16.20"
 data-encoding = "2.3.2"
-tokio = { version = "1", features = ["macros"] }
+tokio = { version = "1", features = ["macros", "time"] }
 tempfile = "3"
 arrayref = "0.3.6"
 directories = "4.0"

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -21,7 +21,7 @@ anyhow = "1.0"
 image = "0.24.6"
 ring = "0.16.20"
 data-encoding = "2.3.2"
-tokio = { version = "1", features = ["macros", "time"] }
+tokio = { version = "1", features = ["macros", "sync", "time"] }
 tempfile = "3"
 arrayref = "0.3.6"
 directories = "4.0"

--- a/frontend/src-tauri/capabilities/migrated.json
+++ b/frontend/src-tauri/capabilities/migrated.json
@@ -93,6 +93,9 @@
     "dialog:default",
     "store:default",
     "opener:allow-reveal-item-in-dir",
-    "opener:allow-open-url"
+    {
+      "identifier": "opener:allow-open-url",
+      "allow": [{ "url": "https://aossie-org.github.io/*" }]
+    }
   ]
 }

--- a/frontend/src-tauri/capabilities/migrated.json
+++ b/frontend/src-tauri/capabilities/migrated.json
@@ -92,6 +92,7 @@
     "fs:default",
     "dialog:default",
     "store:default",
-    "opener:allow-reveal-item-in-dir"
+    "opener:allow-reveal-item-in-dir",
+    "opener:allow-open-url"
   ]
 }

--- a/frontend/src-tauri/src/main.rs
+++ b/frontend/src-tauri/src/main.rs
@@ -363,6 +363,15 @@ fn main() {
             set_close_to_tray,
         ])
         .on_window_event(on_window_event)
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while building tauri application")
+        .run(|app, event| {
+            // The close handler and the tray item both stop the tunnel already,
+            // but neither covers every way the app can exit. This is the one
+            // path all of them pass through, and an ssh child outliving
+            // PictoPy would leave an album reachable from the internet.
+            if let tauri::RunEvent::Exit = event {
+                services::tunnel::shutdown(app);
+            }
+        });
 }

--- a/frontend/src-tauri/src/main.rs
+++ b/frontend/src-tauri/src/main.rs
@@ -75,6 +75,9 @@ fn on_window_event(window: &Window, event: &WindowEvent) {
             if let Some(manager) = app.get_webview_window("model-manager") {
                 let _ = manager.close();
             }
+            // Before the backend goes: an orphaned tunnel would leave an album
+            // reachable from the internet.
+            services::tunnel::shutdown(&app);
             let _ = kill_process_tree();
             app.exit(0);
         }
@@ -285,6 +288,7 @@ fn main() {
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_process::init())
+        .manage(services::tunnel::TunnelState::new())
         .setup(|app| {
             let resource_path = app.path().resolve("resources", BaseDirectory::Resource)?;
             println!("Resource path: {:?}", resource_path);
@@ -321,6 +325,7 @@ fn main() {
                         }
                     }
                     "quit" => {
+                        services::tunnel::shutdown(app);
                         let _ = kill_process_tree();
                         app.exit(0);
                     }
@@ -347,6 +352,9 @@ fn main() {
         })
         .invoke_handler(tauri::generate_handler![
             services::get_resources_folder_path,
+            services::tunnel::tunnel_start,
+            services::tunnel::tunnel_stop,
+            services::tunnel::tunnel_status,
             open_model_manager,
             enable_autostart,
             disable_autostart,

--- a/frontend/src-tauri/src/services/mod.rs
+++ b/frontend/src-tauri/src/services/mod.rs
@@ -1,3 +1,5 @@
+pub mod tunnel;
+
 use tauri::path::BaseDirectory;
 use tauri::Manager;
 

--- a/frontend/src-tauri/src/services/tunnel.rs
+++ b/frontend/src-tauri/src/services/tunnel.rs
@@ -48,16 +48,44 @@ const PROVIDERS: [Provider; 1] = [Provider {
     url_suffix: ".lhr.life",
 }];
 
-pub struct TunnelState {
+/// The part of a spawned process this module actually needs.
+///
+/// Named so the lifecycle can be exercised without spawning ssh; the real
+/// implementation is the shell plugin's child.
+pub trait TunnelChild: Send + 'static {
+    fn pid(&self) -> u32;
+    fn kill(self) -> Result<(), String>;
+}
+
+impl TunnelChild for CommandChild {
+    fn pid(&self) -> u32 {
+        CommandChild::pid(self)
+    }
+
+    fn kill(self) -> Result<(), String> {
+        CommandChild::kill(self).map_err(|e| e.to_string())
+    }
+}
+
+struct ActiveTunnel<C: TunnelChild> {
+    /// None until the provider announces one. The child is tracked before then
+    /// so that an exit during discovery still has something to kill.
+    url: Option<String>,
+    child: C,
+}
+
+pub struct TunnelStateOf<C: TunnelChild> {
     /// Held across an entire start or stop, spawn included. Without it two
     /// concurrent starts could both find no tunnel, both spawn a child, and
     /// leave whichever installed first running with nothing holding its
     /// handle — an ssh process nobody can stop.
     lifecycle: AsyncMutex<()>,
-    active: Mutex<Option<ActiveTunnel>>,
+    active: Mutex<Option<ActiveTunnel<C>>>,
 }
 
-impl TunnelState {
+pub type TunnelState = TunnelStateOf<CommandChild>;
+
+impl<C: TunnelChild> TunnelStateOf<C> {
     pub fn new() -> Self {
         Self {
             lifecycle: AsyncMutex::new(()),
@@ -69,19 +97,63 @@ impl TunnelState {
         self.active
             .lock()
             .ok()
-            .and_then(|active| active.as_ref().map(|tunnel| tunnel.url.clone()))
+            .and_then(|active| active.as_ref().and_then(|tunnel| tunnel.url.clone()))
+    }
+
+    /// Start tracking a child, before it has announced anything.
+    fn track(&self, child: C) -> Result<(), String> {
+        let mut active = self.active.lock().map_err(|_| "tunnel state lost")?;
+        *active = Some(ActiveTunnel { url: None, child });
+        Ok(())
+    }
+
+    fn announce(&self, url: &str) -> Result<(), String> {
+        let mut active = self.active.lock().map_err(|_| "tunnel state lost")?;
+        if let Some(tunnel) = active.as_mut() {
+            tunnel.url = Some(url.to_string());
+        }
+        Ok(())
+    }
+
+    /// Kill whatever is tracked and stop tracking it.
+    ///
+    /// The pid is read first because killing consumes the handle: it cannot be
+    /// put back for a retry, so a failure has to name the process instead.
+    fn stop(&self) -> Result<(), String> {
+        let tunnel = {
+            let mut active = self.active.lock().map_err(|_| "tunnel state lost")?;
+            active.take()
+        };
+        let Some(tunnel) = tunnel else {
+            return Ok(());
+        };
+        let pid = tunnel.child.pid();
+        tunnel.child.kill().map_err(|e| {
+            format!("could not stop the tunnel (ssh pid {pid} may still be running): {e}")
+        })
+    }
+
+    /// Drop a tunnel from state, but only if it is still the current one.
+    ///
+    /// A tunnel that died after a newer one replaced it must not clear the
+    /// newer one's URL, which is why this checks identity rather than taking.
+    fn forget(&self, url: &str) {
+        if let Ok(mut active) = self.active.lock() {
+            let matches = active
+                .as_ref()
+                .and_then(|tunnel| tunnel.url.as_deref())
+                .is_some_and(|current| current == url);
+            if matches {
+                *active = None;
+            }
+        }
     }
 }
 
-impl Default for TunnelState {
+impl<C: TunnelChild> Default for TunnelStateOf<C> {
     fn default() -> Self {
         Self::new()
     }
-}
-
-struct ActiveTunnel {
-    url: String,
-    child: CommandChild,
 }
 
 /// The public URL in a line of provider output, if there is one.
@@ -128,11 +200,11 @@ async fn read_url(events: &mut Receiver<CommandEvent>, suffix: &str) -> Option<S
     None
 }
 
-async fn open(
+fn spawn_ssh(
     app: &AppHandle,
     provider: Provider,
     port: u16,
-) -> Result<(String, CommandChild), String> {
+) -> Result<(Receiver<CommandEvent>, CommandChild), String> {
     let known_hosts = known_hosts_path(app)?;
     let args = vec![
         // No pty: this is not an interactive session, and a spawned child has
@@ -153,36 +225,11 @@ async fn open(
         provider.destination.to_string(),
     ];
 
-    let (mut events, child) = app
-        .shell()
+    app.shell()
         .command("ssh")
         .args(args)
         .spawn()
-        .map_err(|e| format!("could not start ssh: {e}"))?;
-
-    match timeout(URL_TIMEOUT, read_url(&mut events, provider.url_suffix)).await {
-        Ok(Some(url)) => {
-            let handle = app.clone();
-            let watched = url.clone();
-            tauri::async_runtime::spawn(async move {
-                // Keep draining: providers print a banner and an ANSI QR code,
-                // and a full pipe would stall ssh once nobody is reading.
-                while events.recv().await.is_some() {}
-                // The stream ends when ssh exits. Without this the status
-                // command would keep handing out a URL that is already dead.
-                forget(&handle, &watched);
-            });
-            Ok((url, child))
-        }
-        Ok(None) => {
-            let _ = child.kill();
-            Err("ssh exited before providing a URL".to_string())
-        }
-        Err(_) => {
-            let _ = child.kill();
-            Err(format!("no URL within {} seconds", URL_TIMEOUT.as_secs()))
-        }
-    }
+        .map_err(|e| format!("could not start ssh: {e}"))
 }
 
 /// Open a tunnel to the share server, or return the one already running.
@@ -201,16 +248,51 @@ pub async fn tunnel_start(
 
     let mut failures = Vec::new();
     for provider in PROVIDERS {
-        match open(&app, provider, port).await {
-            Ok((url, child)) => {
-                let mut active = state.active.lock().map_err(|_| "tunnel state lost")?;
-                *active = Some(ActiveTunnel {
-                    url: url.clone(),
-                    child,
+        let (mut events, child) = match spawn_ssh(&app, provider, port) {
+            Ok(spawned) => spawned,
+            Err(error) => {
+                failures.push(format!("{}: {error}", provider.name));
+                continue;
+            }
+        };
+
+        // Tracked before the URL arrives. If the app exits while we are still
+        // waiting, shutdown has a handle to kill instead of leaving an ssh
+        // child forwarding an album with nothing owning it.
+        state.track(child)?;
+
+        match timeout(URL_TIMEOUT, read_url(&mut events, provider.url_suffix)).await {
+            Ok(Some(url)) => {
+                state.announce(&url)?;
+                let handle = app.clone();
+                let watched = url.clone();
+                tauri::async_runtime::spawn(async move {
+                    // Keep draining: providers print a banner and an ANSI QR
+                    // code, and a full pipe would stall ssh once nobody reads.
+                    while events.recv().await.is_some() {}
+                    // The stream ends when ssh exits. Without this the status
+                    // command would keep handing out a URL that is already dead.
+                    if let Some(state) = handle.try_state::<TunnelState>() {
+                        state.forget(&watched);
+                    }
                 });
                 return Ok(url);
             }
-            Err(error) => failures.push(format!("{}: {error}", provider.name)),
+            Ok(None) => {
+                let _ = state.stop();
+                failures.push(format!(
+                    "{}: ssh exited before providing a URL",
+                    provider.name
+                ));
+            }
+            Err(_) => {
+                let _ = state.stop();
+                failures.push(format!(
+                    "{}: no URL within {} seconds",
+                    provider.name,
+                    URL_TIMEOUT.as_secs()
+                ));
+            }
         }
     }
 
@@ -224,63 +306,59 @@ pub async fn tunnel_start(
 #[tauri::command]
 pub async fn tunnel_stop(state: State<'_, TunnelState>) -> Result<(), String> {
     let _lifecycle = state.lifecycle.lock().await;
-
-    // CommandChild::kill consumes the handle, so it cannot be put back for a
-    // retry. The pid is captured first so a failure names the process that is
-    // still running rather than leaving nothing to act on.
-    let tunnel = {
-        let mut active = state.active.lock().map_err(|_| "tunnel state lost")?;
-        active.take()
-    };
-
-    let Some(tunnel) = tunnel else {
-        return Ok(());
-    };
-
-    let pid = tunnel.child.pid();
-    tunnel
-        .child
-        .kill()
-        .map_err(|e| format!("could not stop the tunnel (ssh pid {pid} may still be running): {e}"))
+    state.stop()
 }
 
-/// The public URL, if a tunnel is open.
+/// The public URL, if a tunnel is open and has announced one.
 #[tauri::command]
 pub fn tunnel_status(state: State<'_, TunnelState>) -> Result<Option<String>, String> {
     Ok(state.current_url())
 }
 
-/// Drop a tunnel from state, but only if it is still the current one.
-///
-/// A tunnel that died after a newer one replaced it must not clear the newer
-/// one's URL, which is why this checks identity rather than blindly taking.
-fn forget(app: &AppHandle, url: &str) {
-    if let Some(state) = app.try_state::<TunnelState>() {
-        if let Ok(mut active) = state.active.lock() {
-            if active.as_ref().is_some_and(|tunnel| tunnel.url == url) {
-                *active = None;
-            }
-        }
-    }
-}
-
 /// Kill the tunnel on the way out, from outside a command context.
 ///
 /// Deliberately does not take the lifecycle lock: this runs on the exit path,
-/// where blocking on an in-flight start would be worse than racing it.
+/// where blocking on an in-flight start would be worse than racing it. A start
+/// still in progress has already tracked its child, so there is one to kill.
 pub fn shutdown(app: &AppHandle) {
     if let Some(state) = app.try_state::<TunnelState>() {
-        if let Ok(mut active) = state.active.lock() {
-            if let Some(tunnel) = active.take() {
-                let _ = tunnel.child.kill();
-            }
-        }
+        let _ = state.stop();
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::find_url;
+    use super::{find_url, TunnelChild, TunnelStateOf};
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+
+    struct FakeChild {
+        pid: u32,
+        killed: Arc<AtomicBool>,
+        refuses: bool,
+    }
+
+    impl TunnelChild for FakeChild {
+        fn pid(&self) -> u32 {
+            self.pid
+        }
+
+        fn kill(self) -> Result<(), String> {
+            self.killed.store(true, Ordering::SeqCst);
+            if self.refuses {
+                return Err("access denied".to_string());
+            }
+            Ok(())
+        }
+    }
+
+    fn child(killed: &Arc<AtomicBool>, refuses: bool) -> FakeChild {
+        FakeChild {
+            pid: 4242,
+            killed: Arc::clone(killed),
+            refuses,
+        }
+    }
 
     // Verbatim from localhost.run, which prints its own docs and social links
     // before the tunnel URL. Matching the first https:// token would take the
@@ -318,5 +396,75 @@ mod tests {
     fn ignores_plain_http() {
         let line = "http://d9b8d37391ddfb.lhr.life";
         assert_eq!(find_url(line, ".lhr.life"), None);
+    }
+
+    #[test]
+    fn stopping_kills_the_child_and_clears_the_state() {
+        let killed = Arc::new(AtomicBool::new(false));
+        let state = TunnelStateOf::new();
+        state.track(child(&killed, false)).unwrap();
+        state.announce("https://one.lhr.life").unwrap();
+
+        assert!(state.stop().is_ok());
+        assert!(killed.load(Ordering::SeqCst));
+        assert_eq!(state.current_url(), None);
+    }
+
+    #[test]
+    fn stopping_nothing_is_not_an_error() {
+        let state: TunnelStateOf<FakeChild> = TunnelStateOf::new();
+        assert!(state.stop().is_ok());
+    }
+
+    // A child that refused to die is the one case worth naming: the handle is
+    // consumed by the attempt, so the pid is all the caller has left to act on.
+    #[test]
+    fn a_refused_kill_reports_the_process() {
+        let killed = Arc::new(AtomicBool::new(false));
+        let state = TunnelStateOf::new();
+        state.track(child(&killed, true)).unwrap();
+
+        let error = state.stop().unwrap_err();
+        assert!(error.contains("4242"), "{error}");
+        assert!(error.contains("may still be running"), "{error}");
+    }
+
+    // The gap that let an exit during startup orphan an ssh process.
+    #[test]
+    fn a_child_is_killable_before_it_announces_a_url() {
+        let killed = Arc::new(AtomicBool::new(false));
+        let state = TunnelStateOf::new();
+        state.track(child(&killed, false)).unwrap();
+
+        assert_eq!(state.current_url(), None, "nothing to advertise yet");
+        assert!(state.stop().is_ok());
+        assert!(killed.load(Ordering::SeqCst), "the child still gets killed");
+    }
+
+    #[test]
+    fn a_dead_tunnel_does_not_clear_the_one_that_replaced_it() {
+        let killed = Arc::new(AtomicBool::new(false));
+        let state = TunnelStateOf::new();
+        state.track(child(&killed, false)).unwrap();
+        state.announce("https://second.lhr.life").unwrap();
+
+        state.forget("https://first.lhr.life");
+
+        assert_eq!(
+            state.current_url().as_deref(),
+            Some("https://second.lhr.life")
+        );
+    }
+
+    #[test]
+    fn a_tunnel_forgets_itself_when_it_dies() {
+        let killed = Arc::new(AtomicBool::new(false));
+        let state = TunnelStateOf::new();
+        state.track(child(&killed, false)).unwrap();
+        state.announce("https://only.lhr.life").unwrap();
+
+        state.forget("https://only.lhr.life");
+
+        assert_eq!(state.current_url(), None);
     }
 }

--- a/frontend/src-tauri/src/services/tunnel.rs
+++ b/frontend/src-tauri/src/services/tunnel.rs
@@ -1,0 +1,273 @@
+//! Exposing the share server beyond the LAN through an SSH reverse tunnel.
+//!
+//! Nothing is bundled to make this work: every desktop platform ships an ssh
+//! client, and both providers below accept a plain port forward. That avoids a
+//! ~40MB third-party binary in the installer, and the supply-chain question of
+//! pinning one that upstream publishes from unversioned URLs.
+//!
+//! The child process is owned here so it dies with the app. An orphaned tunnel
+//! is an album left reachable from the internet, which is a good deal worse
+//! than the orphaned LAN listener the backend already guards against.
+
+use std::path::PathBuf;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use tauri::{AppHandle, Manager, State};
+use tauri_plugin_shell::process::{CommandChild, CommandEvent};
+use tauri_plugin_shell::ShellExt;
+use tokio::sync::mpsc::Receiver;
+use tokio::time::timeout;
+
+/// How long a provider gets to hand back a URL before we move on to the next.
+const URL_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[derive(Clone, Copy)]
+struct Provider {
+    name: &'static str,
+    /// Destination for ssh, including the user where one is expected.
+    destination: &'static str,
+    /// Remote port to request. localhost.run wants 80; srv.us numbers services.
+    remote_port: &'static str,
+    /// Host suffix identifying the assigned URL. Matched instead of the
+    /// surrounding wording, because both providers print a banner containing
+    /// several unrelated https links before the real one.
+    url_suffix: &'static str,
+}
+
+/// Tried in order until one answers. srv.us is the intended second entry, and
+/// needs a dedicated key generated first, so it lands separately rather than
+/// half-built here. A fallback matters because a provider can fail while
+/// looking healthy: one accepted connections and issued URLs for a tunnel it
+/// then never routed anything to.
+const PROVIDERS: [Provider; 1] = [Provider {
+    name: "localhost.run",
+    destination: "nokey@localhost.run",
+    remote_port: "80",
+    url_suffix: ".lhr.life",
+}];
+
+pub struct TunnelState {
+    active: Mutex<Option<ActiveTunnel>>,
+}
+
+impl TunnelState {
+    pub fn new() -> Self {
+        Self {
+            active: Mutex::new(None),
+        }
+    }
+}
+
+impl Default for TunnelState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+struct ActiveTunnel {
+    url: String,
+    child: CommandChild,
+}
+
+/// The public URL in a line of provider output, if there is one.
+///
+/// Split on whitespace rather than pattern-matching the sentence around it: the
+/// wording is the provider's to change, and one has already been observed
+/// printing something different from its own documentation.
+fn find_url(line: &str, suffix: &str) -> Option<String> {
+    line.split_whitespace()
+        .filter(|token| token.starts_with("https://"))
+        .map(|token| token.trim_end_matches(['/', ',', '.']))
+        .find(|token| token.ends_with(suffix))
+        .map(str::to_string)
+}
+
+/// Our own known_hosts, so accepting a provider's key never edits the user's.
+fn known_hosts_path(app: &AppHandle) -> Result<PathBuf, String> {
+    let directory = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("no app data directory: {e}"))?
+        .join("ssh");
+    std::fs::create_dir_all(&directory)
+        .map_err(|e| format!("could not create {}: {e}", directory.display()))?;
+    Ok(directory.join("known_hosts"))
+}
+
+async fn read_url(events: &mut Receiver<CommandEvent>, suffix: &str) -> Option<String> {
+    while let Some(event) = events.recv().await {
+        let line = match event {
+            // Providers announce the URL on stdout, but ssh's own diagnostics
+            // arrive on stderr, and a failed forward is only visible there.
+            CommandEvent::Stdout(bytes) | CommandEvent::Stderr(bytes) => {
+                String::from_utf8_lossy(&bytes).into_owned()
+            }
+            CommandEvent::Terminated(_) => return None,
+            _ => continue,
+        };
+        if let Some(url) = find_url(&line, suffix) {
+            return Some(url);
+        }
+    }
+    None
+}
+
+async fn open(
+    app: &AppHandle,
+    provider: Provider,
+    port: u16,
+) -> Result<(String, CommandChild), String> {
+    let known_hosts = known_hosts_path(app)?;
+    let args = vec![
+        // No pty: this is not an interactive session, and a spawned child has
+        // no terminal to allocate one against.
+        "-T".to_string(),
+        // Without this the first connection asks a question nothing can answer.
+        "-o".to_string(),
+        "StrictHostKeyChecking=accept-new".to_string(),
+        "-o".to_string(),
+        format!("UserKnownHostsFile={}", known_hosts.display()),
+        "-o".to_string(),
+        "ServerAliveInterval=30".to_string(),
+        // Fail loudly instead of holding a session that forwards nothing.
+        "-o".to_string(),
+        "ExitOnForwardFailure=yes".to_string(),
+        "-R".to_string(),
+        format!("{}:127.0.0.1:{}", provider.remote_port, port),
+        provider.destination.to_string(),
+    ];
+
+    let (mut events, child) = app
+        .shell()
+        .command("ssh")
+        .args(args)
+        .spawn()
+        .map_err(|e| format!("could not start ssh: {e}"))?;
+
+    match timeout(URL_TIMEOUT, read_url(&mut events, provider.url_suffix)).await {
+        Ok(Some(url)) => {
+            // Keep draining: providers print a banner and an ANSI QR code, and
+            // a full pipe would stall ssh once nobody is reading.
+            tauri::async_runtime::spawn(async move { while events.recv().await.is_some() {} });
+            Ok((url, child))
+        }
+        Ok(None) => {
+            let _ = child.kill();
+            Err("ssh exited before providing a URL".to_string())
+        }
+        Err(_) => {
+            let _ = child.kill();
+            Err(format!("no URL within {} seconds", URL_TIMEOUT.as_secs()))
+        }
+    }
+}
+
+/// Open a tunnel to the share server, or return the one already running.
+#[tauri::command]
+pub async fn tunnel_start(
+    app: AppHandle,
+    state: State<'_, TunnelState>,
+    port: u16,
+) -> Result<String, String> {
+    {
+        let active = state.active.lock().map_err(|_| "tunnel state lost")?;
+        if let Some(tunnel) = active.as_ref() {
+            return Ok(tunnel.url.clone());
+        }
+    }
+
+    let mut failures = Vec::new();
+    for provider in PROVIDERS {
+        match open(&app, provider, port).await {
+            Ok((url, child)) => {
+                let mut active = state.active.lock().map_err(|_| "tunnel state lost")?;
+                *active = Some(ActiveTunnel {
+                    url: url.clone(),
+                    child,
+                });
+                return Ok(url);
+            }
+            Err(error) => failures.push(format!("{}: {error}", provider.name)),
+        }
+    }
+
+    Err(format!(
+        "Could not reach a tunnel provider. {}",
+        failures.join("; ")
+    ))
+}
+
+/// Close the tunnel. Safe to call when none is open.
+#[tauri::command]
+pub fn tunnel_stop(state: State<'_, TunnelState>) -> Result<(), String> {
+    let mut active = state.active.lock().map_err(|_| "tunnel state lost")?;
+    if let Some(tunnel) = active.take() {
+        tunnel
+            .child
+            .kill()
+            .map_err(|e| format!("could not stop the tunnel: {e}"))?;
+    }
+    Ok(())
+}
+
+/// The public URL, if a tunnel is open.
+#[tauri::command]
+pub fn tunnel_status(state: State<'_, TunnelState>) -> Result<Option<String>, String> {
+    let active = state.active.lock().map_err(|_| "tunnel state lost")?;
+    Ok(active.as_ref().map(|tunnel| tunnel.url.clone()))
+}
+
+/// Kill the tunnel on the way out, from outside a command context.
+pub fn shutdown(app: &AppHandle) {
+    if let Some(state) = app.try_state::<TunnelState>() {
+        if let Ok(mut active) = state.active.lock() {
+            if let Some(tunnel) = active.take() {
+                let _ = tunnel.child.kill();
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::find_url;
+
+    // Verbatim from localhost.run, which prints its own docs and social links
+    // before the tunnel URL. Matching the first https:// token would take the
+    // wrong one.
+    const BANNER: &str =
+        "Follow your favourite reverse tunnel at [https://twitter.com/localhost_run].";
+    const DOCS: &str = "https://localhost.run/docs/";
+    const ASSIGNED: &str =
+        "d9b8d37391ddfb.lhr.life tunneled with tls termination, https://d9b8d37391ddfb.lhr.life";
+
+    #[test]
+    fn finds_the_assigned_url() {
+        assert_eq!(
+            find_url(ASSIGNED, ".lhr.life").as_deref(),
+            Some("https://d9b8d37391ddfb.lhr.life")
+        );
+    }
+
+    #[test]
+    fn ignores_the_providers_own_links() {
+        assert_eq!(find_url(BANNER, ".lhr.life"), None);
+        assert_eq!(find_url(DOCS, ".lhr.life"), None);
+    }
+
+    #[test]
+    fn tolerates_a_trailing_slash() {
+        let line = "https://6bl6voavpt4jld4b7dq4bglbii.srv.us/";
+        assert_eq!(
+            find_url(line, ".srv.us").as_deref(),
+            Some("https://6bl6voavpt4jld4b7dq4bglbii.srv.us")
+        );
+    }
+
+    #[test]
+    fn ignores_plain_http() {
+        let line = "http://d9b8d37391ddfb.lhr.life";
+        assert_eq!(find_url(line, ".lhr.life"), None);
+    }
+}

--- a/frontend/src-tauri/src/services/tunnel.rs
+++ b/frontend/src-tauri/src/services/tunnel.rs
@@ -147,9 +147,16 @@ async fn open(
 
     match timeout(URL_TIMEOUT, read_url(&mut events, provider.url_suffix)).await {
         Ok(Some(url)) => {
-            // Keep draining: providers print a banner and an ANSI QR code, and
-            // a full pipe would stall ssh once nobody is reading.
-            tauri::async_runtime::spawn(async move { while events.recv().await.is_some() {} });
+            let handle = app.clone();
+            let watched = url.clone();
+            tauri::async_runtime::spawn(async move {
+                // Keep draining: providers print a banner and an ANSI QR code,
+                // and a full pipe would stall ssh once nobody is reading.
+                while events.recv().await.is_some() {}
+                // The stream ends when ssh exits. Without this the status
+                // command would keep handing out a URL that is already dead.
+                forget(&handle, &watched);
+            });
             Ok((url, child))
         }
         Ok(None) => {
@@ -216,6 +223,20 @@ pub fn tunnel_stop(state: State<'_, TunnelState>) -> Result<(), String> {
 pub fn tunnel_status(state: State<'_, TunnelState>) -> Result<Option<String>, String> {
     let active = state.active.lock().map_err(|_| "tunnel state lost")?;
     Ok(active.as_ref().map(|tunnel| tunnel.url.clone()))
+}
+
+/// Drop a tunnel from state, but only if it is still the current one.
+///
+/// A tunnel that died after a newer one replaced it must not clear the newer
+/// one's URL, which is why this checks identity rather than blindly taking.
+fn forget(app: &AppHandle, url: &str) {
+    if let Some(state) = app.try_state::<TunnelState>() {
+        if let Ok(mut active) = state.active.lock() {
+            if active.as_ref().is_some_and(|tunnel| tunnel.url == url) {
+                *active = None;
+            }
+        }
+    }
 }
 
 /// Kill the tunnel on the way out, from outside a command context.

--- a/frontend/src-tauri/src/services/tunnel.rs
+++ b/frontend/src-tauri/src/services/tunnel.rs
@@ -74,13 +74,23 @@ struct ActiveTunnel<C: TunnelChild> {
     child: C,
 }
 
+/// The tracked child, and whether the app has begun shutting down.
+///
+/// Both live under one lock on purpose. Kept apart, a shutdown could land
+/// between a child being spawned and being tracked, find nothing to kill, and
+/// let the start install an ssh process that then outlives the application.
+struct Tracked<C: TunnelChild> {
+    tunnel: Option<ActiveTunnel<C>>,
+    closed: bool,
+}
+
 pub struct TunnelStateOf<C: TunnelChild> {
     /// Held across an entire start or stop, spawn included. Without it two
     /// concurrent starts could both find no tunnel, both spawn a child, and
     /// leave whichever installed first running with nothing holding its
     /// handle — an ssh process nobody can stop.
     lifecycle: AsyncMutex<()>,
-    active: Mutex<Option<ActiveTunnel<C>>>,
+    tracked: Mutex<Tracked<C>>,
 }
 
 pub type TunnelState = TunnelStateOf<CommandChild>;
@@ -89,27 +99,38 @@ impl<C: TunnelChild> TunnelStateOf<C> {
     pub fn new() -> Self {
         Self {
             lifecycle: AsyncMutex::new(()),
-            active: Mutex::new(None),
+            tracked: Mutex::new(Tracked {
+                tunnel: None,
+                closed: false,
+            }),
         }
     }
 
     fn current_url(&self) -> Option<String> {
-        self.active
+        self.tracked
             .lock()
             .ok()
-            .and_then(|active| active.as_ref().and_then(|tunnel| tunnel.url.clone()))
+            .and_then(|tracked| tracked.tunnel.as_ref().and_then(|t| t.url.clone()))
     }
 
     /// Start tracking a child, before it has announced anything.
+    ///
+    /// Refuses once shutdown has been requested, killing the child rather than
+    /// storing it: by then nothing will come back to stop it.
     fn track(&self, child: C) -> Result<(), String> {
-        let mut active = self.active.lock().map_err(|_| "tunnel state lost")?;
-        *active = Some(ActiveTunnel { url: None, child });
+        let mut tracked = self.tracked.lock().map_err(|_| "tunnel state lost")?;
+        if tracked.closed {
+            drop(tracked);
+            let _ = child.kill();
+            return Err("PictoPy is shutting down".to_string());
+        }
+        tracked.tunnel = Some(ActiveTunnel { url: None, child });
         Ok(())
     }
 
     fn announce(&self, url: &str) -> Result<(), String> {
-        let mut active = self.active.lock().map_err(|_| "tunnel state lost")?;
-        if let Some(tunnel) = active.as_mut() {
+        let mut tracked = self.tracked.lock().map_err(|_| "tunnel state lost")?;
+        if let Some(tunnel) = tracked.tunnel.as_mut() {
             tunnel.url = Some(url.to_string());
         }
         Ok(())
@@ -120,9 +141,21 @@ impl<C: TunnelChild> TunnelStateOf<C> {
     /// The pid is read first because killing consumes the handle: it cannot be
     /// put back for a retry, so a failure has to name the process instead.
     fn stop(&self) -> Result<(), String> {
+        self.take_and_kill(false)
+    }
+
+    /// Stop, and refuse to track anything spawned from here on.
+    fn close_permanently(&self) -> Result<(), String> {
+        self.take_and_kill(true)
+    }
+
+    fn take_and_kill(&self, closing: bool) -> Result<(), String> {
         let tunnel = {
-            let mut active = self.active.lock().map_err(|_| "tunnel state lost")?;
-            active.take()
+            let mut tracked = self.tracked.lock().map_err(|_| "tunnel state lost")?;
+            if closing {
+                tracked.closed = true;
+            }
+            tracked.tunnel.take()
         };
         let Some(tunnel) = tunnel else {
             return Ok(());
@@ -138,13 +171,14 @@ impl<C: TunnelChild> TunnelStateOf<C> {
     /// A tunnel that died after a newer one replaced it must not clear the
     /// newer one's URL, which is why this checks identity rather than taking.
     fn forget(&self, url: &str) {
-        if let Ok(mut active) = self.active.lock() {
-            let matches = active
+        if let Ok(mut tracked) = self.tracked.lock() {
+            let matches = tracked
+                .tunnel
                 .as_ref()
                 .and_then(|tunnel| tunnel.url.as_deref())
                 .is_some_and(|current| current == url);
             if matches {
-                *active = None;
+                tracked.tunnel = None;
             }
         }
     }
@@ -318,11 +352,13 @@ pub fn tunnel_status(state: State<'_, TunnelState>) -> Result<Option<String>, St
 /// Kill the tunnel on the way out, from outside a command context.
 ///
 /// Deliberately does not take the lifecycle lock: this runs on the exit path,
-/// where blocking on an in-flight start would be worse than racing it. A start
-/// still in progress has already tracked its child, so there is one to kill.
+/// where blocking on an in-flight start would be worse than racing it. Racing
+/// it is safe because the refusal is recorded under the same lock the start
+/// uses to track its child, so a child spawned but not yet tracked is killed
+/// by whichever of the two arrives second.
 pub fn shutdown(app: &AppHandle) {
     if let Some(state) = app.try_state::<TunnelState>() {
-        let _ = state.stop();
+        let _ = state.close_permanently();
     }
 }
 
@@ -427,6 +463,22 @@ mod tests {
         let error = state.stop().unwrap_err();
         assert!(error.contains("4242"), "{error}");
         assert!(error.contains("may still be running"), "{error}");
+    }
+
+    // Exit can land between ssh being spawned and the handle being tracked.
+    // Whichever arrives second has to kill it, or the process outlives the app
+    // with an album still forwarding.
+    #[test]
+    fn a_child_spawned_during_shutdown_is_killed_not_stored() {
+        let killed = Arc::new(AtomicBool::new(false));
+        let state = TunnelStateOf::new();
+
+        state.close_permanently().unwrap();
+        let refused = state.track(child(&killed, false));
+
+        assert!(refused.is_err(), "tracking must not succeed after shutdown");
+        assert!(killed.load(Ordering::SeqCst), "the child is killed instead");
+        assert_eq!(state.current_url(), None);
     }
 
     // The gap that let an exit during startup orphan an ssh process.

--- a/frontend/src-tauri/src/services/tunnel.rs
+++ b/frontend/src-tauri/src/services/tunnel.rs
@@ -17,6 +17,7 @@ use tauri::{AppHandle, Manager, State};
 use tauri_plugin_shell::process::{CommandChild, CommandEvent};
 use tauri_plugin_shell::ShellExt;
 use tokio::sync::mpsc::Receiver;
+use tokio::sync::Mutex as AsyncMutex;
 use tokio::time::timeout;
 
 /// How long a provider gets to hand back a URL before we move on to the next.
@@ -48,14 +49,27 @@ const PROVIDERS: [Provider; 1] = [Provider {
 }];
 
 pub struct TunnelState {
+    /// Held across an entire start or stop, spawn included. Without it two
+    /// concurrent starts could both find no tunnel, both spawn a child, and
+    /// leave whichever installed first running with nothing holding its
+    /// handle — an ssh process nobody can stop.
+    lifecycle: AsyncMutex<()>,
     active: Mutex<Option<ActiveTunnel>>,
 }
 
 impl TunnelState {
     pub fn new() -> Self {
         Self {
+            lifecycle: AsyncMutex::new(()),
             active: Mutex::new(None),
         }
+    }
+
+    fn current_url(&self) -> Option<String> {
+        self.active
+            .lock()
+            .ok()
+            .and_then(|active| active.as_ref().map(|tunnel| tunnel.url.clone()))
     }
 }
 
@@ -74,7 +88,8 @@ struct ActiveTunnel {
 ///
 /// Split on whitespace rather than pattern-matching the sentence around it: the
 /// wording is the provider's to change, and one has already been observed
-/// printing something different from its own documentation.
+/// printing something different from its own documentation. Each event is a
+/// whole line, because the shell plugin frames process output with read_line.
 fn find_url(line: &str, suffix: &str) -> Option<String> {
     line.split_whitespace()
         .filter(|token| token.starts_with("https://"))
@@ -177,11 +192,11 @@ pub async fn tunnel_start(
     state: State<'_, TunnelState>,
     port: u16,
 ) -> Result<String, String> {
-    {
-        let active = state.active.lock().map_err(|_| "tunnel state lost")?;
-        if let Some(tunnel) = active.as_ref() {
-            return Ok(tunnel.url.clone());
-        }
+    let _lifecycle = state.lifecycle.lock().await;
+
+    // Re-checked while holding the lock, not before taking it.
+    if let Some(url) = state.current_url() {
+        return Ok(url);
     }
 
     let mut failures = Vec::new();
@@ -207,22 +222,32 @@ pub async fn tunnel_start(
 
 /// Close the tunnel. Safe to call when none is open.
 #[tauri::command]
-pub fn tunnel_stop(state: State<'_, TunnelState>) -> Result<(), String> {
-    let mut active = state.active.lock().map_err(|_| "tunnel state lost")?;
-    if let Some(tunnel) = active.take() {
-        tunnel
-            .child
-            .kill()
-            .map_err(|e| format!("could not stop the tunnel: {e}"))?;
-    }
-    Ok(())
+pub async fn tunnel_stop(state: State<'_, TunnelState>) -> Result<(), String> {
+    let _lifecycle = state.lifecycle.lock().await;
+
+    // CommandChild::kill consumes the handle, so it cannot be put back for a
+    // retry. The pid is captured first so a failure names the process that is
+    // still running rather than leaving nothing to act on.
+    let tunnel = {
+        let mut active = state.active.lock().map_err(|_| "tunnel state lost")?;
+        active.take()
+    };
+
+    let Some(tunnel) = tunnel else {
+        return Ok(());
+    };
+
+    let pid = tunnel.child.pid();
+    tunnel
+        .child
+        .kill()
+        .map_err(|e| format!("could not stop the tunnel (ssh pid {pid} may still be running): {e}"))
 }
 
 /// The public URL, if a tunnel is open.
 #[tauri::command]
 pub fn tunnel_status(state: State<'_, TunnelState>) -> Result<Option<String>, String> {
-    let active = state.active.lock().map_err(|_| "tunnel state lost")?;
-    Ok(active.as_ref().map(|tunnel| tunnel.url.clone()))
+    Ok(state.current_url())
 }
 
 /// Drop a tunnel from state, but only if it is still the current one.
@@ -240,6 +265,9 @@ fn forget(app: &AppHandle, url: &str) {
 }
 
 /// Kill the tunnel on the way out, from outside a command context.
+///
+/// Deliberately does not take the lifecycle lock: this runs on the exit path,
+/// where blocking on an in-flight start would be worse than racing it.
 pub fn shutdown(app: &AppHandle) {
     if let Some(state) = app.try_state::<TunnelState>() {
         if let Ok(mut active) = state.active.lock() {

--- a/frontend/src/components/Albums/ShareAlbumDialog.tsx
+++ b/frontend/src/components/Albums/ShareAlbumDialog.tsx
@@ -252,7 +252,7 @@ export const ShareAlbumDialog: React.FC<ShareAlbumDialogProps> = ({
       type="button"
       variant="ghost"
       size="icon"
-      className="text-muted-foreground hover:text-foreground -mt-1 h-7 w-7 shrink-0"
+      className="text-muted-foreground hover:text-foreground h-7 w-7 shrink-0"
       aria-label="How sharing works"
       onClick={() => {
         const url = mode === 'internet' ? DOCS_INTERNET_URL : DOCS_URL;
@@ -328,8 +328,10 @@ export const ShareAlbumDialog: React.FC<ShareAlbumDialogProps> = ({
         ) : activeShare ? (
           <>
             <DialogHeader>
-              <div className="flex items-start justify-between gap-2">
-                <DialogTitle>Sharing "{activeShare.album_name}"</DialogTitle>
+              <div className="flex items-center gap-1">
+                <DialogTitle className="truncate">
+                  Sharing "{activeShare.album_name}"
+                </DialogTitle>
                 {docsButton}
               </div>
               <DialogDescription>
@@ -450,8 +452,10 @@ export const ShareAlbumDialog: React.FC<ShareAlbumDialogProps> = ({
         ) : (
           <form onSubmit={handleCreate}>
             <DialogHeader>
-              <div className="flex items-start justify-between gap-2">
-                <DialogTitle>Share "{album?.name}"</DialogTitle>
+              <div className="flex items-center gap-1">
+                <DialogTitle className="truncate">
+                  Share "{album?.name}"
+                </DialogTitle>
                 {docsButton}
               </div>
               <DialogDescription>

--- a/frontend/src/components/Albums/ShareAlbumDialog.tsx
+++ b/frontend/src/components/Albums/ShareAlbumDialog.tsx
@@ -1,9 +1,11 @@
 import React, { useEffect, useState } from 'react';
 import { QRCodeSVG } from 'qrcode.react';
+import { openUrl } from '@tauri-apps/plugin-opener';
 import {
   Check,
   Copy,
   Globe,
+  Info,
   Loader2,
   Share2,
   TriangleAlert,
@@ -53,6 +55,10 @@ const EXPIRY_OPTIONS = [
 
 // The backend hashes with bcrypt and refuses anything shorter.
 const MIN_PASSWORD_LENGTH = 4;
+
+const DOCS_URL =
+  'https://aossie-org.github.io/PictoPy/overview/sharing-albums/';
+const DOCS_INTERNET_URL = `${DOCS_URL}#internet-mode`;
 
 const formatExpiry = (expiresAt: string | null): string =>
   expiresAt ? new Date(expiresAt).toLocaleString() : 'Until you stop it';
@@ -236,6 +242,25 @@ export const ShareAlbumDialog: React.FC<ShareAlbumDialogProps> = ({
     setCopied(true);
   };
 
+  // Deep links to the section covering whichever mode is selected, so someone
+  // weighing up internet mode lands on what it costs rather than the top.
+  const docsButton = (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon"
+      className="text-muted-foreground hover:text-foreground -mt-1 h-7 w-7 shrink-0"
+      aria-label="How sharing works"
+      onClick={() =>
+        openUrl(mode === 'internet' ? DOCS_INTERNET_URL : DOCS_URL).catch(
+          () => undefined,
+        )
+      }
+    >
+      <Info className="h-4 w-4" />
+    </Button>
+  );
+
   const renderAddress = (entry: ShareUrl) => (
     <button
       key={entry.url}
@@ -290,7 +315,10 @@ export const ShareAlbumDialog: React.FC<ShareAlbumDialogProps> = ({
         ) : activeShare ? (
           <>
             <DialogHeader>
-              <DialogTitle>Sharing "{activeShare.album_name}"</DialogTitle>
+              <div className="flex items-start justify-between gap-2">
+                <DialogTitle>Sharing "{activeShare.album_name}"</DialogTitle>
+                {docsButton}
+              </div>
               <DialogDescription>
                 Anyone on this network can open the link while PictoPy is
                 running. Nothing is uploaded.
@@ -409,7 +437,10 @@ export const ShareAlbumDialog: React.FC<ShareAlbumDialogProps> = ({
         ) : (
           <form onSubmit={handleCreate}>
             <DialogHeader>
-              <DialogTitle>Share "{album?.name}"</DialogTitle>
+              <div className="flex items-start justify-between gap-2">
+                <DialogTitle>Share "{album?.name}"</DialogTitle>
+                {docsButton}
+              </div>
               <DialogDescription>
                 {mode === 'lan'
                   ? 'Serve this album to other devices on your network. The photos stay on this machine.'

--- a/frontend/src/components/Albums/ShareAlbumDialog.tsx
+++ b/frontend/src/components/Albums/ShareAlbumDialog.tsx
@@ -1,6 +1,14 @@
 import React, { useEffect, useState } from 'react';
 import { QRCodeSVG } from 'qrcode.react';
-import { Check, Copy, Share2, Wifi } from 'lucide-react';
+import {
+  Check,
+  Copy,
+  Globe,
+  Loader2,
+  Share2,
+  TriangleAlert,
+  Wifi,
+} from 'lucide-react';
 import {
   Dialog,
   DialogContent,
@@ -19,7 +27,22 @@ import { usePictoMutation, type BackendRes } from '@/hooks/useQueryExtension';
 import { createShare, revokeShare } from '@/api/api-functions';
 import { useMutationFeedback } from '@/hooks/useMutationFeedback';
 import { cn } from '@/lib/utils';
-import { Share, ShareAlbumDialogProps, ShareUrl } from '@/types/Share';
+import { startTunnel, stopTunnel, tunnelStatus } from '@/utils/tunnel';
+import {
+  Share,
+  ShareAlbumDialogProps,
+  ShareMode,
+  ShareUrl,
+} from '@/types/Share';
+
+const MODE_OPTIONS = [
+  { value: 'lan', label: 'This network', icon: Wifi },
+  { value: 'internet', label: 'Internet', icon: Globe },
+] as const satisfies ReadonlyArray<{
+  value: ShareMode;
+  label: string;
+  icon: typeof Wifi;
+}>;
 
 const EXPIRY_OPTIONS = [
   { value: '60', label: 'For 1 hour' },
@@ -41,18 +64,36 @@ export const ShareAlbumDialog: React.FC<ShareAlbumDialogProps> = ({
   onClose,
   onChanged,
 }) => {
+  const [mode, setMode] = useState<ShareMode>('lan');
   const [expiry, setExpiry] = useState<string>('1440');
   const [withPassword, setWithPassword] = useState(false);
   const [password, setPassword] = useState('');
+  // Kept apart from the password field's own validation message so a failed
+  // connection does not put a red border round an unrelated input.
   const [error, setError] = useState('');
+  const [tunnelError, setTunnelError] = useState('');
   const [createdShare, setCreatedShare] = useState<Share | null>(null);
   const [selectedUrl, setSelectedUrl] = useState('');
   const [copied, setCopied] = useState(false);
+  const [tunnelUrl, setTunnelUrl] = useState<string | null>(null);
+  const [isConnecting, setIsConnecting] = useState(false);
 
   // The share this dialog is showing: the one just made, or the newest already
   // running. Older ones stay out of the way until sharing is stopped.
   const activeShare = createdShare ?? shares[0] ?? null;
-  const urls = activeShare?.urls ?? [];
+
+  // A tunnel forwards the whole share port, so its address reaches the same
+  // album as the LAN ones. Showing it alone keeps the link the user asked for
+  // from competing with addresses that only work inside the house.
+  const urls: ShareUrl[] = tunnelUrl
+    ? [
+        {
+          interface: 'Internet',
+          ip: new URL(tunnelUrl).hostname,
+          url: `${tunnelUrl}/s/${activeShare?.token ?? ''}`,
+        },
+      ]
+    : (activeShare?.urls ?? []);
   const shareUrl = urls.find((entry) => entry.url === selectedUrl) ?? urls[0];
 
   // Every token that would still serve this album. Creating leaves earlier
@@ -72,11 +113,32 @@ export const ShareAlbumDialog: React.FC<ShareAlbumDialogProps> = ({
       }),
     // Handled here rather than through the feedback hook so the new share
     // arrives typed rather than as the hook's untyped success payload.
-    onSuccess: (response) => {
-      if (response.data) {
-        setCreatedShare(response.data);
+    onSuccess: async (response) => {
+      const share = response.data;
+      if (!share) {
+        return;
       }
-      onChanged();
+      if (mode === 'lan') {
+        setCreatedShare(share);
+        onChanged();
+        return;
+      }
+
+      setIsConnecting(true);
+      try {
+        setTunnelUrl(await startTunnel(share.port));
+        setCreatedShare(share);
+      } catch (cause) {
+        // The user asked for an internet share and did not get one, so undo
+        // the local half rather than leaving a share they did not ask for.
+        await revokeShare(share.token).catch(() => undefined);
+        setTunnelError(
+          `Could not open a connection: ${String(cause)} The album was not shared.`,
+        );
+      } finally {
+        setIsConnecting(false);
+        onChanged();
+      }
     },
     autoInvalidateTags: ['shares'],
   });
@@ -87,6 +149,12 @@ export const ShareAlbumDialog: React.FC<ShareAlbumDialogProps> = ({
     // react-query hands the mutation function a context as a second argument.
     mutationFn: async (tokens: string[]): Promise<BackendRes<null>> => {
       await Promise.all(tokens.map((token) => revokeShare(token)));
+      if (tunnelUrl) {
+        // One tunnel serves the whole share port, so this closes any other
+        // internet share too. Acceptable while the dialog only ever creates
+        // one at a time, and better than leaving a tunnel to a dead port.
+        await stopTunnel().catch(() => undefined);
+      }
       return { success: true };
     },
     autoInvalidateTags: ['shares'],
@@ -118,14 +186,32 @@ export const ShareAlbumDialog: React.FC<ShareAlbumDialogProps> = ({
     if (!isOpen) {
       return;
     }
+    setMode('lan');
     setExpiry('1440');
     setWithPassword(false);
     setPassword('');
     setError('');
+    setTunnelError('');
     setCreatedShare(null);
     setSelectedUrl('');
     setCopied(false);
+    setIsConnecting(false);
+    // A share made in an earlier session is still served by whatever tunnel is
+    // up, so ask rather than assume it was a LAN share.
+    setTunnelUrl(null);
+    tunnelStatus()
+      .then(setTunnelUrl)
+      .catch(() => undefined);
   }, [isOpen, album?.id]);
+
+  const handleModeChange = (next: ShareMode) => {
+    setMode(next);
+    setError('');
+    setTunnelError('');
+    // Anyone with the link can open it, and messaging apps fetch links to build
+    // previews. Starting protected is the safer default; it stays removable.
+    setWithPassword(next === 'internet');
+  };
 
   const handleCreate = (event: React.FormEvent) => {
     event.preventDefault();
@@ -182,7 +268,26 @@ export const ShareAlbumDialog: React.FC<ShareAlbumDialogProps> = ({
           activeShare ? 'sm:max-w-3xl' : 'sm:max-w-[480px]',
         )}
       >
-        {activeShare ? (
+        {isConnecting ? (
+          <>
+            <DialogHeader>
+              <DialogTitle>Starting a secure connection</DialogTitle>
+              <DialogDescription>
+                Opening a route to this machine so the album can be reached from
+                outside your network.
+              </DialogDescription>
+            </DialogHeader>
+            <div
+              className="flex flex-col items-center justify-center gap-3 py-10"
+              role="status"
+            >
+              <Loader2 className="text-primary h-8 w-8 animate-spin" />
+              <p className="text-muted-foreground text-sm">
+                This usually takes a few seconds.
+              </p>
+            </div>
+          </>
+        ) : activeShare ? (
           <>
             <DialogHeader>
               <DialogTitle>Sharing "{activeShare.album_name}"</DialogTitle>
@@ -306,12 +411,52 @@ export const ShareAlbumDialog: React.FC<ShareAlbumDialogProps> = ({
             <DialogHeader>
               <DialogTitle>Share "{album?.name}"</DialogTitle>
               <DialogDescription>
-                Serve this album to other devices on your network. The photos
-                stay on this machine.
+                {mode === 'lan'
+                  ? 'Serve this album to other devices on your network. The photos stay on this machine.'
+                  : 'Serve this album to anyone with the link, wherever they are.'}
               </DialogDescription>
             </DialogHeader>
 
             <div className="grid gap-4 py-4">
+              {/* Full width, because this is the decision the rest of the form
+                  hangs off rather than one setting among several. */}
+              <div className="bg-muted grid w-full grid-cols-2 gap-1 rounded-lg p-1">
+                {MODE_OPTIONS.map((option) => (
+                  <button
+                    key={option.value}
+                    type="button"
+                    role="radio"
+                    aria-checked={mode === option.value}
+                    onClick={() => handleModeChange(option.value)}
+                    className={cn(
+                      'flex items-center justify-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors',
+                      mode === option.value
+                        ? 'bg-background text-foreground shadow-sm'
+                        : 'text-muted-foreground hover:text-foreground',
+                    )}
+                  >
+                    <option.icon className="h-4 w-4" />
+                    {option.label}
+                  </button>
+                ))}
+              </div>
+
+              {mode === 'internet' && (
+                <div className="border-destructive/40 bg-destructive/5 grid gap-1.5 rounded-md border p-3">
+                  <p className="flex items-center gap-2 text-sm font-medium">
+                    <TriangleAlert className="text-destructive h-4 w-4 shrink-0" />
+                    The link leaves your network
+                  </p>
+                  <p className="text-muted-foreground text-xs">
+                    Photos pass through a tunnel service, which can see them.
+                    Anyone holding the link can open the album, and chat apps
+                    such as WhatsApp and Slack fetch links automatically to
+                    build previews — a password stops those previews seeing
+                    anything.
+                  </p>
+                </div>
+              )}
+
               <div className="grid gap-2">
                 <Label>Keep sharing</Label>
                 <RadioGroup value={expiry} onValueChange={setExpiry}>
@@ -372,6 +517,12 @@ export const ShareAlbumDialog: React.FC<ShareAlbumDialogProps> = ({
                 </div>
               )}
             </div>
+
+            {tunnelError && (
+              <p className="text-destructive pb-2 text-sm" role="alert">
+                {tunnelError}
+              </p>
+            )}
 
             <DialogFooter>
               <Button type="button" variant="outline" onClick={onClose}>

--- a/frontend/src/components/Albums/ShareAlbumDialog.tsx
+++ b/frontend/src/components/Albums/ShareAlbumDialog.tsx
@@ -31,7 +31,7 @@ import { createShare, revokeShare } from '@/api/api-functions';
 import { useMutationFeedback } from '@/hooks/useMutationFeedback';
 import { showInfoDialog } from '@/features/infoDialogSlice';
 import { cn } from '@/lib/utils';
-import { startTunnel, stopTunnel, tunnelStatus } from '@/utils/tunnel';
+import { useShareTunnel } from '@/hooks/useShareTunnel';
 import {
   Share,
   ShareAlbumDialogProps,
@@ -84,8 +84,8 @@ export const ShareAlbumDialog: React.FC<ShareAlbumDialogProps> = ({
   const [createdShare, setCreatedShare] = useState<Share | null>(null);
   const [selectedUrl, setSelectedUrl] = useState('');
   const [copied, setCopied] = useState(false);
-  const [tunnelUrl, setTunnelUrl] = useState<string | null>(null);
-  const [isConnecting, setIsConnecting] = useState(false);
+  const tunnel = useShareTunnel();
+  const { url: tunnelUrl, isConnecting } = tunnel;
 
   // The share this dialog is showing: the one just made, or the newest already
   // running. Older ones stay out of the way until sharing is stopped.
@@ -133,19 +133,25 @@ export const ShareAlbumDialog: React.FC<ShareAlbumDialogProps> = ({
         return;
       }
 
-      setIsConnecting(true);
       try {
-        setTunnelUrl(await startTunnel(share.port));
+        await tunnel.open(share.port);
         setCreatedShare(share);
       } catch (cause) {
         // The user asked for an internet share and did not get one, so undo
         // the local half rather than leaving a share they did not ask for.
-        await revokeShare(share.token).catch(() => undefined);
-        setTunnelError(
-          `Could not open a connection: ${String(cause)} The album was not shared.`,
-        );
+        try {
+          await revokeShare(share.token);
+          setTunnelError(
+            `Could not open a connection: ${String(cause)} The album was not shared.`,
+          );
+        } catch {
+          // Saying "not shared" here would be untrue, and the share is live on
+          // the local network with nothing telling the user so.
+          setTunnelError(
+            `Could not open a connection: ${String(cause)} The album is still being shared on this network — reopen this dialog to stop it.`,
+          );
+        }
       } finally {
-        setIsConnecting(false);
         onChanged();
       }
     },
@@ -158,12 +164,10 @@ export const ShareAlbumDialog: React.FC<ShareAlbumDialogProps> = ({
     // react-query hands the mutation function a context as a second argument.
     mutationFn: async (tokens: string[]): Promise<BackendRes<null>> => {
       await Promise.all(tokens.map((token) => revokeShare(token)));
-      if (tunnelUrl) {
-        // One tunnel serves the whole share port, so this closes any other
-        // internet share too. Acceptable while the dialog only ever creates
-        // one at a time, and better than leaving a tunnel to a dead port.
-        await stopTunnel().catch(() => undefined);
-      }
+      // Closed through the hook, which asks whether one is running rather than
+      // reading state this dialog may not have received yet. A failure here
+      // rejects the mutation, so nothing claims the cleanup finished.
+      await tunnel.close();
       return { success: true };
     },
     autoInvalidateTags: ['shares'],
@@ -181,9 +185,10 @@ export const ShareAlbumDialog: React.FC<ShareAlbumDialogProps> = ({
   useMutationFeedback(revokeShareMutation, {
     loadingMessage: 'Stopping the share...',
     successTitle: 'Sharing stopped',
-    successMessage: 'The album is no longer on the local network.',
+    successMessage: 'The album is no longer being shared.',
     errorTitle: 'Error',
-    errorMessage: 'Could not stop this share. Please try again.',
+    errorMessage:
+      'The share may still be running. Reopen this dialog and try stopping it again.',
     onSuccess: () => {
       onChanged();
       onClose();
@@ -204,14 +209,16 @@ export const ShareAlbumDialog: React.FC<ShareAlbumDialogProps> = ({
     setCreatedShare(null);
     setSelectedUrl('');
     setCopied(false);
-    setIsConnecting(false);
-    // A share made in an earlier session is still served by whatever tunnel is
-    // up, so ask rather than assume it was a LAN share.
-    setTunnelUrl(null);
-    tunnelStatus()
-      .then(setTunnelUrl)
-      .catch(() => undefined);
-  }, [isOpen, album?.id]);
+    // A share made earlier is still served by whatever tunnel is up, so ask
+    // rather than assume it was a local one. The mode follows the answer:
+    // showing an internet link while the help button explains local sharing
+    // would describe the wrong thing.
+    tunnel.refresh().then((current) => {
+      if (current) {
+        setMode('internet');
+      }
+    });
+  }, [isOpen, album?.id, tunnel.refresh]);
 
   const handleModeChange = (next: ShareMode) => {
     setMode(next);
@@ -335,8 +342,9 @@ export const ShareAlbumDialog: React.FC<ShareAlbumDialogProps> = ({
                 {docsButton}
               </div>
               <DialogDescription>
-                Anyone on this network can open the link while PictoPy is
-                running. Nothing is uploaded.
+                {tunnelUrl
+                  ? 'Anyone with this link can open the album while PictoPy is running. It travels through a relay that can see the photos.'
+                  : 'Anyone on this network can open the link while PictoPy is running. Nothing is uploaded.'}
               </DialogDescription>
             </DialogHeader>
 

--- a/frontend/src/components/Albums/ShareAlbumDialog.tsx
+++ b/frontend/src/components/Albums/ShareAlbumDialog.tsx
@@ -148,7 +148,7 @@ export const ShareAlbumDialog: React.FC<ShareAlbumDialogProps> = ({
           // Saying "not shared" here would be untrue, and the share is live on
           // the local network with nothing telling the user so.
           setTunnelError(
-            `Could not open a connection: ${String(cause)} The album is still being shared on this network — reopen this dialog to stop it.`,
+            `Could not open a connection: ${String(cause)} The album is still being shared on this network. Reopen this dialog to stop it.`,
           );
         }
       } finally {
@@ -507,7 +507,7 @@ export const ShareAlbumDialog: React.FC<ShareAlbumDialogProps> = ({
                     Photos pass through a tunnel service, which can see them.
                     Anyone holding the link can open the album, and chat apps
                     such as WhatsApp and Slack fetch links automatically to
-                    build previews — a password stops those previews seeing
+                    build previews, a password stops those previews seeing
                     anything.
                   </p>
                 </div>

--- a/frontend/src/components/Albums/ShareAlbumDialog.tsx
+++ b/frontend/src/components/Albums/ShareAlbumDialog.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { useDispatch } from 'react-redux';
 import { QRCodeSVG } from 'qrcode.react';
 import { openUrl } from '@tauri-apps/plugin-opener';
 import {
@@ -28,6 +29,7 @@ import { Separator } from '@/components/ui/separator';
 import { usePictoMutation, type BackendRes } from '@/hooks/useQueryExtension';
 import { createShare, revokeShare } from '@/api/api-functions';
 import { useMutationFeedback } from '@/hooks/useMutationFeedback';
+import { showInfoDialog } from '@/features/infoDialogSlice';
 import { cn } from '@/lib/utils';
 import { startTunnel, stopTunnel, tunnelStatus } from '@/utils/tunnel';
 import {
@@ -70,6 +72,7 @@ export const ShareAlbumDialog: React.FC<ShareAlbumDialogProps> = ({
   onClose,
   onChanged,
 }) => {
+  const dispatch = useDispatch();
   const [mode, setMode] = useState<ShareMode>('lan');
   const [expiry, setExpiry] = useState<string>('1440');
   const [withPassword, setWithPassword] = useState(false);
@@ -251,11 +254,21 @@ export const ShareAlbumDialog: React.FC<ShareAlbumDialogProps> = ({
       size="icon"
       className="text-muted-foreground hover:text-foreground -mt-1 h-7 w-7 shrink-0"
       aria-label="How sharing works"
-      onClick={() =>
-        openUrl(mode === 'internet' ? DOCS_INTERNET_URL : DOCS_URL).catch(
-          () => undefined,
-        )
-      }
+      onClick={() => {
+        const url = mode === 'internet' ? DOCS_INTERNET_URL : DOCS_URL;
+        // Hand the address over rather than failing quietly: if the browser
+        // cannot be launched there is nothing else to tell the user what
+        // happened, and the page is still readable by other means.
+        openUrl(url).catch(() =>
+          dispatch(
+            showInfoDialog({
+              title: 'Could not open your browser',
+              message: `Open this page instead: ${url}`,
+              variant: 'error',
+            }),
+          ),
+        );
+      }}
     >
       <Info className="h-4 w-4" />
     </Button>

--- a/frontend/src/components/Albums/__tests__/ShareAlbumDialog.test.tsx
+++ b/frontend/src/components/Albums/__tests__/ShareAlbumDialog.test.tsx
@@ -1,6 +1,7 @@
 import userEvent from '@testing-library/user-event';
 import { render, screen, waitFor } from '@/test-utils';
 import { createShare, revokeShare } from '@/api/api-functions';
+import { startTunnel, stopTunnel, tunnelStatus } from '@/utils/tunnel';
 import { Album } from '@/types/Album';
 import { Share } from '@/types/Share';
 import { ShareAlbumDialog } from '../ShareAlbumDialog';
@@ -10,8 +11,19 @@ jest.mock('@/api/api-functions', () => ({
   revokeShare: jest.fn(),
 }));
 
+jest.mock('@/utils/tunnel', () => ({
+  startTunnel: jest.fn(),
+  stopTunnel: jest.fn(),
+  tunnelStatus: jest.fn(),
+}));
+
 const mockCreateShare = createShare as jest.Mock;
 const mockRevokeShare = revokeShare as jest.Mock;
+const mockStartTunnel = startTunnel as jest.Mock;
+const mockStopTunnel = stopTunnel as jest.Mock;
+const mockTunnelStatus = tunnelStatus as jest.Mock;
+
+const internetToggle = () => screen.getByRole('radio', { name: /internet/i });
 
 const album: Album = {
   id: 'a1',
@@ -62,6 +74,95 @@ describe('ShareAlbumDialog', () => {
     jest.clearAllMocks();
     mockCreateShare.mockResolvedValue({ success: true, data: share });
     mockRevokeShare.mockResolvedValue({ success: true });
+    mockStartTunnel.mockResolvedValue('https://abc123.lhr.life');
+    mockStopTunnel.mockResolvedValue(undefined);
+    mockTunnelStatus.mockResolvedValue(null);
+  });
+
+  describe('internet mode', () => {
+    it('shares on the local network unless asked otherwise', async () => {
+      const user = userEvent.setup();
+      renderDialog();
+
+      await user.click(screen.getByRole('button', { name: /start sharing/i }));
+
+      await waitFor(() => expect(mockCreateShare).toHaveBeenCalled());
+      expect(mockStartTunnel).not.toHaveBeenCalled();
+    });
+
+    it('asks for a password by default once the link leaves the network', async () => {
+      const user = userEvent.setup();
+      renderDialog();
+
+      expect(
+        screen.getByRole('switch', { name: /require a password/i }),
+      ).not.toBeChecked();
+
+      await user.click(internetToggle());
+
+      expect(
+        screen.getByRole('switch', { name: /require a password/i }),
+      ).toBeChecked();
+      expect(screen.getByText(/link leaves your network/i)).toBeInTheDocument();
+      expect(
+        screen.getByText(/fetch links automatically/i),
+      ).toBeInTheDocument();
+    });
+
+    it('opens a tunnel and shows only that address', async () => {
+      const user = userEvent.setup();
+      renderDialog();
+
+      await user.click(internetToggle());
+      await user.click(
+        screen.getByRole('switch', { name: /require a password/i }),
+      );
+      await user.click(screen.getByRole('button', { name: /start sharing/i }));
+
+      await waitFor(() => expect(mockStartTunnel).toHaveBeenCalledWith(52125));
+      expect(await screen.findByLabelText('Link')).toHaveValue(
+        'https://abc123.lhr.life/s/tok-1',
+      );
+      // The LAN addresses would only work inside the house, so offering them
+      // alongside the link the user asked for would be misleading.
+      expect(screen.queryByText('192.168.1.5')).not.toBeInTheDocument();
+    });
+
+    it('undoes the share when no tunnel can be opened', async () => {
+      const user = userEvent.setup();
+      mockStartTunnel.mockRejectedValue('no provider answered.');
+      renderDialog();
+
+      await user.click(internetToggle());
+      await user.click(
+        screen.getByRole('switch', { name: /require a password/i }),
+      );
+      await user.click(screen.getByRole('button', { name: /start sharing/i }));
+
+      expect(
+        await screen.findByText(/could not open a connection/i),
+      ).toBeInTheDocument();
+      // Leaving a share the user did not get would be worse than none at all.
+      await waitFor(() =>
+        expect(mockRevokeShare).toHaveBeenCalledWith('tok-1'),
+      );
+      expect(screen.queryByLabelText('Link')).not.toBeInTheDocument();
+    });
+
+    it('closes the tunnel when the share is stopped', async () => {
+      const user = userEvent.setup();
+      mockTunnelStatus.mockResolvedValue('https://abc123.lhr.life');
+      renderDialog([share]);
+
+      await waitFor(() =>
+        expect(screen.getByLabelText('Link')).toHaveValue(
+          'https://abc123.lhr.life/s/tok-1',
+        ),
+      );
+      await user.click(screen.getByRole('button', { name: /stop sharing/i }));
+
+      await waitFor(() => expect(mockStopTunnel).toHaveBeenCalled());
+    });
   });
 
   it('shares without a password by default', async () => {

--- a/frontend/src/components/Albums/__tests__/ShareAlbumDialog.test.tsx
+++ b/frontend/src/components/Albums/__tests__/ShareAlbumDialog.test.tsx
@@ -196,6 +196,69 @@ describe('ShareAlbumDialog', () => {
       );
     });
 
+    it('does not claim the album was withdrawn when undoing it failed', async () => {
+      const user = userEvent.setup();
+      mockStartTunnel.mockRejectedValue('no provider answered.');
+      mockRevokeShare.mockRejectedValue(new Error('backend unreachable'));
+      renderDialog();
+
+      await user.click(internetToggle());
+      await user.click(
+        screen.getByRole('switch', { name: /require a password/i }),
+      );
+      await user.click(screen.getByRole('button', { name: /start sharing/i }));
+
+      // The share is live on the local network; saying otherwise would send the
+      // user away believing nothing is being served.
+      expect(
+        await screen.findByText(/still being shared on this network/i),
+      ).toBeInTheDocument();
+    });
+
+    it('restores internet mode when a tunnel is already running', async () => {
+      const user = userEvent.setup();
+      mockTunnelStatus.mockResolvedValue('https://abc123.lhr.life');
+      renderDialog([share]);
+
+      await waitFor(() =>
+        expect(screen.getByLabelText('Link')).toHaveValue(
+          'https://abc123.lhr.life/s/tok-1',
+        ),
+      );
+      await user.click(
+        screen.getByRole('button', { name: /how sharing works/i }),
+      );
+
+      // Showing an internet link while the help explains local sharing would
+      // describe the wrong thing entirely.
+      expect(mockOpenUrl).toHaveBeenLastCalledWith(
+        'https://aossie-org.github.io/PictoPy/overview/sharing-albums/#internet-mode',
+      );
+    });
+
+    it('reports a tunnel that would not close', async () => {
+      const user = userEvent.setup();
+      mockTunnelStatus.mockResolvedValue('https://abc123.lhr.life');
+      // The wording the Rust command actually produces on a failed kill.
+      mockStopTunnel.mockRejectedValue(
+        new Error(
+          'could not stop the tunnel (ssh pid 900 may still be running): access denied',
+        ),
+      );
+      const { store } = renderDialog([share]);
+
+      await user.click(screen.getByRole('button', { name: /stop sharing/i }));
+
+      // usePictoMutation retries twice with a delay before it reports failure.
+      await waitFor(
+        () => expect(store.getState().infoDialog.variant).toBe('error'),
+        { timeout: 5000 },
+      );
+      expect(store.getState().infoDialog.message).toMatch(
+        /may still be running/i,
+      );
+    });
+
     it('closes the tunnel when the share is stopped', async () => {
       const user = userEvent.setup();
       mockTunnelStatus.mockResolvedValue('https://abc123.lhr.life');

--- a/frontend/src/components/Albums/__tests__/ShareAlbumDialog.test.tsx
+++ b/frontend/src/components/Albums/__tests__/ShareAlbumDialog.test.tsx
@@ -177,6 +177,25 @@ describe('ShareAlbumDialog', () => {
       );
     });
 
+    // Failing quietly would leave nothing on screen and no way to reach the
+    // page, which is how a missing capability presented in the running app.
+    it('hands over the address when the browser cannot be opened', async () => {
+      const user = userEvent.setup();
+      mockOpenUrl.mockRejectedValue(new Error('opener.open_url not allowed'));
+      const { store } = renderDialog();
+
+      await user.click(
+        screen.getByRole('button', { name: /how sharing works/i }),
+      );
+
+      await waitFor(() =>
+        expect(store.getState().infoDialog.isOpen).toBe(true),
+      );
+      expect(store.getState().infoDialog.message).toContain(
+        'https://aossie-org.github.io/PictoPy/overview/sharing-albums/',
+      );
+    });
+
     it('closes the tunnel when the share is stopped', async () => {
       const user = userEvent.setup();
       mockTunnelStatus.mockResolvedValue('https://abc123.lhr.life');

--- a/frontend/src/components/Albums/__tests__/ShareAlbumDialog.test.tsx
+++ b/frontend/src/components/Albums/__tests__/ShareAlbumDialog.test.tsx
@@ -1,5 +1,5 @@
 import userEvent from '@testing-library/user-event';
-import { render, screen, waitFor } from '@/test-utils';
+import { act, render, screen, waitFor } from '@/test-utils';
 import { createShare, revokeShare } from '@/api/api-functions';
 import { openUrl } from '@tauri-apps/plugin-opener';
 import { startTunnel, stopTunnel, tunnelStatus } from '@/utils/tunnel';
@@ -256,6 +256,37 @@ describe('ShareAlbumDialog', () => {
       );
       expect(store.getState().infoDialog.message).toMatch(
         /may still be running/i,
+      );
+    });
+
+    // The status lookup fired on open can resolve after a tunnel has been
+    // opened. Applying its stale answer would drop the address just obtained
+    // and quietly fall back to the local ones.
+    it('keeps a new tunnel when a slow status lookup answers late', async () => {
+      const user = userEvent.setup();
+      let settleStatus: (value: string | null) => void = () => undefined;
+      mockTunnelStatus.mockReturnValueOnce(
+        new Promise<string | null>((resolve) => {
+          settleStatus = resolve;
+        }),
+      );
+      renderDialog();
+
+      await user.click(internetToggle());
+      await user.click(
+        screen.getByRole('switch', { name: /require a password/i }),
+      );
+      await user.click(screen.getByRole('button', { name: /start sharing/i }));
+      await waitFor(() => expect(mockStartTunnel).toHaveBeenCalled());
+
+      await screen.findByLabelText('Link');
+      settleStatus(null);
+      // Flush the stale answer through before asserting, or this passes simply
+      // by looking too early.
+      await act(async () => undefined);
+
+      expect(screen.getByLabelText('Link')).toHaveValue(
+        'https://abc123.lhr.life/s/tok-1',
       );
     });
 

--- a/frontend/src/components/Albums/__tests__/ShareAlbumDialog.test.tsx
+++ b/frontend/src/components/Albums/__tests__/ShareAlbumDialog.test.tsx
@@ -1,6 +1,7 @@
 import userEvent from '@testing-library/user-event';
 import { render, screen, waitFor } from '@/test-utils';
 import { createShare, revokeShare } from '@/api/api-functions';
+import { openUrl } from '@tauri-apps/plugin-opener';
 import { startTunnel, stopTunnel, tunnelStatus } from '@/utils/tunnel';
 import { Album } from '@/types/Album';
 import { Share } from '@/types/Share';
@@ -9,6 +10,10 @@ import { ShareAlbumDialog } from '../ShareAlbumDialog';
 jest.mock('@/api/api-functions', () => ({
   createShare: jest.fn(),
   revokeShare: jest.fn(),
+}));
+
+jest.mock('@tauri-apps/plugin-opener', () => ({
+  openUrl: jest.fn(),
 }));
 
 jest.mock('@/utils/tunnel', () => ({
@@ -22,6 +27,7 @@ const mockRevokeShare = revokeShare as jest.Mock;
 const mockStartTunnel = startTunnel as jest.Mock;
 const mockStopTunnel = stopTunnel as jest.Mock;
 const mockTunnelStatus = tunnelStatus as jest.Mock;
+const mockOpenUrl = openUrl as jest.Mock;
 
 const internetToggle = () => screen.getByRole('radio', { name: /internet/i });
 
@@ -77,6 +83,7 @@ describe('ShareAlbumDialog', () => {
     mockStartTunnel.mockResolvedValue('https://abc123.lhr.life');
     mockStopTunnel.mockResolvedValue(undefined);
     mockTunnelStatus.mockResolvedValue(null);
+    mockOpenUrl.mockResolvedValue(undefined);
   });
 
   describe('internet mode', () => {
@@ -147,6 +154,27 @@ describe('ShareAlbumDialog', () => {
         expect(mockRevokeShare).toHaveBeenCalledWith('tok-1'),
       );
       expect(screen.queryByLabelText('Link')).not.toBeInTheDocument();
+    });
+
+    it('points the help button at whichever mode is selected', async () => {
+      const user = userEvent.setup();
+      renderDialog();
+
+      await user.click(
+        screen.getByRole('button', { name: /how sharing works/i }),
+      );
+      expect(mockOpenUrl).toHaveBeenLastCalledWith(
+        'https://aossie-org.github.io/PictoPy/overview/sharing-albums/',
+      );
+
+      await user.click(internetToggle());
+      await user.click(
+        screen.getByRole('button', { name: /how sharing works/i }),
+      );
+      // Someone weighing up internet mode should land on what it costs.
+      expect(mockOpenUrl).toHaveBeenLastCalledWith(
+        'https://aossie-org.github.io/PictoPy/overview/sharing-albums/#internet-mode',
+      );
     });
 
     it('closes the tunnel when the share is stopped', async () => {

--- a/frontend/src/hooks/__tests__/useShareTunnel.test.ts
+++ b/frontend/src/hooks/__tests__/useShareTunnel.test.ts
@@ -1,0 +1,119 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { startTunnel, stopTunnel, tunnelStatus } from '@/utils/tunnel';
+import { useShareTunnel } from '../useShareTunnel';
+
+jest.mock('@/utils/tunnel', () => ({
+  startTunnel: jest.fn(),
+  stopTunnel: jest.fn(),
+  tunnelStatus: jest.fn(),
+}));
+
+const mockStartTunnel = startTunnel as jest.Mock;
+const mockStopTunnel = stopTunnel as jest.Mock;
+const mockTunnelStatus = tunnelStatus as jest.Mock;
+
+describe('useShareTunnel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockStartTunnel.mockResolvedValue('https://abc123.lhr.life');
+    mockStopTunnel.mockResolvedValue(undefined);
+    mockTunnelStatus.mockResolvedValue(null);
+  });
+
+  it('reports the address it opened', async () => {
+    const { result } = renderHook(() => useShareTunnel());
+
+    await act(async () => {
+      await result.current.open(52125);
+    });
+
+    expect(mockStartTunnel).toHaveBeenCalledWith(52125);
+    expect(result.current.url).toBe('https://abc123.lhr.life');
+  });
+
+  // Stopping while a tunnel is still opening must not leave a live public
+  // address behind once the slow start finally answers.
+  it('closes a tunnel that finished opening after it was stopped', async () => {
+    let settleStart: (value: string) => void = () => undefined;
+    mockStartTunnel.mockReturnValueOnce(
+      new Promise<string>((resolve) => {
+        settleStart = resolve;
+      }),
+    );
+
+    const { result } = renderHook(() => useShareTunnel());
+
+    let opening: Promise<string> = Promise.resolve('');
+    act(() => {
+      opening = result.current.open(52125);
+      opening.catch(() => undefined);
+    });
+
+    await act(async () => {
+      await result.current.close();
+    });
+
+    await act(async () => {
+      settleStart('https://late.lhr.life');
+      await expect(opening).rejects.toThrow(/closed while it was starting/i);
+    });
+
+    expect(result.current.url).toBeNull();
+    // Twice: once for the close, once for the tunnel that arrived too late.
+    expect(mockStopTunnel).toHaveBeenCalledTimes(2);
+  });
+
+  // Asking first would read null while a start is still in flight and skip the
+  // stop, leaving the child the owner already holds.
+  it('asks for a stop without checking whether one is running', async () => {
+    const { result } = renderHook(() => useShareTunnel());
+
+    await act(async () => {
+      await result.current.close();
+    });
+
+    expect(mockStopTunnel).toHaveBeenCalled();
+    expect(mockTunnelStatus).not.toHaveBeenCalled();
+  });
+
+  it('lets a failed stop reach the caller', async () => {
+    mockStopTunnel.mockRejectedValue(
+      new Error('ssh pid 900 may still be running'),
+    );
+    const { result } = renderHook(() => useShareTunnel());
+
+    await act(async () => {
+      await expect(result.current.close()).rejects.toThrow(
+        /may still be running/i,
+      );
+    });
+  });
+
+  it('ignores a status lookup that answers after a tunnel was opened', async () => {
+    let settleStatus: (value: string | null) => void = () => undefined;
+    mockTunnelStatus.mockReturnValueOnce(
+      new Promise<string | null>((resolve) => {
+        settleStatus = resolve;
+      }),
+    );
+
+    const { result } = renderHook(() => useShareTunnel());
+
+    let refreshing: Promise<string | null> = Promise.resolve(null);
+    act(() => {
+      refreshing = result.current.refresh();
+    });
+    await act(async () => {
+      await result.current.open(52125);
+    });
+
+    await act(async () => {
+      settleStatus(null);
+      await refreshing;
+    });
+
+    await waitFor(() =>
+      expect(result.current.url).toBe('https://abc123.lhr.life'),
+    );
+  });
+});

--- a/frontend/src/hooks/useShareTunnel.ts
+++ b/frontend/src/hooks/useShareTunnel.ts
@@ -39,9 +39,16 @@ export const useShareTunnel = (): ShareTunnel => {
   const open = useCallback(
     async (port: number): Promise<string> => {
       revision.current += 1;
+      const startedAt = revision.current;
       setIsConnecting(true);
       try {
         const opened = await startTunnel(port);
+        if (revision.current !== startedAt) {
+          // A close landed while this was starting. Honour it rather than
+          // handing back a live public address nobody asked to keep.
+          await stopTunnel().catch(() => undefined);
+          throw new Error('The connection was closed while it was starting.');
+        }
         apply(opened);
         return opened;
       } finally {
@@ -53,14 +60,10 @@ export const useShareTunnel = (): ShareTunnel => {
 
   const close = useCallback(async (): Promise<void> => {
     revision.current += 1;
-    // Asked fresh instead of read from state above. If the lookup itself
-    // fails, attempt the stop anyway: leaving a tunnel up is the worse of the
-    // two mistakes.
-    const current = await tunnelStatus().catch(() => 'unknown');
-    if (current === null) {
-      apply(null);
-      return;
-    }
+    // Asked for unconditionally rather than only when something is known to be
+    // running: a start still in flight has a child the owner can already kill,
+    // and asking first would read null and skip the stop entirely. Stopping
+    // when nothing is open is a no-op.
     await stopTunnel();
     apply(null);
   }, [apply]);

--- a/frontend/src/hooks/useShareTunnel.ts
+++ b/frontend/src/hooks/useShareTunnel.ts
@@ -1,0 +1,53 @@
+import { useCallback, useState } from 'react';
+import { startTunnel, stopTunnel, tunnelStatus } from '@/utils/tunnel';
+
+/**
+ * The tunnel that makes the share server reachable off the LAN.
+ *
+ * One tunnel forwards the whole share port, so it belongs to the application
+ * rather than to any one album. This owns the view of it, and deliberately
+ * asks the Rust side rather than trusting what a dialog last saw: a share can
+ * be stopped before the first status lookup has even resolved.
+ */
+export const useShareTunnel = () => {
+  const [url, setUrl] = useState<string | null>(null);
+  const [isConnecting, setIsConnecting] = useState(false);
+
+  /** The tunnel's current address, or null. Never throws. */
+  const refresh = useCallback(async (): Promise<string | null> => {
+    const current = await tunnelStatus().catch(() => null);
+    setUrl(current);
+    return current;
+  }, []);
+
+  /** Open a tunnel to the share port. Rejects if no provider answers. */
+  const open = useCallback(async (port: number): Promise<string> => {
+    setIsConnecting(true);
+    try {
+      const opened = await startTunnel(port);
+      setUrl(opened);
+      return opened;
+    } finally {
+      setIsConnecting(false);
+    }
+  }, []);
+
+  /**
+   * Close the tunnel if one is running. Rejects if it could not be closed, so
+   * the caller can say so rather than reporting a cleanup that did not happen.
+   */
+  const close = useCallback(async (): Promise<void> => {
+    // Asked fresh instead of read from state above. If the lookup itself
+    // fails, attempt the stop anyway: leaving a tunnel up is the worse of the
+    // two mistakes.
+    const current = await tunnelStatus().catch(() => 'unknown');
+    if (current === null) {
+      setUrl(null);
+      return;
+    }
+    await stopTunnel();
+    setUrl(null);
+  }, []);
+
+  return { url, isConnecting, refresh, open, close };
+};

--- a/frontend/src/hooks/useShareTunnel.ts
+++ b/frontend/src/hooks/useShareTunnel.ts
@@ -1,5 +1,6 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { startTunnel, stopTunnel, tunnelStatus } from '@/utils/tunnel';
+import { ShareTunnel } from '@/types/Share';
 
 /**
  * The tunnel that makes the share server reachable off the LAN.
@@ -9,45 +10,60 @@ import { startTunnel, stopTunnel, tunnelStatus } from '@/utils/tunnel';
  * asks the Rust side rather than trusting what a dialog last saw: a share can
  * be stopped before the first status lookup has even resolved.
  */
-export const useShareTunnel = () => {
+export const useShareTunnel = (): ShareTunnel => {
   const [url, setUrl] = useState<string | null>(null);
   const [isConnecting, setIsConnecting] = useState(false);
 
-  /** The tunnel's current address, or null. Never throws. */
+  // Bumped whenever a tunnel is opened or closed. A status lookup started
+  // before one of those is describing a tunnel that has since been replaced,
+  // and applying its answer would wipe an address just obtained.
+  const revision = useRef(0);
+  const latest = useRef<string | null>(null);
+
+  const apply = useCallback((value: string | null) => {
+    latest.current = value;
+    setUrl(value);
+  }, []);
+
   const refresh = useCallback(async (): Promise<string | null> => {
+    const startedAt = revision.current;
     const current = await tunnelStatus().catch(() => null);
-    setUrl(current);
-    return current;
-  }, []);
-
-  /** Open a tunnel to the share port. Rejects if no provider answers. */
-  const open = useCallback(async (port: number): Promise<string> => {
-    setIsConnecting(true);
-    try {
-      const opened = await startTunnel(port);
-      setUrl(opened);
-      return opened;
-    } finally {
-      setIsConnecting(false);
+    if (revision.current !== startedAt) {
+      // Something newer finished while this was in flight; it knows better.
+      return latest.current;
     }
-  }, []);
+    apply(current);
+    return current;
+  }, [apply]);
 
-  /**
-   * Close the tunnel if one is running. Rejects if it could not be closed, so
-   * the caller can say so rather than reporting a cleanup that did not happen.
-   */
+  const open = useCallback(
+    async (port: number): Promise<string> => {
+      revision.current += 1;
+      setIsConnecting(true);
+      try {
+        const opened = await startTunnel(port);
+        apply(opened);
+        return opened;
+      } finally {
+        setIsConnecting(false);
+      }
+    },
+    [apply],
+  );
+
   const close = useCallback(async (): Promise<void> => {
+    revision.current += 1;
     // Asked fresh instead of read from state above. If the lookup itself
     // fails, attempt the stop anyway: leaving a tunnel up is the worse of the
     // two mistakes.
     const current = await tunnelStatus().catch(() => 'unknown');
     if (current === null) {
-      setUrl(null);
+      apply(null);
       return;
     }
     await stopTunnel();
-    setUrl(null);
-  }, []);
+    apply(null);
+  }, [apply]);
 
   return { url, isConnecting, refresh, open, close };
 };

--- a/frontend/src/pages/__tests__/Album.test.tsx
+++ b/frontend/src/pages/__tests__/Album.test.tsx
@@ -295,7 +295,11 @@ describe('Albums page', () => {
     await screen.findByText('Trip');
     await openDeleteConfirmation(user);
 
-    const errorDialog = await screen.findByRole('dialog');
+    // usePictoMutation retries twice with a 500ms backoff before it reports
+    // failure, which is already past findBy's default one second wait.
+    const errorDialog = await screen.findByRole('dialog', undefined, {
+      timeout: 5000,
+    });
     expect(within(errorDialog).getByText('Error')).toBeInTheDocument();
 
     // Only the error dialog may be open — the confirmation must not still be

--- a/frontend/src/types/Share.ts
+++ b/frontend/src/types/Share.ts
@@ -20,6 +20,12 @@ export interface Share {
   urls: ShareUrl[];
 }
 
+/**
+ * Where a share can be reached from. LAN keeps everything on the local network;
+ * internet opens a tunnel, which means the photos pass through a third party.
+ */
+export type ShareMode = 'lan' | 'internet';
+
 export interface CreateShareRequest {
   /** Omitted means the share lasts until it is revoked or PictoPy closes. */
   expires_in_minutes?: number;

--- a/frontend/src/types/Share.ts
+++ b/frontend/src/types/Share.ts
@@ -32,6 +32,19 @@ export interface CreateShareRequest {
   password?: string;
 }
 
+/** The view of the tunnel that `useShareTunnel` hands its caller. */
+export interface ShareTunnel {
+  /** The public address, or null when no tunnel is running. */
+  url: string | null;
+  isConnecting: boolean;
+  /** Ask the owner what is running. Never throws. */
+  refresh: () => Promise<string | null>;
+  /** Open a tunnel to the share port. Rejects if no provider answers. */
+  open: (port: number) => Promise<string>;
+  /** Close any running tunnel. Rejects if it could not be closed. */
+  close: () => Promise<void>;
+}
+
 export interface ShareAlbumDialogProps {
   album: Album | null;
   /**

--- a/frontend/src/utils/tunnel.ts
+++ b/frontend/src/utils/tunnel.ts
@@ -1,0 +1,19 @@
+import { invoke } from '@tauri-apps/api/core';
+
+/**
+ * The SSH reverse tunnel that makes the share server reachable off the LAN.
+ *
+ * One tunnel forwards the whole share port, so it serves every share rather
+ * than one album. It is owned by the Rust side, which closes it when PictoPy
+ * exits so an album is never left reachable from the internet.
+ */
+
+/** Open a tunnel to the share port, or return the URL of the one already up. */
+export const startTunnel = (port: number): Promise<string> =>
+  invoke<string>('tunnel_start', { port });
+
+export const stopTunnel = (): Promise<void> => invoke<void>('tunnel_stop');
+
+/** The public URL if a tunnel is running, null once it has gone away. */
+export const tunnelStatus = (): Promise<string | null> =>
+  invoke<string | null>('tunnel_status');

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,6 +67,7 @@ nav:
   - Overview:
       - Features: overview/features.md
       - Architecture: overview/architecture.md
+      - Sharing Albums: overview/sharing-albums.md
 
   - Setup:
       - Overview: setup.md
@@ -82,6 +83,7 @@ nav:
       - Python Backend Directory Structure: backend/backend_python/directory-structure.md
       - Python Backend Image Processing: backend/backend_python/image-processing.md
       - Python Backend Semantic Search: backend/backend_python/semantic-search.md
+      - Python Backend Album Sharing: backend/backend_python/album-sharing.md
       - Rust Backend API: backend/backend_rust/api.md
 
   - Frontend:


### PR DESCRIPTION
Closes #1477

Adds a second mode to the share dialog, chosen while creating a share, that makes an album reachable from outside the local network. Local sharing only works when both people are on the same Wi-Fi, and it fails outright on networks that block their own devices from reaching each other, which is most guest Wi-Fi and some home routers.

## Approach

The route is an SSH reverse tunnel opened with the system `ssh` client, which every desktop platform already ships. Nothing is bundled and nothing is downloaded, so the installer does not grow and there is no third-party binary to pin. The tunnel forwards the share port, and since the share server already binds to all interfaces and serves `/s/{token}`, the backend needs no changes at all; tokens, passwords and expiry behave identically in both modes.

The child process is owned by the Tauri side and closed from the window handler, the tray quit item, and when the share is stopped. An orphaned tunnel would leave an album reachable from the internet, which is worse than the orphaned local listener the backend already guards against. It is killed through its handle rather than by matching process names, because matching on `ssh` would take down the user's own unrelated sessions.

The assigned URL is read from the provider's output by host suffix rather than by the wording around it, because the banner it prints first contains several unrelated links. Output keeps being drained afterwards, since the provider also emits a QR code and a full pipe would stall `ssh`.

## What it costs, and how that is handled

The relay terminates TLS, so it handles photos in readable form as they pass. Internet mode is therefore opt-in per share and never the default, the dialog states the trade-off rather than implying the link is private, and an information button links to the documentation.

Password protection is switched on by default in this mode. It stays removable, but chat applications fetch links to build previews without anyone opening them, and the unlock page is what stops those previews seeing the album. A failed connection undoes the share rather than leaving one the user did not ask for.

## Not included

Reaching a share through router port forwarding is deliberately out of scope. The host cannot confirm that a port is reachable without something outside trying it, so any such indicator would be a guess.

## Testing

Eleven new tests: four in Rust covering the URL parsing against real captured provider output, and seven in the dialog covering the mode toggle, the tunnel lifecycle, the rollback on failure and the documentation link. Full suites at 368 frontend tests and 4 Rust tests passing.

The tunnel transport itself was verified by hand on a network where local sharing provably fails, returning 200 through the public URL with the request arriving locally. The dialog flow has been exercised in the running application only as far as the documentation link; creating an internet share from the app and opening it from outside the network still wants a manual pass before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Internet sharing for albums alongside local-network sharing.
  - Displays public sharing links, connection progress, and tunnel status.
  - Automatically cleans up sharing when tunnel setup fails or sharing stops.
  - Added helpful links and troubleshooting guidance.

- **Documentation**
  - Added user and developer documentation covering album sharing, privacy, connectivity, passwords, and troubleshooting.
  - Updated documentation navigation.

- **Bug Fixes**
  - Improved handling of tunnel failures, application shutdown, and help-link fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->