### PR TITLE
fix(tests): keep local backend test runs off the real library database

### DIFF
--- a/agent-kit/references/backend-endpoint-walkthrough.md
+++ b/agent-kit/references/backend-endpoint-walkthrough.md
@@ -86,5 +86,7 @@ source of truth.
 ## Tests
 
 `backend/tests/test_videos.py` runs against a real SQLite database: the session fixture in
-`conftest.py` creates every table and sets `TEST_MODE=true` before any test runs, then
-tears down afterwards. There is no mocking layer to satisfy.
+`conftest.py` creates every table before any test runs, then tears down afterwards. There
+is no mocking layer to satisfy. The database is a throwaway `backend/test_db.sqlite3`:
+`tests/db_isolation.py` sets `TEST_MODE=true` ahead of every app import so `DATABASE_PATH`
+never resolves to the user's real library.

--- a/agent-kit/skills/add-backend-endpoint/SKILL.md
+++ b/agent-kit/skills/add-backend-endpoint/SKILL.md
@@ -70,8 +70,9 @@ Template: `agent-kit/templates/route.py.md`.
 ## 6. Tests — `backend/tests/test_<resource>.py`
 
 Follow `backend/tests/test_videos.py`. Cover the success path, the empty case, and at least
-one failure path. The session fixture in `conftest.py` creates every table and sets
-`TEST_MODE=true`, so tests get a real database.
+one failure path. The session fixture in `conftest.py` creates every table, so tests get a
+real SQLite database. It is a throwaway `backend/test_db.sqlite3`, not the user's library:
+`tests/db_isolation.py` sets `TEST_MODE=true` before any app import to redirect it.
 
 ## 7. Verify
 

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -58,7 +58,12 @@ Miss one of these and it silently half-works:
 ## Tests
 
 - `tests/test_<resource>.py`. Config in `pytest.ini`: `pythonpath = .`, `testpaths = tests`.
-- The session fixture in `conftest.py` creates every table and sets `TEST_MODE=true`.
+- `tests/db_isolation.py` sets `TEST_MODE=true` before any app import, which points
+  `DATABASE_PATH` at a throwaway `backend/test_db.sqlite3`. Never move that import
+  below the others in `conftest.py`, and never unset `TEST_MODE` mid-run: `settings.py`
+  resolves the path at import time, so either one sends the suite at the user's real
+  library, which it then drops and truncates.
+- The session fixture in `conftest.py` creates every table.
 - Run with `cd backend && pytest`.
 
 ## Environment

--- a/backend/app/config/settings.py
+++ b/backend/app/config/settings.py
@@ -38,7 +38,9 @@ DEFAULT_FACENET_MODEL = f"{MODEL_EXPORTS_PATH}/FaceNet_128D.onnx"
 
 TEST_INPUT_PATH = "tests/inputs"
 TEST_OUTPUT_PATH = "tests/outputs"
-if os.getenv("GITHUB_ACTIONS") == "true":
+# TEST_MODE has to be honoured here, not just GITHUB_ACTIONS: CI sets the latter
+# for free, so a local pytest run would otherwise write to the real library.
+if os.getenv("GITHUB_ACTIONS") == "true" or os.getenv("TEST_MODE") == "true":
     DATABASE_PATH = os.path.join(os.getcwd(), "test_db.sqlite3")
 else:
     DATABASE_PATH = os.path.join(user_data_dir("PictoPy"), "database", "PictoPy.db")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,5 +1,8 @@
+# Must come first: it sets TEST_MODE, which settings.py reads at import time to
+# keep the suite off the user's real library database.
+import tests.db_isolation  # noqa: F401
+
 import pytest
-import os
 
 # Import database table creation functions
 from app.database.faces import db_create_faces_table
@@ -19,9 +22,6 @@ from app.database.memories import db_create_memories_table
 @pytest.fixture(scope="session", autouse=True)
 def setup_before_all_tests():
     print("\n=== Running manual setup fixture ===")
-
-    # Set test environment
-    os.environ["TEST_MODE"] = "true"
 
     # Create all database tables in the same order as main.py
     print("Creating database tables...")
@@ -49,6 +49,5 @@ def setup_before_all_tests():
     # Teardown code runs after all tests
     print("\n=== Running cleanup after all tests ===")
 
-    # Cleanup code here
-    if "TEST_MODE" in os.environ:
-        del os.environ["TEST_MODE"]
+    # TEST_MODE stays set: unsetting it would let any late import of settings.py
+    # resolve DATABASE_PATH back to the real library.

--- a/backend/tests/db_isolation.py
+++ b/backend/tests/db_isolation.py
@@ -1,0 +1,24 @@
+"""Points the database at a throwaway file before anything imports app.config."""
+
+import os
+
+# settings.py resolves DATABASE_PATH at import time, so this has to happen before
+# any app import. CI gets the same redirect for free via GITHUB_ACTIONS.
+os.environ["TEST_MODE"] = "true"
+
+from app.config.settings import DATABASE_PATH  # noqa: E402
+from platformdirs import user_data_dir  # noqa: E402
+
+
+def _assert_not_user_library() -> None:
+    # The suite drops and truncates tables, so a silent redirect failure would
+    # destroy a real library. Fail the session instead.
+    library_dir = os.path.abspath(user_data_dir("PictoPy"))
+    resolved = os.path.abspath(DATABASE_PATH)
+    if os.path.commonpath([resolved, library_dir]) == library_dir:
+        raise RuntimeError(
+            f"Refusing to run tests against the PictoPy library database: {resolved}"
+        )
+
+
+_assert_not_user_library()

--- a/backend/tests/test_db_isolation.py
+++ b/backend/tests/test_db_isolation.py
@@ -1,0 +1,35 @@
+import os
+
+import pytest
+from platformdirs import user_data_dir
+
+from app.config.settings import DATABASE_PATH
+from app.database.connection import DATABASE_PATH as CONNECTION_DATABASE_PATH
+from tests import db_isolation
+
+
+def test_test_mode_redirects_database_path() -> None:
+    assert os.environ["TEST_MODE"] == "true"
+    assert os.path.basename(DATABASE_PATH) == "test_db.sqlite3"
+
+
+def test_database_path_is_outside_the_user_library() -> None:
+    library_dir = os.path.abspath(user_data_dir("PictoPy"))
+    resolved = os.path.abspath(DATABASE_PATH)
+    assert os.path.commonpath([resolved, library_dir]) != library_dir
+
+
+def test_connection_module_uses_the_redirected_path() -> None:
+    # The connection module binds DATABASE_PATH at import time, so a redirect that
+    # lands after it would leave every query pointed at the real library.
+    assert CONNECTION_DATABASE_PATH == DATABASE_PATH
+
+
+def test_guard_rejects_a_path_inside_the_user_library(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    library_db = os.path.join(user_data_dir("PictoPy"), "database", "PictoPy.db")
+    monkeypatch.setattr(db_isolation, "DATABASE_PATH", library_db)
+
+    with pytest.raises(RuntimeError, match="Refusing to run tests"):
+        db_isolation._assert_not_user_library()


### PR DESCRIPTION
Closes #1483

`cd backend && pytest`, the command in `backend/AGENTS.md`, pointed `DATABASE_PATH` at the user's real `PictoPy.db` and created every application table inside it. Several tests `DROP TABLE` and `DELETE FROM`, so on an indexed library a local test run could destroy real data. CI was never affected.

## Why it happened

Two independent faults, and fixing either one alone leaves the bug live.

**1. `settings.py` gated the test path on the wrong variable.**

```python
if os.getenv("GITHUB_ACTIONS") == "true":
    DATABASE_PATH = os.path.join(os.getcwd(), "test_db.sqlite3")
else:
    DATABASE_PATH = os.path.join(user_data_dir("PictoPy"), "database", "PictoPy.db")
```

GitHub sets `GITHUB_ACTIONS=true` automatically, so CI got isolation for free and nobody noticed. Locally nothing sets it.

**2. `conftest.py` set `TEST_MODE` too late to matter.**

It set it inside the `setup_before_all_tests` fixture body. But `conftest.py`'s own module-level `from app.database.faces import ...` imports run during collection, long before any fixture executes, and `settings.py` computes `DATABASE_PATH` at import time. By the time the fixture ran, every module had already frozen the wrong value.

## The fix

`settings.py` now honours `TEST_MODE` alongside `GITHUB_ACTIONS`, and a new `backend/tests/db_isolation.py` sets it **before any app import**. `conftest.py` imports that module as its first statement, so ordering is enforced by the import graph rather than by a comment asking people not to move a line.

Same module refuses to start a run whose resolved `DATABASE_PATH` lands inside `user_data_dir("PictoPy")`. If the redirect ever silently breaks again, the session dies with a message instead of quietly writing to the library.

The fixture's teardown no longer deletes `TEST_MODE`. Unsetting it mid-process would let any later import of `settings.py` resolve straight back to the real library.

## Evidence

Recorded the library database's mtime and size, ran the full suite, compared.

| branch | before | after | result |
| --- | --- | --- | --- |
| `main` | `1787161142 98713600` | `1787162533 98713600` | **mtime moved** |
| this branch | `1787162533 98713600` | `1787162533 98713600` | untouched |

Tables land in `backend/test_db.sqlite3` instead, which `backend/.gitignore` already covers. I hit the `main` row by accident while verifying an unrelated branch, which is a fair illustration of how easy this is to trip.

## Tests

`backend/tests/test_db_isolation.py`, four cases:

- the redirect lands and `TEST_MODE` is set
- `DATABASE_PATH` resolves outside `user_data_dir("PictoPy")`
- `app/database/connection.py` sees the redirected value, since it binds `DATABASE_PATH` at import time and a redirect landing after it would leave every query pointed at the library
- the guard raises when handed a library path

Backend suite goes from 1110 to 1114.

## Credit

@tanmaysachann's analysis on the issue reached the same two-part root cause independently, and added a point worth recording: because each module does `from app.config.settings import DATABASE_PATH`, a name copy rather than a live reference, patching `app.config.settings.DATABASE_PATH` alone is not enough. The existing "safe" tests each have to patch several targets by hand. Quantified across the suite, 17 test files carry that pattern, between 1 and 5 targets each:

```
test_face_clusters.py  5    test_folders.py       5    test_memories_db.py   5
test_video_frames.py   5    test_albums_db.py     4    test_images_db.py     4
test_images_rescan.py  4    test_share_routes.py  4    test_faces_db.py      3
...
```

Fixing the value at the source does not remove that per-file patching, since those tests still want their own isolated tempfile per test. What it does remove is the consequence of forgetting: a file that misses a target now falls back to a throwaway database rather than the user's library.

@Ankushh0027 also offered to take this one. I was assigned the issue so I carried it through, but the analysis above is largely shared ground.

## Docs

Three files stated the old behaviour. `agent-kit/skills/add-backend-endpoint/SKILL.md` read "so tests get a real database", which was true in a way nobody intended.

## Scope

`THUMBNAIL_IMAGES_PATH` and `VIDEO_FRAMES_PATH` still resolve to `user_data_dir` unconditionally, and this PR does not change that.

I looked at whether they are a second live exposure. They are not, but the reason is worth stating precisely rather than waving at. Tests do reach filesystem writes under those paths, including `video_util_purge_frame_cache`, which calls `shutil.rmtree(VIDEO_FRAMES_PATH)`. Every call site redirects the path to a tempdir first: both purge tests request the `frames_dir` fixture (`tests/test_video_frames.py:71-78`), and the thumbnail tests patch `app.utils.videos.THUMBNAIL_IMAGES_PATH` per test. Confirmed empirically too, the real thumbnails directory's mtime predates any of this work.

So the filesystem side is safe by per-test fixture discipline, not by construction. If someone later adds a test that calls `video_util_purge_frame_cache` without requesting `frames_dir`, it recursively deletes the user's real frame cache and nothing stops it. That is the same shape of latent fault this PR fixes for the database, and I have deliberately left it out rather than widen the diff. Happy to file it separately if a maintainer wants it tracked.

## One note for anyone who ran pytest locally before this

The fix stops future runs from writing to the library database. It does not undo writes that already happened. If you ran `cd backend && pytest` on an indexed library, that database may contain tables the fixture created, and rows that tests inserted or deleted. Worth checking before assuming a clean slate.

## Verification

```
1114 passed in 13.91s
black    117 files unchanged
ruff     All checks passed!
markdownlint clean on the three changed docs
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Tests now consistently use a disposable local database instead of the user’s real PictoPy library.
  - Improved protection against accidental access to production data during testing.
  - Test database selection now works in both automated builds and explicit test mode.

- **Tests**
  - Added coverage verifying database isolation, path selection, and protection against unsafe database locations.
  - Updated test setup documentation and instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
