### PR TITLE
Memories Cards still remains after the deletion of all the folders.

### DIFF
--- a/backend/app/database/memories.py
+++ b/backend/app/database/memories.py
@@ -389,10 +389,12 @@ def db_delete_memory(memory_id: MemoryId) -> bool:
 
 def db_prune_empty_memories(min_images: int) -> int:
     """
-    Mark memories whose live image count fell below min_images as 'empty'.
+    Mark memories as 'empty' once they no longer have enough live media.
 
     Images deleted from the library cascade out of memory_images, so a memory
-    can silently shrink below the point where it is worth surfacing.
+    can silently shrink below the point where it is worth surfacing. A memory
+    that still holds live videos is left alone even so -- the video content
+    stands on its own regardless of how few images remain.
     """
     conn = None
     try:
@@ -404,6 +406,8 @@ def db_prune_empty_memories(min_images: int) -> int:
             WHERE status = 'complete'
               AND (SELECT COUNT(*) FROM memory_images mi
                     WHERE mi.memory_id = memories.memory_id) < ?
+              AND (SELECT COUNT(*) FROM memory_videos mv
+                    WHERE mv.memory_id = memories.memory_id) = 0
             """,
             (min_images,),
         )

--- a/backend/app/routes/folders.py
+++ b/backend/app/routes/folders.py
@@ -419,7 +419,7 @@ def disable_ai_tagging(request: UpdateAITaggingRequest):
 )
 def delete_folders(
     request: DeleteFoldersRequest, app_state: State = Depends(get_state)
-):
+) -> DeleteFoldersResponse:
     """Delete multiple folders by their IDs."""
     try:
         if not request.folder_ids:
@@ -427,12 +427,12 @@ def delete_folders(
 
         deleted_count = db_delete_folders_batch(request.folder_ids)
 
-        # Deleted images/videos cascade out of memory_images/memory_videos,
-        # which can leave memories pointing at nothing. Re-curate so those
-        # get pruned instead of lingering in the grid until the next
-        # unrelated add/sync/tagging run.
+        # Best-effort: re-curate to prune memories orphaned by the delete; a failed submit shouldn't mask a delete that already succeeded.
         executor: ProcessPoolExecutor = app_state.executor
-        executor.submit(_curate_memories, "folder_delete")
+        try:
+            executor.submit(_curate_memories, "folder_delete")
+        except Exception as e:
+            logger.error(f"Failed to queue memory curation after folder delete: {e}")
 
         return DeleteFoldersResponse(
             data=DeleteFoldersData(

--- a/backend/app/routes/folders.py
+++ b/backend/app/routes/folders.py
@@ -419,7 +419,7 @@ def disable_ai_tagging(request: UpdateAITaggingRequest):
 )
 def delete_folders(
     request: DeleteFoldersRequest, app_state: State = Depends(get_state)
-) -> DeleteFoldersResponse:
+):
     """Delete multiple folders by their IDs."""
     try:
         if not request.folder_ids:
@@ -427,12 +427,22 @@ def delete_folders(
 
         deleted_count = db_delete_folders_batch(request.folder_ids)
 
-        # Best-effort: re-curate to prune memories orphaned by the delete; a failed submit shouldn't mask a delete that already succeeded.
+        # Synchronous so the response can't race the frontend's next
+        # Memories fetch; imported late, like _curate_memories below.
+        try:
+            from app.utils.memory_curator import memory_curator_prune_empty
+
+            memory_curator_prune_empty()
+        except Exception:
+            logger.exception("Failed to prune empty memories after folder delete")
+
+        # New memories from what's left can still be found in the
+        # background -- best-effort, a dropped submit just delays it.
         executor: ProcessPoolExecutor = app_state.executor
         try:
             executor.submit(_curate_memories, "folder_delete")
-        except Exception as e:
-            logger.error(f"Failed to queue memory curation after folder delete: {e}")
+        except Exception:
+            logger.exception("Failed to queue memory curation after folder delete")
 
         return DeleteFoldersResponse(
             data=DeleteFoldersData(

--- a/backend/app/routes/folders.py
+++ b/backend/app/routes/folders.py
@@ -417,13 +417,22 @@ def disable_ai_tagging(request: UpdateAITaggingRequest):
     response_model=DeleteFoldersResponse,
     responses={code: {"model": ErrorResponse} for code in [400, 500]},
 )
-def delete_folders(request: DeleteFoldersRequest):
+def delete_folders(
+    request: DeleteFoldersRequest, app_state: State = Depends(get_state)
+):
     """Delete multiple folders by their IDs."""
     try:
         if not request.folder_ids:
             raise ValueError("No folder IDs provided")
 
         deleted_count = db_delete_folders_batch(request.folder_ids)
+
+        # Deleted images/videos cascade out of memory_images/memory_videos,
+        # which can leave memories pointing at nothing. Re-curate so those
+        # get pruned instead of lingering in the grid until the next
+        # unrelated add/sync/tagging run.
+        executor: ProcessPoolExecutor = app_state.executor
+        executor.submit(_curate_memories, "folder_delete")
 
         return DeleteFoldersResponse(
             data=DeleteFoldersData(

--- a/backend/app/utils/memory_curator.py
+++ b/backend/app/utils/memory_curator.py
@@ -195,6 +195,20 @@ def memory_curator_get_preferences() -> MemoriesPreferences:
         return MemoriesPreferences()
 
 
+def memory_curator_prune_empty(min_images: Optional[int] = None) -> int:
+    """
+    Mark memories empty once their live image count drops below the
+    configured minimum -- e.g. a folder was deleted out from under one.
+
+    A single UPDATE, not a curation pass: safe to call synchronously from a
+    route. Pass min_images when the caller already has preferences loaded
+    (memory_curator_run); omit it to have this fetch its own.
+    """
+    if min_images is None:
+        min_images = memory_curator_get_preferences().min_images
+    return db_prune_empty_memories(min_images)
+
+
 def memory_curator_params_signature(preferences: MemoriesPreferences) -> str:
     """Fingerprint the inputs that determine curation output."""
     payload = {
@@ -1003,14 +1017,14 @@ def memory_curator_run(
             if stale:
                 logger.info(f"Dropped {stale} memories whose capture dates moved")
         except Exception:
-            logger.error("Failed to drop stale memories", exc_info=True)
+            logger.exception("Failed to drop stale memories")
 
         try:
-            emptied = db_prune_empty_memories(preferences.min_images)
+            emptied = memory_curator_prune_empty(preferences.min_images)
             if emptied:
                 logger.info(f"Marked {emptied} memories empty (images/folders removed)")
         except Exception:
-            logger.error("Failed to prune empty memories", exc_info=True)
+            logger.exception("Failed to prune empty memories")
 
         context = _CurationContext(reference, preferences, params_signature)
 

--- a/backend/app/utils/memory_curator.py
+++ b/backend/app/utils/memory_curator.py
@@ -29,6 +29,7 @@ from app.database.image_embeddings import (
 )
 from app.database.memories import (
     db_delete_stale_memories,
+    db_prune_empty_memories,
     db_get_video_candidates_in_period,
     db_get_video_scoring_signals,
     db_finish_memory_run,
@@ -1003,6 +1004,13 @@ def memory_curator_run(
                 logger.info(f"Dropped {stale} memories whose capture dates moved")
         except Exception:
             logger.error("Failed to drop stale memories", exc_info=True)
+
+        try:
+            emptied = db_prune_empty_memories(preferences.min_images)
+            if emptied:
+                logger.info(f"Marked {emptied} memories empty (images/folders removed)")
+        except Exception:
+            logger.error("Failed to prune empty memories", exc_info=True)
 
         context = _CurationContext(reference, preferences, params_signature)
 

--- a/backend/tests/test_folders.py
+++ b/backend/tests/test_folders.py
@@ -619,6 +619,27 @@ class TestFoldersAPI:
         mock_delete_batch.assert_called_once_with(["folder-1", "folder-2", "folder-3"])
 
     @patch("app.routes.folders.db_delete_folders_batch")
+    def test_delete_folders_background_processing_called(
+        self, mock_delete_batch, client
+    ):
+        """Test that memory re-curation is triggered after deleting folders."""
+        mock_delete_batch.return_value = 3
+
+        response = client.request(
+            "DELETE",
+            "/folders/delete-folders",
+            content='{"folder_ids": ["folder-1", "folder-2", "folder-3"]}',
+            headers={"Content-Type": "application/json"},
+        )
+
+        assert response.status_code == 200
+
+        # Verify background processing was triggered, so memories left
+        # pointing at the deleted folder's images get pruned.
+        app_state = client.app.state
+        app_state.executor.submit.assert_called_once()
+
+    @patch("app.routes.folders.db_delete_folders_batch")
     def test_delete_folders_single_folder(self, mock_delete_batch, client):
         """Test deleting a single folder."""
         mock_delete_batch.return_value = 1

--- a/backend/tests/test_folders.py
+++ b/backend/tests/test_folders.py
@@ -13,6 +13,7 @@ from concurrent.futures import Future, ProcessPoolExecutor
 
 
 from app.routes.folders import router as folders_router
+from app.routes.folders import _curate_memories
 
 from app.database.folders import (
     db_create_folders_table,
@@ -618,11 +619,12 @@ class TestFoldersAPI:
 
         mock_delete_batch.assert_called_once_with(["folder-1", "folder-2", "folder-3"])
 
+    @patch("app.utils.memory_curator.memory_curator_prune_empty")
     @patch("app.routes.folders.db_delete_folders_batch")
     def test_delete_folders_background_processing_called(
-        self, mock_delete_batch, client
-    ):
-        """Test that memory re-curation is triggered after deleting folders."""
+        self, mock_delete_batch: MagicMock, mock_prune: MagicMock, client: TestClient
+    ) -> None:
+        """Pruning and re-curation are both triggered after deleting folders."""
         mock_delete_batch.return_value = 3
 
         response = client.request(
@@ -634,10 +636,65 @@ class TestFoldersAPI:
 
         assert response.status_code == 200
 
-        # Verify background processing was triggered, so memories left
-        # pointing at the deleted folder's images get pruned.
+        # Empty memories are pruned synchronously, before the response returns.
+        mock_prune.assert_called_once_with()
+
+        # The heavier curation pass still runs in the background.
         app_state = client.app.state
-        app_state.executor.submit.assert_called_once()
+        app_state.executor.submit.assert_called_once_with(
+            _curate_memories, "folder_delete"
+        )
+
+    @patch("app.utils.memory_curator.memory_curator_prune_empty")
+    @patch("app.routes.folders.db_delete_folders_batch")
+    def test_delete_folders_survives_curation_submission_failure(
+        self, mock_delete_batch: MagicMock, mock_prune: MagicMock, client: TestClient
+    ) -> None:
+        """
+        A broken/shutdown executor must not turn an already-successful
+        delete into a failure response -- the background curation pass is
+        best-effort on top of a delete that already happened.
+        """
+        mock_delete_batch.return_value = 3
+        client.app.state.executor.submit.side_effect = RuntimeError(
+            "cannot schedule new futures after shutdown"
+        )
+
+        response = client.request(
+            "DELETE",
+            "/folders/delete-folders",
+            content='{"folder_ids": ["folder-1", "folder-2", "folder-3"]}',
+            headers={"Content-Type": "application/json"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["data"]["deleted_count"] == 3
+
+        # The synchronous prune is unaffected by the background submit
+        # failing -- the two are independent try/excepts.
+        mock_prune.assert_called_once_with()
+        client.app.state.executor.submit.assert_called_once()
+
+    @patch("app.utils.memory_curator.memory_curator_prune_empty")
+    @patch("app.routes.folders.db_delete_folders_batch")
+    def test_delete_folders_survives_pruning_failure(
+        self, mock_delete_batch: MagicMock, mock_prune: MagicMock, client: TestClient
+    ) -> None:
+        """Mirror of the submit-failure test -- prune failing doesn't block it either."""
+        mock_delete_batch.return_value = 3
+        mock_prune.side_effect = RuntimeError("prune failed")
+
+        response = client.request(
+            "DELETE",
+            "/folders/delete-folders",
+            content='{"folder_ids": ["folder-1"]}',
+            headers={"Content-Type": "application/json"},
+        )
+
+        assert response.status_code == 200
+        client.app.state.executor.submit.assert_called_once_with(
+            _curate_memories, "folder_delete"
+        )
 
     @patch("app.routes.folders.db_delete_folders_batch")
     def test_delete_folders_single_folder(self, mock_delete_batch, client):

--- a/backend/tests/test_memories_db.py
+++ b/backend/tests/test_memories_db.py
@@ -85,6 +85,27 @@ def images(test_db: str) -> List[str]:
     return image_ids
 
 
+@pytest.fixture
+def videos(test_db: str, images: List[str]) -> List[str]:
+    """Insert five videos into the same folder the `images` fixture uses."""
+    conn = sqlite3.connect(test_db)
+    video_ids = [f"vid-{i}" for i in range(5)]
+    for i, video_id in enumerate(video_ids):
+        conn.execute(
+            "INSERT INTO videos (id, path, folder_id, thumbnailPath, captured_at) "
+            "VALUES (?, ?, 'folder-1', ?, ?)",
+            (
+                video_id,
+                f"/videos/{i}.mp4",
+                f"/thumbs/vid-{i}.jpg",
+                f"2024-06-15 1{i}:30:00",
+            ),
+        )
+    conn.commit()
+    conn.close()
+    return video_ids
+
+
 def make_memory(dedupe_key: str, **overrides: Any) -> Dict[str, Any]:
     memory: Dict[str, Any] = {
         "memory_id": str(uuid.uuid4()),
@@ -333,6 +354,27 @@ class TestMarkAndPrune:
         assert db_prune_empty_memories(2) == 1
         assert db_get_memory(shrink)["status"] == "empty"
         assert db_get_memory(keep)["status"] == "complete"
+
+    def test_prune_retains_video_only_memories(self, videos: List[str]):
+        """Losing every image doesn't make a memory empty if videos remain."""
+        memory_id = db_upsert_memory(make_memory("video-only"), [], entries(videos[:2]))
+
+        assert db_prune_empty_memories(2) == 0
+        assert db_get_memory(memory_id)["status"] == "complete"
+
+    def test_prune_marks_below_threshold_images_with_no_videos(self, images: List[str]):
+        """Too few images and no video to fall back on: still prune."""
+        memory_id = db_upsert_memory(make_memory("thin"), entries(images[:1]))
+
+        assert db_prune_empty_memories(2) == 1
+        assert db_get_memory(memory_id)["status"] == "empty"
+
+    def test_prune_marks_memories_with_no_media_at_all(self, test_db: str):
+        """No images, no videos: unambiguously empty."""
+        memory_id = db_upsert_memory(make_memory("bare"), [])
+
+        assert db_prune_empty_memories(2) == 1
+        assert db_get_memory(memory_id)["status"] == "empty"
 
 
 # ##############################

--- a/backend/tests/test_memory_curator.py
+++ b/backend/tests/test_memory_curator.py
@@ -1009,6 +1009,30 @@ class TestVideoCuration:
         assert sorted(orders) == list(range(len(orders)))
 
 
+class TestPruneEmpty:
+    def test_uses_the_supplied_min_images_without_a_fetch(self) -> None:
+        with (
+            patch.object(
+                memory_curator, "db_prune_empty_memories", return_value=2
+            ) as prune,
+            patch.object(memory_curator, "memory_curator_get_preferences") as get_prefs,
+        ):
+            result = memory_curator.memory_curator_prune_empty(7)
+
+        prune.assert_called_once_with(7)
+        get_prefs.assert_not_called()
+        assert result == 2
+
+    def test_fetches_preferences_when_none_supplied(self) -> None:
+        # stub_preferences (autouse) returns min_images=3.
+        with patch.object(
+            memory_curator, "db_prune_empty_memories", return_value=0
+        ) as prune:
+            memory_curator.memory_curator_prune_empty()
+
+        prune.assert_called_once_with(3)
+
+
 class TestRunOrchestration:
     def test_returns_the_number_of_memories_written(self):
         with patch.object(memory_curator, "db_finish_memory_run") as finish:

--- a/backend/tests/test_memory_curator.py
+++ b/backend/tests/test_memory_curator.py
@@ -1064,6 +1064,22 @@ class TestRunOrchestration:
             upserts = run_curator(anniversary=make_anniversary_images(2024, 5))
         assert len(of_type(upserts, "anniversary")) == 1
 
+    def test_empty_memories_are_pruned_with_the_configured_min_images(self):
+        """
+        Images deleted out from under a memory (a folder removal, say) leave
+        it with nothing to show; this is what makes it stop surfacing.
+        """
+        with patch.object(memory_curator, "db_prune_empty_memories") as prune:
+            run_curator(anniversary=make_anniversary_images(2024, 5))
+        prune.assert_called_once_with(3)  # stub_preferences sets min_images=3
+
+    def test_a_failing_empty_prune_does_not_stop_the_run(self):
+        with patch.object(
+            memory_curator, "db_prune_empty_memories", side_effect=Exception("locked")
+        ):
+            upserts = run_curator(anniversary=make_anniversary_images(2024, 5))
+        assert len(of_type(upserts, "anniversary")) == 1
+
     def test_recently_used_is_refreshed_between_triggers(self):
         """Later triggers must not reuse what an earlier one just claimed."""
         mocks: Dict[str, Any] = {}

--- a/frontend/src/hooks/__tests__/useFolderOperations.test.tsx
+++ b/frontend/src/hooks/__tests__/useFolderOperations.test.tsx
@@ -47,6 +47,11 @@ const clustersKeyCalls = (spy: jest.SpyInstance) =>
     ([arg]) => JSON.stringify(arg?.queryKey) === JSON.stringify(['clusters']),
   );
 
+const memoriesKeyCalls = (spy: jest.SpyInstance) =>
+  spy.mock.calls.filter(
+    ([arg]) => JSON.stringify(arg?.queryKey) === JSON.stringify(['memories']),
+  );
+
 describe('useFolderOperations - delete folder cache invalidation', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -60,6 +65,19 @@ describe('useFolderOperations - delete folder cache invalidation', () => {
 
     await waitFor(() => {
       expect(clustersKeyCalls(invalidateSpy).length).toBeGreaterThan(0);
+    });
+  });
+
+  it('invalidates the memories query when folder deletion succeeds', async () => {
+    // Invalidates the 5-minute frontend cache so the UI immediately reflects synchronous
+    // backend deletions without requiring the user to manually regenerate.
+    deleteFolders.mockResolvedValueOnce({ success: true, data: {} });
+    const { result, invalidateSpy } = renderUseFolderOperations();
+
+    result.current.deleteFolder('folder-1');
+
+    await waitFor(() => {
+      expect(memoriesKeyCalls(invalidateSpy).length).toBeGreaterThan(0);
     });
   });
 
@@ -89,5 +107,6 @@ describe('useFolderOperations - delete folder cache invalidation', () => {
     );
 
     expect(clustersKeyCalls(invalidateSpy)).toHaveLength(0);
+    expect(memoriesKeyCalls(invalidateSpy)).toHaveLength(0);
   });
 });

--- a/frontend/src/hooks/useFolderOperations.tsx
+++ b/frontend/src/hooks/useFolderOperations.tsx
@@ -13,6 +13,7 @@ import { setFolders, setTaggingStatus } from '@/features/folderSlice';
 import { FolderDetails, isIndexingPending } from '@/types/Folder';
 import { useMutationFeedback } from './useMutationFeedback';
 import { getFoldersTaggingStatus } from '@/api/api-functions/folders';
+import { MEMORIES_QUERY_KEY } from '@/hooks/useMemories';
 
 /**
  * Custom hook for folder operations
@@ -136,12 +137,11 @@ export const useFolderOperations = () => {
     mutationFn: async (folder_id: string) =>
       deleteFolders({ folder_ids: [folder_id] }),
     autoInvalidateTags: ['folders'],
-    // Deleting a folder cascades to its images and faces, so any cluster built from
-    // them is now stale. This has to be a separate call: autoInvalidateTags is passed
-    // through as a single queryKey and matches by prefix, so ['folders', 'clusters']
-    // would match neither query.
+    // Clusters and memories become stale on folder deletion. They require separate invalidation calls
+    // because autoInvalidateTags uses prefix matching, meaning a combined queryKey wouldn't match either.
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['clusters'] });
+      queryClient.invalidateQueries({ queryKey: MEMORIES_QUERY_KEY });
     },
   });
 


### PR DESCRIPTION
###  Addressed Issues:

Fixes #1485 : Folder Deletion dosen't delete memories that were made from that folder.

**Problem Statement:**  Deleting a folder from Settings, removes the folder's images from the library,
but any auto-generated Memories built from those images are left behind as empty,
broken tiles instead of being removed.


###  Screenshots/Recordings:

**PictoPy Before:**


https://github.com/user-attachments/assets/4b6f8b7c-6141-4d8a-9176-680de83738d3


**PictoPy After:**


https://github.com/user-attachments/assets/b527829b-515a-4299-924e-5bee9a396d65




###  Additional Notes:

**Reason for Changes:**

There's a memories table separate from the images table. Each memory has links to the photos it's made up of. When you delete a folder, its photos get deleted from the database, and that correctly cascades to remove the links between those photos and whatever memory they belonged to.

But nothing ever goes back and checks the memory itself afterward. So the memory row just sits there forever, still marked "complete," with zero photos attached.

1. **Dead Code:** there's already a function for exactly this, `db_prune_empty_memories(),` that marks a memory "empty" once its photo count drops too low. It's fully written, and it even has its own passing tests. Nobody ever calls it. It iss a dead code.

2. Deleting a folder doesn't trigger any memory recalculation at all — adding a folder does, syncing does, toggling AI tagging does, but delete was just skipped.


**Files Changed :** 8 (4 test files, 3 main backend files, 1 Frontend File)

**Backend:**
**1. app/utils/memory_curator.py:**

```
from app.database.memories import (
    db_delete_stale_memories,
    db_prune_empty_memories,
    db_get_video_candidates_in_period,
    db_get_video_scoring_signals,
    db_finish_memory_run,
```
    
    Added this `db_prune_empty_memories ` It was already present as a dead code.

```
 try:
            emptied = db_prune_empty_memories(preferences.min_images)
            if emptied:
                logger.info(f"Marked {emptied} memories empty (images/folders removed)")
        except Exception:
            logger.error("Failed to prune empty memories", exc_info=True)
```
Added this in memory_curator_run function.



**2. app/routes/folders.py:**

```
def delete_folders(
    request: DeleteFoldersRequest, app_state: State = Depends(get_state)
):
```

changed this : `def delete_folders(request: DeleteFoldersRequest):`

.


```
 # Deleted images/videos cascade out of memory_images/memory_videos,
        # which can leave memories pointing at nothing. Re-curate so those
        # get pruned instead of lingering in the grid until the next
        # unrelated add/sync/tagging run.
        executor: ProcessPoolExecutor = app_state.executor
        executor.submit(_curate_memories, "folder_delete")
```

**3.backend/app/database/memories.py:**
Coderabbit Fix.



**4. Added required tests in test files.**
a)backend/tests/test_folders.py
b)backend/tests/test_memory_curator.py
c)backend/tests/test_memories_db.py

**Frontend:**

**1.frontend/src/hooks/useFolderOperations.tsx:**

`import { MEMORIES_QUERY_KEY } from '@/hooks/useMemories';`

   ```
 // Clusters and memories become stale on folder deletion. They require separate invalidation calls
    // because autoInvalidateTags uses prefix matching, meaning a combined queryKey wouldn't match either.
    onSuccess: () => {
      queryClient.invalidateQueries({ queryKey: ['clusters'] });
      queryClient.invalidateQueries({ queryKey: MEMORIES_QUERY_KEY });
```

**Explaination:** 
The Root Cause: When a folder is deleted, the database correctly cascades the deletion to images and faces. However, the frontend forgets to invalidate the memories React Query cache (even though it already does this for clusters).

The Bug: Because useMemories() has a 5-minute staleTime, the UI relies on the uninvalidated cache and shows outdated memories for up to 5 minutes instead of refetching from the updated database.

Why "Regenerate" works: The useRefreshMemories hook is the only thing explicitly invalidating the memories cache, forcing the UI to finally sync with the database.

The Fix: Simply added a cache invalidation for memories immediately following a folder deletion.


**2.frontend/src/hooks/__tests__/useFolderOperations.test.tsx:** Added the required tests that were needed.


**Passing Checks:**
```
pytest
ruff check .
```

### Summary:
Now, whenever you press regenerate after updating the folders in the folder management. The memories also gets updated on time of deletion.


### AI Usage Disclosure:

We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact. AI slop is strongly discouraged and may lead to banning and blocking. Do not spam our repos with AI slop.

Check one of the checkboxes below:

- [ ] This PR does not contain AI-generated code at all.
- [x] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools: Claude Sonnet 5


## Checklist
<!-- Mark items with [x] to indicate completion -->
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [x] If applicable, I have made corresponding changes or additions to the documentation
- [x] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Successful folder deletions now trigger background memory re-curation.
  * Memories with fewer than the configured minimum number of images are identified for cleanup during curation.

* **Bug Fixes**
  * Memories containing live videos are preserved during image-based cleanup.
  * Memory cleanup and background re-curation continue gracefully when individual operations or job submission fail.
  * Successful folder deletions now refresh memory results automatically.

* **Tests**
  * Added coverage for cleanup thresholds, video-only memories, folder deletion updates, and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->