### PR TITLE
fix: skip unchanged files when rescanning a folder

### DIFF
--- a/backend/app/database/images.py
+++ b/backend/app/database/images.py
@@ -1,4 +1,5 @@
 # Standard library imports
+import os
 import sqlite3
 from typing import Any, Dict, List, Mapping, Tuple, TypedDict, Union, Optional
 import json
@@ -50,6 +51,14 @@ class UntaggedImageRecord(TypedDict):
     folder_id: FolderId
     thumbnailPath: str
     metadata: Mapping[str, Any]
+
+
+class ImageSyncState(TypedDict):
+    """What a rescan needs in order to tell an unchanged file from a new one."""
+
+    thumbnailPath: Optional[str]
+    file_size: Optional[int]
+    file_mtime: Optional[int]
 
 
 ImageClassPair = Tuple[ImageId, ClassId]
@@ -462,6 +471,69 @@ def db_get_images_by_folder_ids(
     except sqlite3.Error as e:
         logger.error(f"Error getting images by folder IDs: {e}")
         return []
+    finally:
+        conn.close()
+
+
+def _as_int(value: Any) -> Optional[int]:
+    """A metadata blob is whatever a past scan wrote; non-numeric means unknown."""
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def db_get_image_sync_state_by_folder_ids(
+    folder_ids: List[FolderId],
+) -> Dict[ImagePath, ImageSyncState]:
+    """
+    Map stored image paths to the size and mtime recorded when each was last read.
+
+    Keyed by normcased absolute path, because the caller matches against paths it
+    just walked off disk and Windows hands back inconsistent casing.
+    """
+    if not folder_ids:
+        return {}
+
+    conn = _connect()
+    cursor = conn.cursor()
+    state: Dict[ImagePath, ImageSyncState] = {}
+
+    try:
+        placeholders = ",".join("?" for _ in folder_ids)
+        cursor.execute(
+            f"""
+            SELECT path, thumbnailPath, metadata
+            FROM images
+            WHERE folder_id IN ({placeholders})
+            """,
+            folder_ids,
+        )
+
+        for path, thumbnail_path, metadata in cursor.fetchall():
+            if not path:
+                continue
+
+            parsed: Mapping[str, Any] = {}
+            if metadata:
+                try:
+                    loaded = json.loads(metadata)
+                    if isinstance(loaded, dict):
+                        parsed = loaded
+                except (json.JSONDecodeError, TypeError):
+                    # An unreadable blob just means this row gets re-read.
+                    pass
+
+            state[os.path.normcase(os.path.abspath(path))] = ImageSyncState(
+                thumbnailPath=thumbnail_path,
+                file_size=_as_int(parsed.get("file_size")),
+                file_mtime=_as_int(parsed.get("file_mtime")),
+            )
+
+        return state
+    except sqlite3.Error as e:
+        logger.error(f"Error getting image sync state by folder IDs: {e}")
+        return {}
     finally:
         conn.close()
 

--- a/backend/app/database/images.py
+++ b/backend/app/database/images.py
@@ -479,7 +479,10 @@ def _as_int(value: Any) -> Optional[int]:
     """A metadata blob is whatever a past scan wrote; non-numeric means unknown."""
     try:
         return int(value)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
+        # OverflowError is not a ValueError: JSON reads 1e309 as inf, and this
+        # query runs once for every folder, so letting it escape would abort the
+        # whole scan rather than one file.
         return None
 
 

--- a/backend/app/utils/images.py
+++ b/backend/app/utils/images.py
@@ -11,10 +11,12 @@ from pathlib import Path
 
 from app.config.settings import THUMBNAIL_IMAGES_PATH
 from app.database.images import (
+    ImageSyncState,
     db_bulk_insert_images,
     db_get_untagged_images,
     db_update_image_tagged_status,
     db_insert_image_classes_batch,
+    db_get_image_sync_state_by_folder_ids,
     db_get_images_by_folder_ids,
     db_delete_images_by_ids,
 )
@@ -55,6 +57,13 @@ def image_util_process_folder_images(folder_data: List[Tuple[str, int, bool]]) -
         all_image_records = []
         all_folder_ids = []
 
+        # One query up front. The watcher calls sync-folder on any file change,
+        # so this walk reruns constantly over folders that are almost entirely
+        # unchanged, and rereading each file is the expensive part.
+        known_state = db_get_image_sync_state_by_folder_ids(
+            [folder_id for _, folder_id, _ in folder_data]
+        )
+
         # Process each folder in the provided data
         for folder_path, folder_id, recursive in folder_data:
             try:
@@ -72,7 +81,7 @@ def image_util_process_folder_images(folder_data: List[Tuple[str, int, bool]]) -
 
                 # Step 3: Prepare image records for this folder
                 folder_image_records = image_util_prepare_image_records(
-                    image_files, folder_path_to_id
+                    image_files, folder_path_to_id, known_state
                 )
                 all_image_records.extend(folder_image_records)
 
@@ -239,8 +248,46 @@ def image_util_classify_and_face_detect_images(
     return total_faces_skipped
 
 
+def image_util_is_unchanged(
+    image_path: str, recorded: Optional[ImageSyncState]
+) -> bool:
+    """
+    True when the file and its thumbnail both match what the last scan recorded.
+
+    A row written before file_mtime was tracked has no mtime to compare, so it
+    gets reread once and carries the field from then on.
+    """
+    if not recorded:
+        return False
+
+    recorded_size = recorded.get("file_size")
+    recorded_mtime = recorded.get("file_mtime")
+    if recorded_size is None or recorded_mtime is None:
+        return False
+
+    try:
+        stats = os.stat(image_path)
+    except OSError:
+        return False
+
+    if stats.st_size != recorded_size or int(stats.st_mtime) != recorded_mtime:
+        return False
+
+    # Skipping the file means keeping its existing thumbnail, so that thumbnail
+    # has to still be there. Zero bytes is a half-written one, not a usable one.
+    thumbnail_path = recorded.get("thumbnailPath")
+    if not thumbnail_path:
+        return False
+    try:
+        return os.path.getsize(thumbnail_path) > 0
+    except OSError:
+        return False
+
+
 def image_util_prepare_image_records(
-    image_files: List[str], folder_path_to_id: Dict[str, int]
+    image_files: List[str],
+    folder_path_to_id: Dict[str, int],
+    known_state: Optional[Dict[str, ImageSyncState]] = None,
 ) -> List[Dict]:
     """
     Prepare image records with thumbnails for database insertion.
@@ -249,18 +296,27 @@ def image_util_prepare_image_records(
     Args:
         image_files: List of image file paths
         folder_path_to_id: Dictionary mapping folder paths to IDs
+        known_state: Size/mtime recorded for already-stored paths. Files matching
+            it are left alone; omit to reread every file.
 
     Returns:
         List of image record dictionaries ready for database insertion
     """
     image_records = []
     extractor = MetadataExtractor()
+    known_state = known_state or {}
+    skipped = 0
 
     for image_path in image_files:
         folder_id = image_util_find_folder_id_for_image(image_path, folder_path_to_id)
 
         if not folder_id:
             continue  # Skip if no matching folder ID found
+
+        recorded = known_state.get(os.path.normcase(os.path.abspath(image_path)))
+        if image_util_is_unchanged(image_path, recorded):
+            skipped += 1
+            continue
 
         image_id = str(uuid.uuid4())
         thumbnail_name = f"thumbnail_{image_id}.jpg"
@@ -317,6 +373,9 @@ def image_util_prepare_image_records(
             }
 
             image_records.append(image_record)
+
+    if skipped:
+        logger.info(f"Skipped {skipped} unchanged image(s) during rescan")
 
     return image_records
 
@@ -597,6 +656,7 @@ def image_util_extract_metadata(image_path: str) -> dict:
             "height": 0,
             "file_location": image_path,
             "file_size": 0,
+            "file_mtime": 0,
             "item_type": "unknown",
         }
 
@@ -662,6 +722,10 @@ def image_util_extract_metadata(image_path: str) -> dict:
                 "height": height,
                 "file_location": image_path,
                 "file_size": stats.st_size,
+                # Whole seconds: external drives are often FAT/exFAT, whose
+                # coarser mtime would otherwise never compare equal to its own
+                # float from a previous scan.
+                "file_mtime": int(stats.st_mtime),
                 "item_type": mime_type,
             }
 
@@ -681,6 +745,7 @@ def image_util_extract_metadata(image_path: str) -> dict:
                 "date_source": DATE_SOURCE_FILESYSTEM,
                 "file_location": image_path,
                 "file_size": stats.st_size,
+                "file_mtime": int(stats.st_mtime),
                 "width": 0,
                 "height": 0,
                 "item_type": "unknown",
@@ -695,6 +760,7 @@ def image_util_extract_metadata(image_path: str) -> dict:
             "height": 0,
             "file_location": image_path,
             "file_size": 0,
+            "file_mtime": 0,
             "item_type": "unknown",
         }
 

--- a/backend/tests/test_images_rescan.py
+++ b/backend/tests/test_images_rescan.py
@@ -260,6 +260,33 @@ class TestSyncStateQuery:
             "file_mtime": 1700000000,
         }
 
+    def test_a_non_finite_size_does_not_abort_the_scan(self, folder, tmp_path):
+        """JSON reads 1e309 as inf, and int(inf) raises outside the ValueError family."""
+        path = str(tmp_path / "a.jpg")
+        db_bulk_insert_images(
+            [
+                {
+                    "id": "img-1",
+                    "path": path,
+                    "folder_id": folder,
+                    "thumbnailPath": "/thumbs/img-1.jpg",
+                    "metadata": '{"file_size": 1e309, "file_mtime": 1e309}',
+                    "isTagged": False,
+                    "isEmbedded": False,
+                    "latitude": None,
+                    "longitude": None,
+                    "captured_at": None,
+                }
+            ]
+        )
+
+        recorded = db_get_image_sync_state_by_folder_ids([folder])[
+            os.path.normcase(os.path.abspath(path))
+        ]
+
+        assert recorded["file_size"] is None
+        assert recorded["file_mtime"] is None
+
     def test_an_unreadable_blob_leaves_the_file_looking_changed(self, folder, tmp_path):
         path = str(tmp_path / "a.jpg")
         db_bulk_insert_images(

--- a/backend/tests/test_images_rescan.py
+++ b/backend/tests/test_images_rescan.py
@@ -1,0 +1,378 @@
+"""
+The watcher calls sync-folder on any file change, so the folder walk reruns
+constantly over folders that are almost entirely unchanged. These cover the
+check that keeps it from rereading and re-thumbnailing every file each time.
+"""
+
+import json
+import os
+import sqlite3
+import tempfile
+from typing import Any, Dict, Iterator, List
+
+import pytest
+from PIL import Image
+
+from app.database.folders import db_create_folders_table
+from app.database.images import (
+    db_bulk_insert_images,
+    db_create_images_table,
+    db_get_image_sync_state_by_folder_ids,
+)
+from app.database.yolo_mapping import db_create_YOLO_classes_table
+from app.utils.images import (
+    image_util_extract_metadata,
+    image_util_generate_thumbnail,
+    image_util_is_unchanged,
+    image_util_prepare_image_records,
+    image_util_process_folder_images,
+)
+
+
+@pytest.fixture(scope="function")
+def test_db(monkeypatch: pytest.MonkeyPatch) -> Iterator[str]:
+    """Point the image/folder DB modules at a fresh tempfile database."""
+    db_fd, db_path = tempfile.mkstemp()
+    os.close(db_fd)
+
+    monkeypatch.setattr("app.config.settings.DATABASE_PATH", db_path)
+    monkeypatch.setattr("app.database.images.DATABASE_PATH", db_path)
+    monkeypatch.setattr("app.database.folders.DATABASE_PATH", db_path)
+    monkeypatch.setattr("app.database.yolo_mapping.DATABASE_PATH", db_path)
+
+    db_create_YOLO_classes_table()  # mappings (image_classes FK target)
+    db_create_folders_table()  # folders (images.folder_id FK target)
+    db_create_images_table()
+
+    yield db_path
+
+    os.unlink(db_path)
+
+
+@pytest.fixture
+def folder(test_db: str) -> str:
+    """Insert a folder row to satisfy the images.folder_id FK."""
+    conn = sqlite3.connect(test_db)
+    conn.execute(
+        "INSERT INTO folders (folder_id, folder_path, last_modified_time, AI_Tagging) "
+        "VALUES (?, ?, 0, 1)",
+        ("folder-1", "/photos"),
+    )
+    conn.commit()
+    conn.close()
+    return "folder-1"
+
+
+def _photo(path, colour=(10, 20, 30)) -> str:
+    """Write a real JPEG; the walk opens and verifies every candidate file."""
+    Image.new("RGB", (8, 8), colour).save(path, "JPEG")
+    return str(path)
+
+
+def _thumbnail(path) -> str:
+    Image.new("RGB", (4, 4), "white").save(path, "JPEG")
+    return str(path)
+
+
+def _state(photo: str, thumbnail: str, **overrides: Any) -> Dict[str, Any]:
+    """The sync state a previous scan would have recorded for an untouched file."""
+    stats = os.stat(photo)
+    recorded: Dict[str, Any] = {
+        "thumbnailPath": thumbnail,
+        "file_size": stats.st_size,
+        "file_mtime": int(stats.st_mtime),
+    }
+    recorded.update(overrides)
+    return recorded
+
+
+class TestIsUnchanged:
+    def test_matching_size_and_mtime_is_unchanged(self, tmp_path):
+        photo = _photo(tmp_path / "a.jpg")
+        thumb = _thumbnail(tmp_path / "thumb.jpg")
+        assert image_util_is_unchanged(photo, _state(photo, thumb)) is True
+
+    def test_a_rewritten_file_is_changed(self, tmp_path):
+        photo = _photo(tmp_path / "a.jpg")
+        thumb = _thumbnail(tmp_path / "thumb.jpg")
+        recorded = _state(photo, thumb)
+
+        os.utime(photo, (0, 0))
+
+        assert image_util_is_unchanged(photo, recorded) is False
+
+    def test_a_resized_file_is_changed(self, tmp_path):
+        photo = _photo(tmp_path / "a.jpg")
+        thumb = _thumbnail(tmp_path / "thumb.jpg")
+        recorded = _state(photo, thumb, file_size=999999)
+        assert image_util_is_unchanged(photo, recorded) is False
+
+    def test_a_missing_thumbnail_forces_a_reread(self, tmp_path):
+        """Skipping means keeping the old thumbnail, so it has to still exist."""
+        photo = _photo(tmp_path / "a.jpg")
+        recorded = _state(photo, str(tmp_path / "gone.jpg"))
+        assert image_util_is_unchanged(photo, recorded) is False
+
+    def test_a_half_written_thumbnail_forces_a_reread(self, tmp_path):
+        photo = _photo(tmp_path / "a.jpg")
+        truncated = tmp_path / "thumb.jpg"
+        truncated.write_bytes(b"")
+        assert image_util_is_unchanged(photo, _state(photo, str(truncated))) is False
+
+    def test_a_row_predating_mtime_tracking_is_reread(self, tmp_path):
+        """Shipped databases have file_size but no file_mtime; reread them once."""
+        photo = _photo(tmp_path / "a.jpg")
+        thumb = _thumbnail(tmp_path / "thumb.jpg")
+        assert (
+            image_util_is_unchanged(photo, _state(photo, thumb, file_mtime=None))
+            is False
+        )
+
+    def test_an_unknown_path_is_changed(self, tmp_path):
+        assert image_util_is_unchanged(str(tmp_path / "a.jpg"), None) is False
+
+    def test_a_file_that_vanished_is_changed(self, tmp_path):
+        photo = _photo(tmp_path / "a.jpg")
+        thumb = _thumbnail(tmp_path / "thumb.jpg")
+        recorded = _state(photo, thumb)
+        os.unlink(photo)
+        assert image_util_is_unchanged(photo, recorded) is False
+
+
+class TestPrepareImageRecordsSkips:
+    """Regenerating a thumbnail per file is the cost this avoids."""
+
+    @pytest.fixture
+    def thumbnail_dir(self, tmp_path, monkeypatch) -> str:
+        target = tmp_path / "thumbs"
+        target.mkdir()
+        monkeypatch.setattr("app.utils.images.THUMBNAIL_IMAGES_PATH", str(target))
+        return str(target)
+
+    @pytest.fixture
+    def counted_thumbnails(self, monkeypatch) -> List[str]:
+        """Record every file the run actually regenerated a thumbnail for."""
+        generated: List[str] = []
+
+        def spy(image_path: str, thumbnail_path: str, *args, **kwargs):
+            generated.append(image_path)
+            return image_util_generate_thumbnail(
+                image_path, thumbnail_path, *args, **kwargs
+            )
+
+        monkeypatch.setattr("app.utils.images.image_util_generate_thumbnail", spy)
+        return generated
+
+    def test_an_unchanged_file_produces_no_record_and_no_thumbnail(
+        self, tmp_path, thumbnail_dir, counted_thumbnails
+    ):
+        photo = _photo(tmp_path / "a.jpg")
+        thumb = _thumbnail(tmp_path / "existing.jpg")
+        known = {os.path.normcase(os.path.abspath(photo)): _state(photo, thumb)}
+
+        records = image_util_prepare_image_records(
+            [photo], {str(tmp_path): "folder-1"}, known
+        )
+
+        assert records == []
+        assert counted_thumbnails == []
+
+    def test_a_changed_file_is_still_processed(
+        self, tmp_path, thumbnail_dir, counted_thumbnails
+    ):
+        photo = _photo(tmp_path / "a.jpg")
+        thumb = _thumbnail(tmp_path / "existing.jpg")
+        known = {
+            os.path.normcase(os.path.abspath(photo)): _state(
+                photo, thumb, file_size=12345
+            )
+        }
+
+        records = image_util_prepare_image_records(
+            [photo], {str(tmp_path): "folder-1"}, known
+        )
+
+        assert len(records) == 1
+        assert counted_thumbnails == [photo]
+
+    def test_only_the_changed_file_is_reread(
+        self, tmp_path, thumbnail_dir, counted_thumbnails
+    ):
+        stale = _photo(tmp_path / "stale.jpg", (1, 2, 3))
+        fresh = _photo(tmp_path / "fresh.jpg", (4, 5, 6))
+        thumb = _thumbnail(tmp_path / "existing.jpg")
+        known = {
+            os.path.normcase(os.path.abspath(stale)): _state(stale, thumb),
+            os.path.normcase(os.path.abspath(fresh)): _state(
+                fresh, thumb, file_mtime=0
+            ),
+        }
+
+        records = image_util_prepare_image_records(
+            [stale, fresh], {str(tmp_path): "folder-1"}, known
+        )
+
+        assert [record["path"] for record in records] == [fresh]
+        assert counted_thumbnails == [fresh]
+
+    def test_without_known_state_every_file_is_processed(
+        self, tmp_path, thumbnail_dir, counted_thumbnails
+    ):
+        """The default has to stay a full reread, since other callers rely on it."""
+        photo = _photo(tmp_path / "a.jpg")
+
+        records = image_util_prepare_image_records([photo], {str(tmp_path): "folder-1"})
+
+        assert len(records) == 1
+        assert counted_thumbnails == [photo]
+
+
+class TestSyncStateQuery:
+    def test_no_folders_queries_nothing(self, test_db):
+        assert db_get_image_sync_state_by_folder_ids([]) == {}
+
+    def test_size_and_mtime_come_back_off_the_metadata_blob(self, folder, tmp_path):
+        path = str(tmp_path / "a.jpg")
+        db_bulk_insert_images(
+            [
+                {
+                    "id": "img-1",
+                    "path": path,
+                    "folder_id": folder,
+                    "thumbnailPath": "/thumbs/img-1.jpg",
+                    "metadata": json.dumps(
+                        {"file_size": 4096, "file_mtime": 1700000000}
+                    ),
+                    "isTagged": False,
+                    "isEmbedded": False,
+                    "latitude": None,
+                    "longitude": None,
+                    "captured_at": None,
+                }
+            ]
+        )
+
+        state = db_get_image_sync_state_by_folder_ids([folder])
+
+        assert state[os.path.normcase(os.path.abspath(path))] == {
+            "thumbnailPath": "/thumbs/img-1.jpg",
+            "file_size": 4096,
+            "file_mtime": 1700000000,
+        }
+
+    def test_an_unreadable_blob_leaves_the_file_looking_changed(self, folder, tmp_path):
+        path = str(tmp_path / "a.jpg")
+        db_bulk_insert_images(
+            [
+                {
+                    "id": "img-1",
+                    "path": path,
+                    "folder_id": folder,
+                    "thumbnailPath": "/thumbs/img-1.jpg",
+                    "metadata": "not json",
+                    "isTagged": False,
+                    "isEmbedded": False,
+                    "latitude": None,
+                    "longitude": None,
+                    "captured_at": None,
+                }
+            ]
+        )
+
+        recorded = db_get_image_sync_state_by_folder_ids([folder])[
+            os.path.normcase(os.path.abspath(path))
+        ]
+
+        assert recorded["file_size"] is None
+        assert recorded["file_mtime"] is None
+        assert image_util_is_unchanged(path, recorded) is False
+
+
+class TestRescanningAFolder:
+    """The whole point: the second walk over an untouched folder does no work."""
+
+    @pytest.fixture
+    def library(self, tmp_path, test_db, monkeypatch):
+        photos = tmp_path / "photos"
+        photos.mkdir()
+        thumbs = tmp_path / "thumbs"
+        thumbs.mkdir()
+        monkeypatch.setattr("app.utils.images.THUMBNAIL_IMAGES_PATH", str(thumbs))
+
+        for index in range(5):
+            _photo(photos / f"p{index}.jpg", (index * 20, 40, 90))
+
+        conn = sqlite3.connect(test_db)
+        conn.execute(
+            "INSERT INTO folders (folder_id, folder_path, last_modified_time, "
+            "AI_Tagging) VALUES (?, ?, 0, 1)",
+            ("folder-1", str(photos)),
+        )
+        conn.commit()
+        conn.close()
+        return photos
+
+    @pytest.fixture
+    def generated(self, monkeypatch) -> List[str]:
+        collected: List[str] = []
+
+        def spy(image_path: str, thumbnail_path: str, *args, **kwargs):
+            collected.append(image_path)
+            return image_util_generate_thumbnail(
+                image_path, thumbnail_path, *args, **kwargs
+            )
+
+        monkeypatch.setattr("app.utils.images.image_util_generate_thumbnail", spy)
+        return collected
+
+    def test_second_scan_of_an_untouched_folder_regenerates_nothing(
+        self, library, generated
+    ):
+        folder_data = [(str(library), "folder-1", False)]
+
+        assert image_util_process_folder_images(folder_data) is True
+        assert len(generated) == 5
+
+        generated.clear()
+        assert image_util_process_folder_images(folder_data) is True
+        assert generated == []
+
+    def test_only_a_touched_file_is_reread_on_rescan(self, library, generated):
+        folder_data = [(str(library), "folder-1", False)]
+        image_util_process_folder_images(folder_data)
+
+        touched = library / "p3.jpg"
+        os.utime(touched, (0, 0))
+
+        generated.clear()
+        image_util_process_folder_images(folder_data)
+
+        assert generated == [str(touched)]
+
+    def test_rescanning_does_not_churn_image_ids(self, library, generated, test_db):
+        """A new id per scan would cascade every face, tag, and album row away."""
+        folder_data = [(str(library), "folder-1", False)]
+        image_util_process_folder_images(folder_data)
+
+        conn = sqlite3.connect(test_db)
+        before = dict(conn.execute("SELECT path, id FROM images").fetchall())
+        conn.close()
+
+        image_util_process_folder_images(folder_data)
+
+        conn = sqlite3.connect(test_db)
+        after = dict(conn.execute("SELECT path, id FROM images").fetchall())
+        conn.close()
+
+        assert before == after
+
+
+class TestExtractMetadataRecordsMtime:
+    def test_mtime_is_recorded_in_whole_seconds(self, tmp_path):
+        photo = _photo(tmp_path / "a.jpg")
+        metadata = image_util_extract_metadata(photo)
+        assert metadata["file_mtime"] == int(os.stat(photo).st_mtime)
+
+    def test_a_missing_file_records_no_usable_mtime(self, tmp_path):
+        metadata = image_util_extract_metadata(str(tmp_path / "gone.jpg"))
+        assert metadata["file_mtime"] == 0


### PR DESCRIPTION
The sync microservice calls `sync-folder` on any file change under a watched folder. That walk regenerated a thumbnail and rescanned EXIF for **every** file in the folder, not just the one that changed — so editing a single photo re-read the whole library folder.

This records `file_mtime` alongside the `file_size` already stored in the metadata blob, and skips a file when its size, mtime, and existing thumbnail all still match.

### Notes

- No schema migration. Rows written before this have no `file_mtime`, so they get re-read once and carry the field from then on.
- mtime is truncated to whole seconds — external drives are often FAT/exFAT, whose coarser timestamps would otherwise never compare equal across scans.
- A zero-byte thumbnail counts as missing. Skipping a file means keeping its existing thumbnail, so a half-written one has to force a re-read.
- `image_util_prepare_image_records` takes the recorded state as an optional argument, so callers that omit it keep the old full-re-read behaviour.

### Verification

On a folder of 5 images: first scan generated 5 thumbnails, a second scan of the untouched folder generated 0, and touching one file regenerated exactly that one.

Image IDs are asserted to be identical across rescans — a churned ID would cascade every face, tag, and album row away, so that one is worth pinning down.

20 new tests, full backend suite passes (1105), `pre-commit` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Image rescans now skip files that have not changed, making repeat scans faster.
  - Files with updated content or modified timestamps are reprocessed automatically.

- **Reliability**
  - Thumbnails are regenerated when missing, empty, or outdated.
  - Image modification details are consistently recorded, including for unreadable or fallback cases.
  - Existing image IDs are preserved during rescans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->