### PR TITLE
fix(albums): center Add Images button in empty album view

### DIFF
--- a/frontend/src/components/EmptyStates/EmptyGalleryState.tsx
+++ b/frontend/src/components/EmptyStates/EmptyGalleryState.tsx
@@ -1,4 +1,5 @@
 import { FolderOpen, Image as ImageIcon, type LucideIcon } from 'lucide-react';
+import { ReactNode } from 'react';
 import { useNavigate } from 'react-router';
 import { ROUTES } from '@/constants/routes';
 
@@ -7,6 +8,7 @@ interface EmptyGalleryStateProps {
   description?: string;
   formatsHint?: string;
   formatsIcon?: LucideIcon;
+  action?: ReactNode;
 }
 
 export const EmptyGalleryState = ({
@@ -14,6 +16,7 @@ export const EmptyGalleryState = ({
   description = 'Your gallery is empty. Please add a folder containing images to get started.',
   formatsHint = 'Supports PNG, JPG, JPEG image formats.',
   formatsIcon: FormatsIcon = ImageIcon,
+  action,
 }: EmptyGalleryStateProps) => {
   const navigate = useNavigate();
 
@@ -28,26 +31,32 @@ export const EmptyGalleryState = ({
       <p className="mb-6 max-w-md text-gray-500 dark:text-gray-400">
         {description}
       </p>
-      <div className="flex flex-col gap-2 text-sm text-gray-400 dark:text-gray-500">
-        <div className="flex items-center gap-2">
-          <FolderOpen className="h-4 w-4" />
-          <span>
-            Go to{' '}
-            <button
-              type="button"
-              onClick={() => navigate(`/${ROUTES.SETTINGS}`)}
-              className="rounded text-blue-500 hover:underline focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:outline-none"
-            >
-              Settings
-            </button>{' '}
-            to add folders.
-          </span>
-        </div>
-        <div className="flex items-center gap-2">
+
+      <div className="mb-6 flex flex-col items-center justify-center gap-2">
+        {action ?? (
+          <div className="flex items-center gap-2 text-sm text-gray-400 dark:text-gray-500">
+            <FolderOpen className="h-4 w-4" />
+            <span>
+              Go to{' '}
+              <button
+                type="button"
+                onClick={() => navigate(`/${ROUTES.SETTINGS}`)}
+                className="rounded text-blue-500 hover:underline focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:outline-none"
+              >
+                Settings
+              </button>{' '}
+              to add folders.
+            </span>
+          </div>
+        )}
+      </div>
+
+      {formatsHint && (
+        <div className="flex items-center gap-2 text-sm text-gray-400 dark:text-gray-500">
           <FormatsIcon className="h-4 w-4" />
           <span>{formatsHint}</span>
         </div>
-      </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/pages/Album/AlbumDetail.tsx
+++ b/frontend/src/pages/Album/AlbumDetail.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useParams, useNavigate, useLocation } from 'react-router';
 import { Button } from '@/components/ui/button';
+import { EmptyGalleryState } from '@/components/EmptyStates/EmptyGalleryState';
 import { ArrowLeft, Plus, Trash2 } from 'lucide-react';
 import { ImageCard } from '@/components/Media/ImageCard';
 import { MediaView } from '@/components/Media/MediaView';
@@ -231,12 +232,12 @@ export const AlbumDetail = () => {
   return (
     <div className="flex h-full flex-col">
       {/* Header */}
-      <div className="mb-6">
-        <div className="mb-4 flex items-center gap-3">
+      <div className="mb-6 flex items-start justify-between gap-4">
+        <div className="flex items-center gap-3">
           <Button variant="ghost" size="icon" onClick={handleBack}>
             <ArrowLeft className="h-5 w-5" />
           </Button>
-          <div className="flex-1">
+          <div>
             <h1 className="text-2xl font-bold">{album.name}</h1>
             {album.description && (
               <p className="text-muted-foreground text-sm">
@@ -246,12 +247,7 @@ export const AlbumDetail = () => {
           </div>
         </div>
 
-        <div className="flex items-center justify-between">
-          <p className="text-muted-foreground text-sm">
-            {images.length} {images.length === 1 ? 'photo' : 'photos'}
-            {selectedImages.size > 0 && ` • ${selectedImages.size} selected`}
-          </p>
-
+        <div className="flex flex-col items-end gap-2">
           <div className="flex items-center gap-2">
             {isSelectionMode ? (
               <>
@@ -296,6 +292,11 @@ export const AlbumDetail = () => {
               </>
             )}
           </div>
+
+          <p className="text-muted-foreground text-sm">
+            {images.length} {images.length === 1 ? 'photo' : 'photos'}
+            {selectedImages.size > 0 && ` • ${selectedImages.size} selected`}
+          </p>
         </div>
       </div>
 
@@ -308,17 +309,17 @@ export const AlbumDetail = () => {
             ))}
           </div>
         ) : images.length === 0 ? (
-          <div className="flex h-full items-center justify-center">
-            <div className="text-center">
-              <p className="text-muted-foreground mb-4">
-                No images in this album yet
-              </p>
+          <EmptyGalleryState
+            title="No images in this album yet"
+            description="Add images to start organizing this album."
+            formatsHint=""
+            action={
               <Button onClick={() => setIsAddImagesDialogOpen(true)}>
                 <Plus className="mr-2 h-4 w-4" />
                 Add Images
               </Button>
-            </div>
-          </div>
+            }
+          />
         ) : (
           <div className="grid grid-cols-2 gap-4 pb-6 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
             {images.map((image, index) => (


### PR DESCRIPTION
Fixes #1460

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a consistent empty-state experience for albums, including an Add Images action.
  * Empty gallery states can now display custom actions instead of the default Settings prompt.
  * Improved responsive album header layout and photo count placement.

* **Bug Fixes**
  * Formats guidance is now shown only when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->