### PR TITLE
fix: standardize /toggle-favourite response model and error envelope

### DIFF
--- a/backend/app/routes/images.py
+++ b/backend/app/routes/images.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, HTTPException, Query, status
 from typing import List, Optional
 from app.database.images import db_get_all_images
-from app.schemas.images import ErrorResponse
+from app.schemas.images import ErrorResponse, ToggleFavouriteResponse
 from app.utils.images import image_util_parse_metadata
 from pydantic import BaseModel
 from app.database.images import (
@@ -320,7 +320,11 @@ class ToggleFavouriteRequest(BaseModel):
     image_id: str
 
 
-@router.post("/toggle-favourite")
+@router.post(
+    "/toggle-favourite",
+    response_model=ToggleFavouriteResponse,
+    responses={code: {"model": ErrorResponse} for code in [404, 500]},
+)
 def toggle_favourite(req: ToggleFavouriteRequest):
     """
     Toggle the favorite status of an image.
@@ -331,14 +335,22 @@ def toggle_favourite(req: ToggleFavouriteRequest):
         if not success:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
-                detail="Image not found or failed to toggle",
+                detail=ErrorResponse(
+                    success=False,
+                    error="Image not found",
+                    message=f"No image with id '{image_id}' could be toggled",
+                ).model_dump(),
             )
         # Fetch updated status to return
         image = db_get_image_by_id(image_id)
         if not image:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
-                detail="Image not found after toggle",
+                detail=ErrorResponse(
+                    success=False,
+                    error="Image not found",
+                    message=f"Image '{image_id}' disappeared after toggling",
+                ).model_dump(),
             )
         return {
             "success": True,
@@ -351,7 +363,11 @@ def toggle_favourite(req: ToggleFavouriteRequest):
         logger.error(f"error in /toggle-favourite route: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Internal server error: {e}",
+            detail=ErrorResponse(
+                success=False,
+                error="Internal server error",
+                message=f"Unable to toggle favourite: {str(e)}",
+            ).model_dump(),
         )
 
 

--- a/backend/app/schemas/images.py
+++ b/backend/app/schemas/images.py
@@ -134,3 +134,9 @@ class DeleteThumbnailsResponse(BaseModel):
 class GetThumbnailPathResponse(BaseModel):
     success: bool
     thumbnailPath: str
+
+
+class ToggleFavouriteResponse(BaseModel):
+    success: bool
+    image_id: str
+    isFavourite: bool

--- a/backend/tests/test_toggle_favourite.py
+++ b/backend/tests/test_toggle_favourite.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi import FastAPI
@@ -8,7 +8,7 @@ from app.routes.images import router as images_router
 
 
 @pytest.fixture
-def client():
+def client() -> TestClient:
     """Create a test client with the images router mounted."""
     app = FastAPI()
     app.include_router(images_router, prefix="/images")
@@ -20,7 +20,9 @@ class TestToggleFavourite:
 
     @patch("app.routes.images.db_get_image_by_id")
     @patch("app.routes.images.db_toggle_image_favourite_status")
-    def test_success(self, mock_toggle, mock_get, client):
+    def test_success(
+        self, mock_toggle: MagicMock, mock_get: MagicMock, client: TestClient
+    ) -> None:
         mock_toggle.return_value = True
         mock_get.return_value = {"isFavourite": True}
 
@@ -33,7 +35,7 @@ class TestToggleFavourite:
         assert body["isFavourite"] is True
 
     @patch("app.routes.images.db_toggle_image_favourite_status")
-    def test_not_found(self, mock_toggle, client):
+    def test_not_found(self, mock_toggle: MagicMock, client: TestClient) -> None:
         mock_toggle.return_value = False
 
         resp = client.post("/images/toggle-favourite", json={"image_id": "bad-id"})
@@ -45,7 +47,7 @@ class TestToggleFavourite:
         assert "message" in detail
 
     @patch("app.routes.images.db_toggle_image_favourite_status")
-    def test_internal_error(self, mock_toggle, client):
+    def test_internal_error(self, mock_toggle: MagicMock, client: TestClient) -> None:
         mock_toggle.side_effect = Exception("db crashed")
 
         resp = client.post("/images/toggle-favourite", json={"image_id": "img-1"})

--- a/backend/tests/test_toggle_favourite.py
+++ b/backend/tests/test_toggle_favourite.py
@@ -1,0 +1,56 @@
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.routes.images import router as images_router
+
+
+@pytest.fixture
+def client():
+    """Create a test client with the images router mounted."""
+    app = FastAPI()
+    app.include_router(images_router, prefix="/images")
+    return TestClient(app)
+
+
+class TestToggleFavourite:
+    """Route-level tests for POST /images/toggle-favourite."""
+
+    @patch("app.routes.images.db_get_image_by_id")
+    @patch("app.routes.images.db_toggle_image_favourite_status")
+    def test_success(self, mock_toggle, mock_get, client):
+        mock_toggle.return_value = True
+        mock_get.return_value = {"isFavourite": True}
+
+        resp = client.post("/images/toggle-favourite", json={"image_id": "img-1"})
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["success"] is True
+        assert body["image_id"] == "img-1"
+        assert body["isFavourite"] is True
+
+    @patch("app.routes.images.db_toggle_image_favourite_status")
+    def test_not_found(self, mock_toggle, client):
+        mock_toggle.return_value = False
+
+        resp = client.post("/images/toggle-favourite", json={"image_id": "bad-id"})
+
+        assert resp.status_code == 404
+        detail = resp.json()["detail"]
+        assert detail["success"] is False
+        assert "error" in detail
+        assert "message" in detail
+
+    @patch("app.routes.images.db_toggle_image_favourite_status")
+    def test_internal_error(self, mock_toggle, client):
+        mock_toggle.side_effect = Exception("db crashed")
+
+        resp = client.post("/images/toggle-favourite", json={"image_id": "img-1"})
+
+        assert resp.status_code == 500
+        detail = resp.json()["detail"]
+        assert detail["success"] is False
+        assert detail["error"] == "Internal server error"

--- a/frontend/src/api/api-functions/togglefav.ts
+++ b/frontend/src/api/api-functions/togglefav.ts
@@ -1,9 +1,16 @@
 import { imagesEndpoints } from '../apiEndpoints';
 import { apiClient } from '../axiosConfig';
-import { APIResponse } from '@/types/API';
 
-export const togglefav = async (image_id: string): Promise<APIResponse> => {
-  const response = await apiClient.post<APIResponse>(
+export interface ToggleFavouriteResponse {
+  success: boolean;
+  image_id: string;
+  isFavourite: boolean;
+}
+
+export const togglefav = async (
+  image_id: string,
+): Promise<ToggleFavouriteResponse> => {
+  const response = await apiClient.post<ToggleFavouriteResponse>(
     imagesEndpoints.setFavourite,
     { image_id },
   );


### PR DESCRIPTION
Fixes #1479

## Additional Notes:

**Backend changes:**
- Added `ToggleFavouriteResponse` Pydantic model in `backend/app/schemas/images.py` with typed fields (`success`, `image_id`, `isFavourite`)
- Updated `@router.post("/toggle-favourite")` in `backend/app/routes/images.py` to include `response_model=ToggleFavouriteResponse` and `responses` for OpenAPI metadata
- Wrapped all error paths in `ErrorResponse(...).model_dump()` instead of plain text strings, matching the pattern used in the videos `/toggle-favourite` route
- Added route-level tests in `backend/tests/test_toggle_favourite.py` covering success (200), not found (404), and internal server error (500) cases

**Frontend changes:**

- Replaced the generic `APIResponse` (with `[key: string]: any`) in `frontend/src/api/api-functions/togglefav.ts` with a strongly-typed `ToggleFavouriteResponse` interface matching the backend's Pydantic model



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Favourite toggling now returns clear success details, including the image ID and updated favourite status.
  * Missing images and unexpected server errors now provide structured, informative error responses.

* **Bug Fixes**
  * Improved handling and reporting of failures when toggling image favourites.

* **Tests**
  * Added coverage for successful toggles, missing images, and server-side errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->