### PR TITLE
feat: add start minimized toggle for autostart

### DIFF
--- a/frontend/src-tauri/src/main.rs
+++ b/frontend/src-tauri/src/main.rs
@@ -3,6 +3,7 @@
 
 mod services;
 
+use services::settings::{CLOSE_TO_TRAY_KEY, START_MINIMIZED_KEY, STORE_PATH};
 use sysinfo::System;
 use tauri::menu::{Menu, MenuItem, PredefinedMenuItem};
 use tauri::path::BaseDirectory;
@@ -12,10 +13,6 @@ use tauri_plugin_autostart::ManagerExt;
 #[cfg(feature = "ci")]
 use tauri_plugin_shell::ShellExt;
 use tauri_plugin_store::StoreExt;
-
-const STORE_PATH: &str = "settings.json";
-const CLOSE_TO_TRAY_KEY: &str = "close_to_tray";
-const START_MINIMIZED_KEY: &str = "start_minimized";
 
 const ENDPOINTS: [(&str, &str, &str); 2] = [
     (
@@ -259,38 +256,6 @@ fn is_autostart_enabled(app: tauri::AppHandle) -> Result<bool, String> {
     app.autolaunch().is_enabled().map_err(|e| e.to_string())
 }
 
-#[tauri::command]
-fn get_close_to_tray(app: tauri::AppHandle) -> Result<bool, String> {
-    let store = app.store(STORE_PATH).map_err(|e| e.to_string())?;
-    Ok(store
-        .get(CLOSE_TO_TRAY_KEY)
-        .and_then(|v| v.as_bool())
-        .unwrap_or(true))
-}
-
-#[tauri::command]
-fn set_close_to_tray(app: tauri::AppHandle, enabled: bool) -> Result<(), String> {
-    let store = app.store(STORE_PATH).map_err(|e| e.to_string())?;
-    store.set(CLOSE_TO_TRAY_KEY, enabled);
-    store.save().map_err(|e| e.to_string())
-}
-
-#[tauri::command]
-fn get_start_minimized(app: tauri::AppHandle) -> Result<bool, String> {
-    let store = app.store(STORE_PATH).map_err(|e| e.to_string())?;
-    Ok(store
-        .get(START_MINIMIZED_KEY)
-        .and_then(|v| v.as_bool())
-        .unwrap_or(true)) // default: start minimized to tray, matching prior behavior
-}
-
-#[tauri::command]
-fn set_start_minimized(app: tauri::AppHandle, enabled: bool) -> Result<(), String> {
-    let store = app.store(STORE_PATH).map_err(|e| e.to_string())?;
-    store.set(START_MINIMIZED_KEY, enabled);
-    store.save().map_err(|e| e.to_string())
-}
-
 fn main() {
     tauri::Builder::default()
         // Auto-start: pass --minimized so the window starts hidden when launched at boot
@@ -386,10 +351,10 @@ fn main() {
             enable_autostart,
             disable_autostart,
             is_autostart_enabled,
-            get_close_to_tray,
-            set_close_to_tray,
-            get_start_minimized,
-            set_start_minimized,
+            services::settings::get_close_to_tray,
+            services::settings::set_close_to_tray,
+            services::settings::get_start_minimized,
+            services::settings::set_start_minimized,
         ])
         .on_window_event(on_window_event)
         .build(tauri::generate_context!())

--- a/frontend/src-tauri/src/main.rs
+++ b/frontend/src-tauri/src/main.rs
@@ -15,6 +15,7 @@ use tauri_plugin_store::StoreExt;
 
 const STORE_PATH: &str = "settings.json";
 const CLOSE_TO_TRAY_KEY: &str = "close_to_tray";
+const START_MINIMIZED_KEY: &str = "start_minimized";
 
 const ENDPOINTS: [(&str, &str, &str); 2] = [
     (
@@ -274,6 +275,22 @@ fn set_close_to_tray(app: tauri::AppHandle, enabled: bool) -> Result<(), String>
     store.save().map_err(|e| e.to_string())
 }
 
+#[tauri::command]
+fn get_start_minimized(app: tauri::AppHandle) -> Result<bool, String> {
+    let store = app.store(STORE_PATH).map_err(|e| e.to_string())?;
+    Ok(store
+        .get(START_MINIMIZED_KEY)
+        .and_then(|v| v.as_bool())
+        .unwrap_or(true)) // default: start minimized to tray, matching prior behavior
+}
+
+#[tauri::command]
+fn set_start_minimized(app: tauri::AppHandle, enabled: bool) -> Result<(), String> {
+    let store = app.store(STORE_PATH).map_err(|e| e.to_string())?;
+    store.set(START_MINIMIZED_KEY, enabled);
+    store.save().map_err(|e| e.to_string())
+}
+
 fn main() {
     tauri::Builder::default()
         // Auto-start: pass --minimized so the window starts hidden when launched at boot
@@ -296,9 +313,19 @@ fn main() {
             prod(app.handle(), &resource_path)?;
 
             // When auto-started at boot (--minimized flag), keep the window hidden
+            // unless the user has opted out via the "Start Minimized" preference.
             if std::env::args().any(|a| a == "--minimized") {
-                if let Some(window) = app.get_webview_window("main") {
-                    let _ = window.hide();
+                let start_minimized = app
+                    .store(STORE_PATH)
+                    .ok()
+                    .and_then(|s| s.get(START_MINIMIZED_KEY))
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(true); // default: start minimized to tray
+
+                if start_minimized {
+                    if let Some(window) = app.get_webview_window("main") {
+                        let _ = window.hide();
+                    }
                 }
             }
 
@@ -361,6 +388,8 @@ fn main() {
             is_autostart_enabled,
             get_close_to_tray,
             set_close_to_tray,
+            get_start_minimized,
+            set_start_minimized,
         ])
         .on_window_event(on_window_event)
         .build(tauri::generate_context!())

--- a/frontend/src-tauri/src/services/mod.rs
+++ b/frontend/src-tauri/src/services/mod.rs
@@ -1,3 +1,4 @@
+pub mod settings;
 pub mod tunnel;
 
 use tauri::path::BaseDirectory;

--- a/frontend/src-tauri/src/services/settings.rs
+++ b/frontend/src-tauri/src/services/settings.rs
@@ -1,0 +1,37 @@
+use tauri_plugin_store::StoreExt;
+
+pub const STORE_PATH: &str = "settings.json";
+pub const CLOSE_TO_TRAY_KEY: &str = "close_to_tray";
+pub const START_MINIMIZED_KEY: &str = "start_minimized";
+
+#[tauri::command]
+pub fn get_close_to_tray(app: tauri::AppHandle) -> Result<bool, String> {
+    let store = app.store(STORE_PATH).map_err(|e| e.to_string())?;
+    Ok(store
+        .get(CLOSE_TO_TRAY_KEY)
+        .and_then(|v| v.as_bool())
+        .unwrap_or(true))
+}
+
+#[tauri::command]
+pub fn set_close_to_tray(app: tauri::AppHandle, enabled: bool) -> Result<(), String> {
+    let store = app.store(STORE_PATH).map_err(|e| e.to_string())?;
+    store.set(CLOSE_TO_TRAY_KEY, enabled);
+    store.save().map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn get_start_minimized(app: tauri::AppHandle) -> Result<bool, String> {
+    let store = app.store(STORE_PATH).map_err(|e| e.to_string())?;
+    Ok(store
+        .get(START_MINIMIZED_KEY)
+        .and_then(|v| v.as_bool())
+        .unwrap_or(true)) // default: start minimized to tray, matching prior behavior
+}
+
+#[tauri::command]
+pub fn set_start_minimized(app: tauri::AppHandle, enabled: bool) -> Result<(), String> {
+    let store = app.store(STORE_PATH).map_err(|e| e.to_string())?;
+    store.set(START_MINIMIZED_KEY, enabled);
+    store.save().map_err(|e| e.to_string())
+}

--- a/frontend/src/pages/SettingsPage/components/SettingSwitchRow.tsx
+++ b/frontend/src/pages/SettingsPage/components/SettingSwitchRow.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+
+interface SettingSwitchRowProps {
+  /**
+   * Base id used to derive the label/description ids referenced by
+   * aria-labelledby / aria-describedby
+   */
+  id: string;
+  /**
+   * Row title
+   */
+  label: string;
+  /**
+   * Row description
+   */
+  description: string;
+  /**
+   * Whether the switch is on
+   */
+  checked: boolean;
+  /**
+   * Whether the switch is disabled (loading / pending / unknown state)
+   */
+  disabled: boolean;
+  /**
+   * Called when the switch is toggled
+   */
+  onToggle: () => void;
+}
+
+/**
+ * Reusable labeled toggle switch row used by the System settings card
+ */
+const SettingSwitchRow: React.FC<SettingSwitchRowProps> = ({
+  id,
+  label,
+  description,
+  checked,
+  disabled,
+  onToggle,
+}) => {
+  const labelId = `${id}-label`;
+  const descId = `${id}-desc`;
+
+  return (
+    <div className="flex items-center justify-between py-1">
+      <div>
+        <div id={labelId} className="font-medium">
+          {label}
+        </div>
+        <div id={descId} className="text-muted-foreground text-sm">
+          {description}
+        </div>
+      </div>
+
+      <button
+        role="switch"
+        aria-checked={checked}
+        aria-labelledby={labelId}
+        aria-describedby={descId}
+        disabled={disabled}
+        onClick={onToggle}
+        className={[
+          'relative inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full',
+          'transition-colors duration-200 ease-in-out',
+          'focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2',
+          'disabled:cursor-not-allowed disabled:opacity-50',
+          checked
+            ? 'bg-primary focus-visible:ring-primary'
+            : 'bg-gray-200 focus-visible:ring-gray-500 dark:bg-gray-700',
+        ].join(' ')}
+      >
+        <span
+          className={[
+            'inline-block h-4 w-4 rounded-full bg-white shadow-md',
+            'transition-transform duration-200 ease-in-out',
+            checked ? 'translate-x-6' : 'translate-x-1',
+          ].join(' ')}
+        />
+      </button>
+    </div>
+  );
+};
+
+export default SettingSwitchRow;

--- a/frontend/src/pages/SettingsPage/components/SystemSettingsCard.tsx
+++ b/frontend/src/pages/SettingsPage/components/SystemSettingsCard.tsx
@@ -7,9 +7,11 @@ const SystemSettingsCard: React.FC = () => {
   // null = unknown / error reading state
   const [autostart, setAutostart] = useState<boolean | null>(null);
   const [closeToTray, setCloseToTray] = useState<boolean | null>(null);
+  const [startMinimized, setStartMinimized] = useState<boolean | null>(null);
   const [loading, setLoading] = useState(true);
   const [pending, setPending] = useState(false);
   const [pendingCloseToTray, setPendingCloseToTray] = useState(false);
+  const [pendingStartMinimized, setPendingStartMinimized] = useState(false);
 
   useEffect(() => {
     Promise.all([
@@ -19,6 +21,9 @@ const SystemSettingsCard: React.FC = () => {
       invoke<boolean>('get_close_to_tray')
         .then(setCloseToTray)
         .catch(() => setCloseToTray(null)),
+      invoke<boolean>('get_start_minimized')
+        .then(setStartMinimized)
+        .catch(() => setStartMinimized(null)),
     ]).finally(() => setLoading(false));
   }, []);
 
@@ -50,12 +55,30 @@ const SystemSettingsCard: React.FC = () => {
     }
   };
 
+  const handleStartMinimizedToggle = async () => {
+    if (startMinimized === null) return;
+    const next = !startMinimized;
+    setPendingStartMinimized(true);
+    try {
+      await invoke('set_start_minimized', { enabled: next });
+      setStartMinimized(next);
+    } catch (err) {
+      console.error('Failed to toggle start minimized:', err);
+    } finally {
+      setPendingStartMinimized(false);
+    }
+  };
+
   const isDisabled = loading || pending || autostart === null;
   const isChecked = autostart === true;
 
   const closeToTrayDisabled =
     loading || pendingCloseToTray || closeToTray === null;
   const closeToTrayChecked = closeToTray === true;
+
+  const startMinimizedDisabled =
+    loading || pendingStartMinimized || startMinimized === null;
+  const startMinimizedChecked = startMinimized === true;
 
   return (
     <SettingsCard
@@ -100,6 +123,49 @@ const SystemSettingsCard: React.FC = () => {
           />
         </button>
       </div>
+
+      {isChecked && (
+        <div className="flex items-center justify-between py-1">
+          <div>
+            <div id="start-minimized-label" className="font-medium">
+              Start minimized
+            </div>
+            <div
+              id="start-minimized-desc"
+              className="text-muted-foreground text-sm"
+            >
+              When enabled, PictoPy starts silently in the system tray on boot.
+              When disabled, the main window opens on boot instead.
+            </div>
+          </div>
+
+          <button
+            role="switch"
+            aria-checked={startMinimizedChecked}
+            aria-labelledby="start-minimized-label"
+            aria-describedby="start-minimized-desc"
+            disabled={startMinimizedDisabled}
+            onClick={handleStartMinimizedToggle}
+            className={[
+              'relative inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full',
+              'transition-colors duration-200 ease-in-out',
+              'focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2',
+              'disabled:cursor-not-allowed disabled:opacity-50',
+              startMinimizedChecked
+                ? 'bg-primary focus-visible:ring-primary'
+                : 'bg-gray-200 focus-visible:ring-gray-500 dark:bg-gray-700',
+            ].join(' ')}
+          >
+            <span
+              className={[
+                'inline-block h-4 w-4 rounded-full bg-white shadow-md',
+                'transition-transform duration-200 ease-in-out',
+                startMinimizedChecked ? 'translate-x-6' : 'translate-x-1',
+              ].join(' ')}
+            />
+          </button>
+        </div>
+      )}
 
       <div className="flex items-center justify-between py-1">
         <div>

--- a/frontend/src/pages/SettingsPage/components/SystemSettingsCard.tsx
+++ b/frontend/src/pages/SettingsPage/components/SystemSettingsCard.tsx
@@ -81,9 +81,10 @@ const SystemSettingsCard: React.FC = () => {
     loading || pendingStartMinimized || startMinimized === null;
   const startMinimizedChecked = startMinimized === true;
 
-  const autostartDescription = startMinimizedChecked
-    ? 'Automatically start PictoPy when you log in. The window starts minimized to the system tray.'
-    : 'Automatically start PictoPy when you log in. The main window opens directly on boot.';
+  const autostartDescription =
+    startMinimized === false
+      ? 'Automatically start PictoPy when you log in. The main window opens directly on boot.'
+      : 'Automatically start PictoPy when you log in. The window starts minimized to the system tray.';
 
   return (
     <SettingsCard

--- a/frontend/src/pages/SettingsPage/components/SystemSettingsCard.tsx
+++ b/frontend/src/pages/SettingsPage/components/SystemSettingsCard.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Monitor } from 'lucide-react';
 import { invoke } from '@tauri-apps/api/core';
 import SettingsCard from './SettingsCard';
+import SettingSwitchRow from './SettingSwitchRow';
 
 const SystemSettingsCard: React.FC = () => {
   // null = unknown / error reading state
@@ -80,133 +81,44 @@ const SystemSettingsCard: React.FC = () => {
     loading || pendingStartMinimized || startMinimized === null;
   const startMinimizedChecked = startMinimized === true;
 
+  const autostartDescription = startMinimizedChecked
+    ? 'Automatically start PictoPy when you log in. The window starts minimized to the system tray.'
+    : 'Automatically start PictoPy when you log in. The main window opens directly on boot.';
+
   return (
     <SettingsCard
       icon={Monitor}
       title="System"
       description="System integration and startup behavior"
     >
-      <div className="flex items-center justify-between py-1">
-        <div>
-          <div id="autostart-label" className="font-medium">
-            Launch at startup
-          </div>
-          <div id="autostart-desc" className="text-muted-foreground text-sm">
-            Automatically start PictoPy when you log in. The window starts
-            minimized to the system tray.
-          </div>
-        </div>
-
-        <button
-          role="switch"
-          aria-checked={isChecked}
-          aria-labelledby="autostart-label"
-          aria-describedby="autostart-desc"
-          disabled={isDisabled}
-          onClick={handleToggle}
-          className={[
-            'relative inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full',
-            'transition-colors duration-200 ease-in-out',
-            'focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2',
-            'disabled:cursor-not-allowed disabled:opacity-50',
-            isChecked
-              ? 'bg-primary focus-visible:ring-primary'
-              : 'bg-gray-200 focus-visible:ring-gray-500 dark:bg-gray-700',
-          ].join(' ')}
-        >
-          <span
-            className={[
-              'inline-block h-4 w-4 rounded-full bg-white shadow-md',
-              'transition-transform duration-200 ease-in-out',
-              isChecked ? 'translate-x-6' : 'translate-x-1',
-            ].join(' ')}
-          />
-        </button>
-      </div>
+      <SettingSwitchRow
+        id="autostart"
+        label="Launch at startup"
+        description={autostartDescription}
+        checked={isChecked}
+        disabled={isDisabled}
+        onToggle={handleToggle}
+      />
 
       {isChecked && (
-        <div className="flex items-center justify-between py-1">
-          <div>
-            <div id="start-minimized-label" className="font-medium">
-              Start minimized
-            </div>
-            <div
-              id="start-minimized-desc"
-              className="text-muted-foreground text-sm"
-            >
-              When enabled, PictoPy starts silently in the system tray on boot.
-              When disabled, the main window opens on boot instead.
-            </div>
-          </div>
-
-          <button
-            role="switch"
-            aria-checked={startMinimizedChecked}
-            aria-labelledby="start-minimized-label"
-            aria-describedby="start-minimized-desc"
-            disabled={startMinimizedDisabled}
-            onClick={handleStartMinimizedToggle}
-            className={[
-              'relative inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full',
-              'transition-colors duration-200 ease-in-out',
-              'focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2',
-              'disabled:cursor-not-allowed disabled:opacity-50',
-              startMinimizedChecked
-                ? 'bg-primary focus-visible:ring-primary'
-                : 'bg-gray-200 focus-visible:ring-gray-500 dark:bg-gray-700',
-            ].join(' ')}
-          >
-            <span
-              className={[
-                'inline-block h-4 w-4 rounded-full bg-white shadow-md',
-                'transition-transform duration-200 ease-in-out',
-                startMinimizedChecked ? 'translate-x-6' : 'translate-x-1',
-              ].join(' ')}
-            />
-          </button>
-        </div>
+        <SettingSwitchRow
+          id="start-minimized"
+          label="Start minimized"
+          description="When enabled, PictoPy starts silently in the system tray on boot. When disabled, the main window opens on boot instead."
+          checked={startMinimizedChecked}
+          disabled={startMinimizedDisabled}
+          onToggle={handleStartMinimizedToggle}
+        />
       )}
 
-      <div className="flex items-center justify-between py-1">
-        <div>
-          <div id="close-to-tray-label" className="font-medium">
-            Close to tray
-          </div>
-          <div
-            id="close-to-tray-desc"
-            className="text-muted-foreground text-sm"
-          >
-            When enabled, closing the window hides the app to the system tray
-            instead of exiting.
-          </div>
-        </div>
-
-        <button
-          role="switch"
-          aria-checked={closeToTrayChecked}
-          aria-labelledby="close-to-tray-label"
-          aria-describedby="close-to-tray-desc"
-          disabled={closeToTrayDisabled}
-          onClick={handleCloseToTrayToggle}
-          className={[
-            'relative inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full',
-            'transition-colors duration-200 ease-in-out',
-            'focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2',
-            'disabled:cursor-not-allowed disabled:opacity-50',
-            closeToTrayChecked
-              ? 'bg-primary focus-visible:ring-primary'
-              : 'bg-gray-200 focus-visible:ring-gray-500 dark:bg-gray-700',
-          ].join(' ')}
-        >
-          <span
-            className={[
-              'inline-block h-4 w-4 rounded-full bg-white shadow-md',
-              'transition-transform duration-200 ease-in-out',
-              closeToTrayChecked ? 'translate-x-6' : 'translate-x-1',
-            ].join(' ')}
-          />
-        </button>
-      </div>
+      <SettingSwitchRow
+        id="close-to-tray"
+        label="Close to tray"
+        description="When enabled, closing the window hides the app to the system tray instead of exiting."
+        checked={closeToTrayChecked}
+        disabled={closeToTrayDisabled}
+        onToggle={handleCloseToTrayToggle}
+      />
     </SettingsCard>
   );
 };


### PR DESCRIPTION
Part of  #817 

Follow-up to #1301 (auto-start and minimize to tray).

Adds a "Start Minimized" toggle in Settings → General that gives 
users control over whether the app opens its main window or stays 
hidden in the tray when launched at boot.

## Behavior
- Toggle is only visible when "Launch at Startup" is ON
- When ON (default): app starts silently in the tray on boot — 
  same as current behavior
- When OFF: app starts and opens the main window directly on boot
- Preference persists across restarts via tauri-plugin-store, 
  following the same pattern as the existing close-to-tray toggle

## Files Changed
- `frontend/src-tauri/src/main.rs` — added START_MINIMIZED_KEY, 
  get_start_minimized and set_start_minimized Tauri commands, 
  updated startup handler to read the persisted preference
- `frontend/src/pages/SettingsPage/components/SystemSettingsCard.tsx` 
  — added toggle UI, conditionally rendered only when autostart is ON


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Start minimized** setting in System Settings.
  * The preference is saved and restored between sessions.
  * When enabled, the app starts minimized during automatic startup.
  * The setting is available only when automatic startup is enabled.
  * Improved consistency of system setting controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->