### PR TITLE
feat: add password confirmation and visibility toggle in create album…

### DIFF
--- a/frontend/src/components/Albums/CreateAlbumDialog.tsx
+++ b/frontend/src/components/Albums/CreateAlbumDialog.tsx
@@ -16,6 +16,7 @@ import { CreateAlbumDialogProps } from '@/types/Album';
 import { usePictoMutation } from '@/hooks/useQueryExtension';
 import { createAlbum } from '@/api/api-functions';
 import { useMutationFeedback } from '@/hooks/useMutationFeedback';
+import { Eye, EyeOff } from 'lucide-react';
 
 export const CreateAlbumDialog: React.FC<CreateAlbumDialogProps> = ({
   isOpen,
@@ -27,11 +28,14 @@ export const CreateAlbumDialog: React.FC<CreateAlbumDialogProps> = ({
     description: '',
     is_locked: false,
     password: '',
+    confirmPassword: '',
   });
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
   const [errors, setErrors] = useState<Record<string, string>>({});
 
   const createAlbumMutation = usePictoMutation({
-    mutationFn: createAlbum,
+    mutationFn: (data: Parameters<typeof createAlbum>[0]) => createAlbum(data),
   });
 
   useMutationFeedback(createAlbumMutation, {
@@ -55,8 +59,15 @@ export const CreateAlbumDialog: React.FC<CreateAlbumDialogProps> = ({
       newErrors.name = 'Album name is required';
     }
 
-    if (formData.is_locked && !formData.password.trim()) {
-      newErrors.password = 'Password is required for locked albums';
+    if (formData.is_locked) {
+      if (!formData.password.trim()) {
+        newErrors.password = 'Password is required for locked albums';
+      }
+      if (!formData.confirmPassword.trim()) {
+        newErrors.confirmPassword = 'Confirm password is required';
+      } else if (formData.password !== formData.confirmPassword) {
+        newErrors.confirmPassword = 'Passwords do not match';
+      }
     }
 
     setErrors(newErrors);
@@ -88,7 +99,10 @@ export const CreateAlbumDialog: React.FC<CreateAlbumDialogProps> = ({
       description: '',
       is_locked: false,
       password: '',
+      confirmPassword: '',
     });
+    setShowPassword(false);
+    setShowConfirmPassword(false);
     setErrors({});
     onClose();
   };
@@ -161,24 +175,95 @@ export const CreateAlbumDialog: React.FC<CreateAlbumDialogProps> = ({
 
             {/* Password Field (shown only if locked) */}
             {formData.is_locked && (
-              <div className="grid gap-2">
-                <Label htmlFor="password">
-                  Password <span className="text-destructive">*</span>
-                </Label>
-                <Input
-                  id="password"
-                  type="password"
-                  placeholder="Enter a password"
-                  value={formData.password}
-                  onChange={(e) =>
-                    setFormData({ ...formData, password: e.target.value })
-                  }
-                  className={errors.password ? 'border-destructive' : ''}
-                />
-                {errors.password && (
-                  <p className="text-destructive text-sm">{errors.password}</p>
-                )}
-              </div>
+              <>
+                <div className="grid gap-2">
+                  <Label htmlFor="password">
+                    Password <span className="text-destructive">*</span>
+                  </Label>
+                  <div className="relative">
+                    <Input
+                      id="password"
+                      type={showPassword ? 'text' : 'password'}
+                      placeholder="Enter a password"
+                      value={formData.password}
+                      onChange={(e) =>
+                        setFormData({ ...formData, password: e.target.value })
+                      }
+                      className={
+                        errors.password ? 'border-destructive pr-10' : 'pr-10'
+                      }
+                    />
+                    <button
+                      type="button"
+                      className="text-muted-foreground hover:text-foreground absolute top-0 right-0 flex h-full items-center px-3"
+                      onClick={() => setShowPassword(!showPassword)}
+                      aria-label={
+                        showPassword ? 'Hide password' : 'Show password'
+                      }
+                    >
+                      {showPassword ? (
+                        <EyeOff className="h-4 w-4" />
+                      ) : (
+                        <Eye className="h-4 w-4" />
+                      )}
+                    </button>
+                  </div>
+                  {errors.password && (
+                    <p className="text-destructive text-sm">
+                      {errors.password}
+                    </p>
+                  )}
+                </div>
+
+                {/* Confirm Password Field */}
+                <div className="grid gap-2">
+                  <Label htmlFor="confirm-password">
+                    Confirm Password <span className="text-destructive">*</span>
+                  </Label>
+                  <div className="relative">
+                    <Input
+                      id="confirm-password"
+                      type={showConfirmPassword ? 'text' : 'password'}
+                      placeholder="Confirm your password"
+                      value={formData.confirmPassword}
+                      onChange={(e) =>
+                        setFormData({
+                          ...formData,
+                          confirmPassword: e.target.value,
+                        })
+                      }
+                      className={
+                        errors.confirmPassword
+                          ? 'border-destructive pr-10'
+                          : 'pr-10'
+                      }
+                    />
+                    <button
+                      type="button"
+                      className="text-muted-foreground hover:text-foreground absolute top-0 right-0 flex h-full items-center px-3"
+                      onClick={() =>
+                        setShowConfirmPassword(!showConfirmPassword)
+                      }
+                      aria-label={
+                        showConfirmPassword
+                          ? 'Hide confirm password'
+                          : 'Show confirm password'
+                      }
+                    >
+                      {showConfirmPassword ? (
+                        <EyeOff className="h-4 w-4" />
+                      ) : (
+                        <Eye className="h-4 w-4" />
+                      )}
+                    </button>
+                  </div>
+                  {errors.confirmPassword && (
+                    <p className="text-destructive text-sm">
+                      {errors.confirmPassword}
+                    </p>
+                  )}
+                </div>
+              </>
             )}
           </div>
 

--- a/frontend/src/components/Albums/CreateAlbumDialog.tsx
+++ b/frontend/src/components/Albums/CreateAlbumDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   Dialog,
   DialogContent,
@@ -33,6 +33,25 @@ export const CreateAlbumDialog: React.FC<CreateAlbumDialogProps> = ({
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
   const [errors, setErrors] = useState<Record<string, string>>({});
+
+  const resetForm = () => {
+    setFormData({
+      name: '',
+      description: '',
+      is_locked: false,
+      password: '',
+      confirmPassword: '',
+    });
+    setShowPassword(false);
+    setShowConfirmPassword(false);
+    setErrors({});
+  };
+
+  useEffect(() => {
+    if (!isOpen) {
+      resetForm();
+    }
+  }, [isOpen]);
 
   const createAlbumMutation = usePictoMutation({
     mutationFn: (data: Parameters<typeof createAlbum>[0]) => createAlbum(data),
@@ -94,21 +113,12 @@ export const CreateAlbumDialog: React.FC<CreateAlbumDialogProps> = ({
   };
 
   const handleClose = () => {
-    setFormData({
-      name: '',
-      description: '',
-      is_locked: false,
-      password: '',
-      confirmPassword: '',
-    });
-    setShowPassword(false);
-    setShowConfirmPassword(false);
-    setErrors({});
+    resetForm();
     onClose();
   };
 
   return (
-    <Dialog open={isOpen} onOpenChange={handleClose}>
+    <Dialog open={isOpen} onOpenChange={(open) => !open && handleClose()}>
       <DialogContent className="sm:max-w-[500px]">
         <form onSubmit={handleSubmit}>
           <DialogHeader>
@@ -131,10 +141,18 @@ export const CreateAlbumDialog: React.FC<CreateAlbumDialogProps> = ({
                 onChange={(e) =>
                   setFormData({ ...formData, name: e.target.value })
                 }
+                aria-invalid={!!errors.name}
+                aria-describedby={errors.name ? 'name-error' : undefined}
                 className={errors.name ? 'border-destructive' : ''}
               />
               {errors.name && (
-                <p className="text-destructive text-sm">{errors.name}</p>
+                <p
+                  id="name-error"
+                  className="text-destructive text-sm"
+                  role="alert"
+                >
+                  {errors.name}
+                </p>
               )}
             </div>
 
@@ -167,9 +185,23 @@ export const CreateAlbumDialog: React.FC<CreateAlbumDialogProps> = ({
               <Switch
                 id="locked"
                 checked={formData.is_locked}
-                onCheckedChange={(checked) =>
-                  setFormData({ ...formData, is_locked: checked })
-                }
+                onCheckedChange={(checked) => {
+                  setFormData((prev) => ({
+                    ...prev,
+                    is_locked: checked,
+                    ...(checked ? {} : { password: '', confirmPassword: '' }),
+                  }));
+                  if (!checked) {
+                    setShowPassword(false);
+                    setShowConfirmPassword(false);
+                    setErrors((prev) => {
+                      const updated = { ...prev };
+                      delete updated.password;
+                      delete updated.confirmPassword;
+                      return updated;
+                    });
+                  }
+                }}
               />
             </div>
 
@@ -189,6 +221,10 @@ export const CreateAlbumDialog: React.FC<CreateAlbumDialogProps> = ({
                       onChange={(e) =>
                         setFormData({ ...formData, password: e.target.value })
                       }
+                      aria-invalid={!!errors.password}
+                      aria-describedby={
+                        errors.password ? 'password-error' : undefined
+                      }
                       className={
                         errors.password ? 'border-destructive pr-10' : 'pr-10'
                       }
@@ -200,6 +236,7 @@ export const CreateAlbumDialog: React.FC<CreateAlbumDialogProps> = ({
                       aria-label={
                         showPassword ? 'Hide password' : 'Show password'
                       }
+                      aria-controls="password"
                     >
                       {showPassword ? (
                         <EyeOff className="h-4 w-4" />
@@ -209,7 +246,11 @@ export const CreateAlbumDialog: React.FC<CreateAlbumDialogProps> = ({
                     </button>
                   </div>
                   {errors.password && (
-                    <p className="text-destructive text-sm">
+                    <p
+                      id="password-error"
+                      className="text-destructive text-sm"
+                      role="alert"
+                    >
                       {errors.password}
                     </p>
                   )}
@@ -232,6 +273,12 @@ export const CreateAlbumDialog: React.FC<CreateAlbumDialogProps> = ({
                           confirmPassword: e.target.value,
                         })
                       }
+                      aria-invalid={!!errors.confirmPassword}
+                      aria-describedby={
+                        errors.confirmPassword
+                          ? 'confirm-password-error'
+                          : undefined
+                      }
                       className={
                         errors.confirmPassword
                           ? 'border-destructive pr-10'
@@ -249,6 +296,7 @@ export const CreateAlbumDialog: React.FC<CreateAlbumDialogProps> = ({
                           ? 'Hide confirm password'
                           : 'Show confirm password'
                       }
+                      aria-controls="confirm-password"
                     >
                       {showConfirmPassword ? (
                         <EyeOff className="h-4 w-4" />
@@ -258,7 +306,11 @@ export const CreateAlbumDialog: React.FC<CreateAlbumDialogProps> = ({
                     </button>
                   </div>
                   {errors.confirmPassword && (
-                    <p className="text-destructive text-sm">
+                    <p
+                      id="confirm-password-error"
+                      className="text-destructive text-sm"
+                      role="alert"
+                    >
                       {errors.confirmPassword}
                     </p>
                   )}

--- a/frontend/src/components/Albums/CreateAlbumDialog.tsx
+++ b/frontend/src/components/Albums/CreateAlbumDialog.tsx
@@ -256,7 +256,6 @@ export const CreateAlbumDialog: React.FC<CreateAlbumDialogProps> = ({
                   )}
                 </div>
 
-                {/* Confirm Password Field */}
                 <div className="grid gap-2">
                   <Label htmlFor="confirm-password">
                     Confirm Password <span className="text-destructive">*</span>

--- a/frontend/src/components/Albums/__tests__/CreateAlbumDialog.test.tsx
+++ b/frontend/src/components/Albums/__tests__/CreateAlbumDialog.test.tsx
@@ -102,7 +102,6 @@ describe('CreateAlbumDialog', () => {
       'confirm-password',
     );
 
-    // Toggle password visibility
     await user.click(togglePasswordBtn);
     expect(passwordInput).toHaveAttribute('type', 'text');
     expect(
@@ -112,7 +111,6 @@ describe('CreateAlbumDialog', () => {
     await user.click(screen.getByRole('button', { name: /hide password/i }));
     expect(passwordInput).toHaveAttribute('type', 'password');
 
-    // Toggle confirm password visibility
     await user.click(toggleConfirmBtn);
     expect(confirmPasswordInput).toHaveAttribute('type', 'text');
     expect(
@@ -132,7 +130,6 @@ describe('CreateAlbumDialog', () => {
     await user.type(screen.getByLabelText(/album name/i), 'Family Trip');
     await user.click(screen.getByLabelText(/lock album/i));
 
-    // Submit with both password and confirm password empty
     await user.click(screen.getByRole('button', { name: /create album/i }));
 
     const passwordInput = screen.getByLabelText(/^password \*/i);
@@ -200,7 +197,6 @@ describe('CreateAlbumDialog', () => {
       'mismatchedpass',
     );
 
-    // Show both passwords
     await user.click(screen.getByRole('button', { name: /show password/i }));
     await user.click(
       screen.getByRole('button', { name: /show confirm password/i }),
@@ -214,18 +210,15 @@ describe('CreateAlbumDialog', () => {
       'text',
     );
 
-    // Trigger password validation errors
     await user.click(screen.getByRole('button', { name: /create album/i }));
     expect(screen.getByText('Passwords do not match')).toBeInTheDocument();
 
-    // Toggle off lock
     await user.click(screen.getByLabelText(/lock album/i));
     expect(screen.queryByLabelText(/^password/i)).not.toBeInTheDocument();
     expect(
       screen.queryByText('Passwords do not match'),
     ).not.toBeInTheDocument();
 
-    // Toggle on lock again — fields should be empty, type="password", and have no errors
     await user.click(screen.getByLabelText(/lock album/i));
     const passwordInput = screen.getByLabelText(/^password \*/i);
     const confirmPasswordInput = screen.getByLabelText(/confirm password \*/i);
@@ -258,17 +251,14 @@ describe('CreateAlbumDialog', () => {
       'mismatchedpass',
     );
 
-    // Show both passwords
     await user.click(screen.getByRole('button', { name: /show password/i }));
     await user.click(
       screen.getByRole('button', { name: /show confirm password/i }),
     );
 
-    // Trigger validation error
     await user.click(screen.getByRole('button', { name: /create album/i }));
     expect(screen.getByText('Passwords do not match')).toBeInTheDocument();
 
-    // Simulate closing externally
     rerender(
       <CreateAlbumDialog
         isOpen={false}
@@ -277,7 +267,6 @@ describe('CreateAlbumDialog', () => {
       />,
     );
 
-    // Reopen dialog
     rerender(
       <CreateAlbumDialog
         isOpen={true}
@@ -292,7 +281,6 @@ describe('CreateAlbumDialog', () => {
     ).not.toBeInTheDocument();
     expect(screen.queryByLabelText(/^password/i)).not.toBeInTheDocument();
 
-    // Enable locking and assert visibility and error state are reset
     await user.click(screen.getByLabelText(/lock album/i));
     const passwordInput = screen.getByLabelText(/^password \*/i);
     const confirmPasswordInput = screen.getByLabelText(/confirm password \*/i);

--- a/frontend/src/components/Albums/__tests__/CreateAlbumDialog.test.tsx
+++ b/frontend/src/components/Albums/__tests__/CreateAlbumDialog.test.tsx
@@ -1,0 +1,210 @@
+import userEvent from '@testing-library/user-event';
+import { render, screen, waitFor } from '@/test-utils';
+import { createAlbum } from '@/api/api-functions';
+import { CreateAlbumDialog } from '../CreateAlbumDialog';
+
+jest.mock('@/api/api-functions', () => ({
+  createAlbum: jest.fn(),
+}));
+
+const mockCreateAlbum = createAlbum as jest.Mock;
+
+const renderDialog = (
+  isOpen = true,
+  onClose = jest.fn(),
+  onSuccess = jest.fn(),
+) =>
+  render(
+    <CreateAlbumDialog
+      isOpen={isOpen}
+      onClose={onClose}
+      onSuccess={onSuccess}
+    />,
+  );
+
+describe('CreateAlbumDialog', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCreateAlbum.mockResolvedValue({
+      success: true,
+      data: { id: 'a1', name: 'New Album' },
+    });
+  });
+
+  it('renders the dialog when isOpen is true', () => {
+    renderDialog(true);
+    expect(
+      screen.getByRole('heading', { name: /create new album/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/album name/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/description/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/lock album/i)).toBeInTheDocument();
+    expect(screen.queryByLabelText(/^password/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText(/confirm password/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows error if album name is empty on submission', async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.click(screen.getByRole('button', { name: /create album/i }));
+
+    expect(screen.getByText('Album name is required')).toBeInTheDocument();
+    expect(mockCreateAlbum).not.toHaveBeenCalled();
+  });
+
+  it('reveals password and confirm password inputs when lock album is toggled on', async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    expect(screen.queryByLabelText(/^password/i)).not.toBeInTheDocument();
+
+    await user.click(screen.getByLabelText(/lock album/i));
+
+    expect(screen.getByLabelText(/^password \*/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/confirm password \*/i)).toBeInTheDocument();
+  });
+
+  it('toggles password and confirm password visibility', async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.click(screen.getByLabelText(/lock album/i));
+
+    const passwordInput = screen.getByLabelText(/^password \*/i);
+    const confirmPasswordInput = screen.getByLabelText(/confirm password \*/i);
+    const togglePasswordBtn = screen.getByRole('button', {
+      name: /show password/i,
+    });
+    const toggleConfirmBtn = screen.getByRole('button', {
+      name: /show confirm password/i,
+    });
+
+    expect(passwordInput).toHaveAttribute('type', 'password');
+    expect(confirmPasswordInput).toHaveAttribute('type', 'password');
+
+    // Toggle password visibility
+    await user.click(togglePasswordBtn);
+    expect(passwordInput).toHaveAttribute('type', 'text');
+    expect(
+      screen.getByRole('button', { name: /hide password/i }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /hide password/i }));
+    expect(passwordInput).toHaveAttribute('type', 'password');
+
+    // Toggle confirm password visibility
+    await user.click(toggleConfirmBtn);
+    expect(confirmPasswordInput).toHaveAttribute('type', 'text');
+    expect(
+      screen.getByRole('button', { name: /hide confirm password/i }),
+    ).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole('button', { name: /hide confirm password/i }),
+    );
+    expect(confirmPasswordInput).toHaveAttribute('type', 'password');
+  });
+
+  it('validates password requirement when lock album is enabled', async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.type(screen.getByLabelText(/album name/i), 'Family Trip');
+    await user.click(screen.getByLabelText(/lock album/i));
+
+    // Submit with both password and confirm password empty
+    await user.click(screen.getByRole('button', { name: /create album/i }));
+
+    expect(
+      screen.getByText('Password is required for locked albums'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Confirm password is required'),
+    ).toBeInTheDocument();
+    expect(mockCreateAlbum).not.toHaveBeenCalled();
+  });
+
+  it('validates that confirm password is required if password is entered', async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.type(screen.getByLabelText(/album name/i), 'Family Trip');
+    await user.click(screen.getByLabelText(/lock album/i));
+    await user.type(screen.getByLabelText(/^password \*/i), 'securepass123');
+
+    await user.click(screen.getByRole('button', { name: /create album/i }));
+
+    expect(
+      screen.getByText('Confirm password is required'),
+    ).toBeInTheDocument();
+    expect(mockCreateAlbum).not.toHaveBeenCalled();
+  });
+
+  it('validates that passwords must match', async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.type(screen.getByLabelText(/album name/i), 'Family Trip');
+    await user.click(screen.getByLabelText(/lock album/i));
+    await user.type(screen.getByLabelText(/^password \*/i), 'securepass123');
+    await user.type(
+      screen.getByLabelText(/confirm password \*/i),
+      'differentpass',
+    );
+
+    await user.click(screen.getByRole('button', { name: /create album/i }));
+
+    expect(screen.getByText('Passwords do not match')).toBeInTheDocument();
+    expect(mockCreateAlbum).not.toHaveBeenCalled();
+  });
+
+  it('submits locked album successfully when passwords match', async () => {
+    const user = userEvent.setup();
+    renderDialog(true, jest.fn(), jest.fn());
+
+    await user.type(screen.getByLabelText(/album name/i), 'Secret Album');
+    await user.type(screen.getByLabelText(/description/i), 'Secret photos');
+    await user.click(screen.getByLabelText(/lock album/i));
+    await user.type(screen.getByLabelText(/^password \*/i), 'secret123');
+    await user.type(screen.getByLabelText(/confirm password \*/i), 'secret123');
+
+    await user.click(screen.getByRole('button', { name: /create album/i }));
+
+    await waitFor(() => {
+      expect(mockCreateAlbum).toHaveBeenCalledWith({
+        name: 'Secret Album',
+        description: 'Secret photos',
+        is_locked: true,
+        password: 'secret123',
+      });
+    });
+  });
+
+  it('submits unlocked album without password payload', async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.type(screen.getByLabelText(/album name/i), 'Public Album');
+    await user.click(screen.getByRole('button', { name: /create album/i }));
+
+    await waitFor(() => {
+      expect(mockCreateAlbum).toHaveBeenCalledWith({
+        name: 'Public Album',
+        is_locked: false,
+      });
+    });
+  });
+
+  it('calls onClose when Cancel button is clicked', async () => {
+    const user = userEvent.setup();
+    const handleClose = jest.fn();
+    renderDialog(true, handleClose);
+
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
+
+    expect(handleClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/Albums/__tests__/CreateAlbumDialog.test.tsx
+++ b/frontend/src/components/Albums/__tests__/CreateAlbumDialog.test.tsx
@@ -188,33 +188,85 @@ describe('CreateAlbumDialog', () => {
     expect(mockCreateAlbum).not.toHaveBeenCalled();
   });
 
-  it('clears password fields and visibility when lock toggle is turned off', async () => {
+  it('clears password fields, visibility, and validation errors when lock toggle is turned off', async () => {
     const user = userEvent.setup();
     renderDialog();
 
     await user.type(screen.getByLabelText(/album name/i), 'Family Trip');
     await user.click(screen.getByLabelText(/lock album/i));
     await user.type(screen.getByLabelText(/^password \*/i), 'secret123');
-    await user.type(screen.getByLabelText(/confirm password \*/i), 'secret123');
+    await user.type(
+      screen.getByLabelText(/confirm password \*/i),
+      'mismatchedpass',
+    );
+
+    // Show both passwords
+    await user.click(screen.getByRole('button', { name: /show password/i }));
+    await user.click(
+      screen.getByRole('button', { name: /show confirm password/i }),
+    );
+    expect(screen.getByLabelText(/^password \*/i)).toHaveAttribute(
+      'type',
+      'text',
+    );
+    expect(screen.getByLabelText(/confirm password \*/i)).toHaveAttribute(
+      'type',
+      'text',
+    );
+
+    // Trigger password validation errors
+    await user.click(screen.getByRole('button', { name: /create album/i }));
+    expect(screen.getByText('Passwords do not match')).toBeInTheDocument();
 
     // Toggle off lock
     await user.click(screen.getByLabelText(/lock album/i));
     expect(screen.queryByLabelText(/^password/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Passwords do not match'),
+    ).not.toBeInTheDocument();
 
-    // Toggle on lock again — fields should be empty
+    // Toggle on lock again — fields should be empty, type="password", and have no errors
     await user.click(screen.getByLabelText(/lock album/i));
-    expect(screen.getByLabelText(/^password \*/i)).toHaveValue('');
-    expect(screen.getByLabelText(/confirm password \*/i)).toHaveValue('');
+    const passwordInput = screen.getByLabelText(/^password \*/i);
+    const confirmPasswordInput = screen.getByLabelText(/confirm password \*/i);
+    expect(passwordInput).toHaveValue('');
+    expect(passwordInput).toHaveAttribute('type', 'password');
+    expect(passwordInput).not.toHaveAttribute('aria-invalid', 'true');
+    expect(confirmPasswordInput).toHaveValue('');
+    expect(confirmPasswordInput).toHaveAttribute('type', 'password');
+    expect(confirmPasswordInput).not.toHaveAttribute('aria-invalid', 'true');
+    expect(
+      screen.queryByText('Passwords do not match'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /show password/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /show confirm password/i }),
+    ).toBeInTheDocument();
   });
 
-  it('resets all form state and sensitive data when closed and reopened', async () => {
+  it('resets all form state, visibility, and validation errors when closed and reopened', async () => {
     const user = userEvent.setup();
     const { rerender } = renderDialog(true);
 
     await user.type(screen.getByLabelText(/album name/i), 'Secret Trip');
     await user.click(screen.getByLabelText(/lock album/i));
     await user.type(screen.getByLabelText(/^password \*/i), 'secret123');
-    await user.type(screen.getByLabelText(/confirm password \*/i), 'secret123');
+    await user.type(
+      screen.getByLabelText(/confirm password \*/i),
+      'mismatchedpass',
+    );
+
+    // Show both passwords
+    await user.click(screen.getByRole('button', { name: /show password/i }));
+    await user.click(
+      screen.getByRole('button', { name: /show confirm password/i }),
+    );
+
+    // Trigger validation error
+    await user.click(screen.getByRole('button', { name: /create album/i }));
+    expect(screen.getByText('Passwords do not match')).toBeInTheDocument();
 
     // Simulate closing externally
     rerender(
@@ -235,7 +287,30 @@ describe('CreateAlbumDialog', () => {
     );
 
     expect(screen.getByLabelText(/album name \*/i)).toHaveValue('');
+    expect(
+      screen.queryByText('Passwords do not match'),
+    ).not.toBeInTheDocument();
     expect(screen.queryByLabelText(/^password/i)).not.toBeInTheDocument();
+
+    // Enable locking and assert visibility and error state are reset
+    await user.click(screen.getByLabelText(/lock album/i));
+    const passwordInput = screen.getByLabelText(/^password \*/i);
+    const confirmPasswordInput = screen.getByLabelText(/confirm password \*/i);
+    expect(passwordInput).toHaveValue('');
+    expect(passwordInput).toHaveAttribute('type', 'password');
+    expect(passwordInput).not.toHaveAttribute('aria-invalid', 'true');
+    expect(confirmPasswordInput).toHaveValue('');
+    expect(confirmPasswordInput).toHaveAttribute('type', 'password');
+    expect(confirmPasswordInput).not.toHaveAttribute('aria-invalid', 'true');
+    expect(
+      screen.queryByText('Passwords do not match'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /show password/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /show confirm password/i }),
+    ).toBeInTheDocument();
   });
 
   it('submits locked album successfully when passwords match', async () => {

--- a/frontend/src/components/Albums/__tests__/CreateAlbumDialog.test.tsx
+++ b/frontend/src/components/Albums/__tests__/CreateAlbumDialog.test.tsx
@@ -7,7 +7,7 @@ jest.mock('@/api/api-functions', () => ({
   createAlbum: jest.fn(),
 }));
 
-const mockCreateAlbum = createAlbum as jest.Mock;
+const mockCreateAlbum = jest.mocked(createAlbum);
 
 const renderDialog = (
   isOpen = true,
@@ -27,7 +27,16 @@ describe('CreateAlbumDialog', () => {
     jest.clearAllMocks();
     mockCreateAlbum.mockResolvedValue({
       success: true,
-      data: { id: 'a1', name: 'New Album' },
+      message: 'Album created',
+      data: {
+        id: 'a1',
+        name: 'New Album',
+        description: null,
+        is_locked: false,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        image_count: 0,
+      },
     });
   });
 
@@ -51,7 +60,10 @@ describe('CreateAlbumDialog', () => {
 
     await user.click(screen.getByRole('button', { name: /create album/i }));
 
+    const nameInput = screen.getByLabelText(/album name \*/i);
     expect(screen.getByText('Album name is required')).toBeInTheDocument();
+    expect(nameInput).toHaveAttribute('aria-invalid', 'true');
+    expect(nameInput).toHaveAttribute('aria-describedby', 'name-error');
     expect(mockCreateAlbum).not.toHaveBeenCalled();
   });
 
@@ -84,6 +96,11 @@ describe('CreateAlbumDialog', () => {
 
     expect(passwordInput).toHaveAttribute('type', 'password');
     expect(confirmPasswordInput).toHaveAttribute('type', 'password');
+    expect(togglePasswordBtn).toHaveAttribute('aria-controls', 'password');
+    expect(toggleConfirmBtn).toHaveAttribute(
+      'aria-controls',
+      'confirm-password',
+    );
 
     // Toggle password visibility
     await user.click(togglePasswordBtn);
@@ -118,12 +135,22 @@ describe('CreateAlbumDialog', () => {
     // Submit with both password and confirm password empty
     await user.click(screen.getByRole('button', { name: /create album/i }));
 
+    const passwordInput = screen.getByLabelText(/^password \*/i);
+    const confirmPasswordInput = screen.getByLabelText(/confirm password \*/i);
+
     expect(
       screen.getByText('Password is required for locked albums'),
     ).toBeInTheDocument();
     expect(
       screen.getByText('Confirm password is required'),
     ).toBeInTheDocument();
+    expect(passwordInput).toHaveAttribute('aria-invalid', 'true');
+    expect(passwordInput).toHaveAttribute('aria-describedby', 'password-error');
+    expect(confirmPasswordInput).toHaveAttribute('aria-invalid', 'true');
+    expect(confirmPasswordInput).toHaveAttribute(
+      'aria-describedby',
+      'confirm-password-error',
+    );
     expect(mockCreateAlbum).not.toHaveBeenCalled();
   });
 
@@ -159,6 +186,56 @@ describe('CreateAlbumDialog', () => {
 
     expect(screen.getByText('Passwords do not match')).toBeInTheDocument();
     expect(mockCreateAlbum).not.toHaveBeenCalled();
+  });
+
+  it('clears password fields and visibility when lock toggle is turned off', async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.type(screen.getByLabelText(/album name/i), 'Family Trip');
+    await user.click(screen.getByLabelText(/lock album/i));
+    await user.type(screen.getByLabelText(/^password \*/i), 'secret123');
+    await user.type(screen.getByLabelText(/confirm password \*/i), 'secret123');
+
+    // Toggle off lock
+    await user.click(screen.getByLabelText(/lock album/i));
+    expect(screen.queryByLabelText(/^password/i)).not.toBeInTheDocument();
+
+    // Toggle on lock again — fields should be empty
+    await user.click(screen.getByLabelText(/lock album/i));
+    expect(screen.getByLabelText(/^password \*/i)).toHaveValue('');
+    expect(screen.getByLabelText(/confirm password \*/i)).toHaveValue('');
+  });
+
+  it('resets all form state and sensitive data when closed and reopened', async () => {
+    const user = userEvent.setup();
+    const { rerender } = renderDialog(true);
+
+    await user.type(screen.getByLabelText(/album name/i), 'Secret Trip');
+    await user.click(screen.getByLabelText(/lock album/i));
+    await user.type(screen.getByLabelText(/^password \*/i), 'secret123');
+    await user.type(screen.getByLabelText(/confirm password \*/i), 'secret123');
+
+    // Simulate closing externally
+    rerender(
+      <CreateAlbumDialog
+        isOpen={false}
+        onClose={jest.fn()}
+        onSuccess={jest.fn()}
+      />,
+    );
+
+    // Reopen dialog
+    rerender(
+      <CreateAlbumDialog
+        isOpen={true}
+        onClose={jest.fn()}
+        onSuccess={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByLabelText(/album name \*/i)).toHaveValue('');
+    expect(screen.queryByLabelText(/^password/i)).not.toBeInTheDocument();
   });
 
   it('submits locked album successfully when passwords match', async () => {


### PR DESCRIPTION
… dialog

###  Addressed Issues:

Fixes #1492 


###  Screenshots/Recordings:
<img width="1920" height="1051" alt="Screenshot from 2026-08-19 00-06-23" src="https://github.com/user-attachments/assets/4236c8eb-b09a-4518-a6a4-0ecff8eaa518" />


###  Additional Notes:                                                                                
  • Adds a Confirm Password field when "Lock album" is enabled.                                       
  • Adds show/hide password visibility toggle buttons for both password fields.                       
  • Validates password requirement and ensures passwords match before submission.                                
  • Adds comprehensive unit test suite in CreateAlbumDialog.test.tsx (10/10 tests passing).           
                                                                                                      
  Local checks run:                                                                                   
                                                                                                      
  • npm test                                                                                          
  • npm run lint:check                                                                                
  • npm run format:check   


### AI Usage Disclosure:

We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact. AI slop is strongly discouraged and may lead to banning and blocking. Do not spam our repos with AI slop.

Check one of the checkboxes below:

- [x] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools: Antigravity (Gemini 3.7 Flash)


## Checklist
<!-- Mark items with [x] to indicate completion -->
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [x] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added password confirmation when creating locked albums.
  - Added show/hide controls for album passwords.
  - Added validation messages for missing or mismatched passwords.
  - Password fields and validation errors now reset when closing the dialog or disabling album locking.

- **Bug Fixes**
  - Improved validation and submission behavior for locked and unlocked albums.

- **Tests**
  - Expanded coverage for album creation, validation, password visibility, submission, and cancellation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->