### PR TITLE
   fix: open original file using plugin-opener instead of deprecated plugin-shell

### DIFF
--- a/frontend/src-tauri/capabilities/migrated.json
+++ b/frontend/src-tauri/capabilities/migrated.json
@@ -2,7 +2,9 @@
   "identifier": "migrated",
   "description": "permissions that were migrated from v1",
   "local": true,
-  "windows": ["main"],
+  "windows": [
+    "main"
+  ],
   "permissions": [
     "core:path:default",
     "core:event:default",
@@ -79,11 +81,15 @@
     "process:default",
     {
       "identifier": "fs:scope",
-      "allow": ["**"]
+      "allow": [
+        "**"
+      ]
     },
     {
       "identifier": "fs:read-all",
-      "allow": ["**"]
+      "allow": [
+        "**"
+      ]
     },
     "shell:default",
     "dialog:default",
@@ -94,8 +100,20 @@
     "store:default",
     "opener:allow-reveal-item-in-dir",
     {
+      "identifier": "opener:allow-open-path",
+      "allow": [
+        {
+          "path": "**"
+        }
+      ]
+    },
+    {
       "identifier": "opener:allow-open-url",
-      "allow": [{ "url": "https://aossie-org.github.io/*" }]
+      "allow": [
+        {
+          "url": "https://aossie-org.github.io/*"
+        }
+      ]
     }
   ]
 }

--- a/frontend/src-tauri/src/commands.rs
+++ b/frontend/src-tauri/src/commands.rs
@@ -1,0 +1,13 @@
+use tauri_plugin_opener::OpenerExt;
+
+#[tauri::command]
+pub fn open_image_file(app: tauri::AppHandle, path: String) -> Result<(), String> {
+    let allowed_extensions = [".jpg", ".jpeg", ".png"];
+    let lower = path.to_lowercase();
+    if !allowed_extensions.iter().any(|ext| lower.ends_with(ext)) {
+        return Err("Only image files can be opened".into());
+    }
+    app.opener()
+        .open_path(path, None::<String>)
+        .map_err(|e| e.to_string())
+}

--- a/frontend/src-tauri/src/main.rs
+++ b/frontend/src-tauri/src/main.rs
@@ -11,6 +11,7 @@ use tauri::{Manager, Window, WindowEvent};
 use tauri_plugin_autostart::ManagerExt;
 #[cfg(feature = "ci")]
 use tauri_plugin_shell::ShellExt;
+use tauri_plugin_opener::OpenerExt;
 use tauri_plugin_store::StoreExt;
 
 const STORE_PATH: &str = "settings.json";
@@ -274,6 +275,18 @@ fn set_close_to_tray(app: tauri::AppHandle, enabled: bool) -> Result<(), String>
     store.save().map_err(|e| e.to_string())
 }
 
+#[tauri::command]
+fn open_image_file(app: tauri::AppHandle, path: String) -> Result<(), String> {
+    let allowed_extensions = [".jpg", ".jpeg", ".png"];
+    let lower = path.to_lowercase();
+    if !allowed_extensions.iter().any(|ext| lower.ends_with(ext)) {
+        return Err("Only image files can be opened".into());
+    }
+    app.opener()
+        .open_path(path, None::<String>)
+        .map_err(|e| e.to_string())
+}
+
 fn main() {
     tauri::Builder::default()
         // Auto-start: pass --minimized so the window starts hidden when launched at boot
@@ -361,6 +374,7 @@ fn main() {
             is_autostart_enabled,
             get_close_to_tray,
             set_close_to_tray,
+            open_image_file,
         ])
         .on_window_event(on_window_event)
         .build(tauri::generate_context!())

--- a/frontend/src-tauri/src/main.rs
+++ b/frontend/src-tauri/src/main.rs
@@ -2,6 +2,7 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 mod services;
+mod commands;
 
 use sysinfo::System;
 use tauri::menu::{Menu, MenuItem, PredefinedMenuItem};
@@ -11,7 +12,7 @@ use tauri::{Manager, Window, WindowEvent};
 use tauri_plugin_autostart::ManagerExt;
 #[cfg(feature = "ci")]
 use tauri_plugin_shell::ShellExt;
-use tauri_plugin_opener::OpenerExt;
+
 use tauri_plugin_store::StoreExt;
 
 const STORE_PATH: &str = "settings.json";
@@ -275,17 +276,6 @@ fn set_close_to_tray(app: tauri::AppHandle, enabled: bool) -> Result<(), String>
     store.save().map_err(|e| e.to_string())
 }
 
-#[tauri::command]
-fn open_image_file(app: tauri::AppHandle, path: String) -> Result<(), String> {
-    let allowed_extensions = [".jpg", ".jpeg", ".png"];
-    let lower = path.to_lowercase();
-    if !allowed_extensions.iter().any(|ext| lower.ends_with(ext)) {
-        return Err("Only image files can be opened".into());
-    }
-    app.opener()
-        .open_path(path, None::<String>)
-        .map_err(|e| e.to_string())
-}
 
 fn main() {
     tauri::Builder::default()
@@ -374,7 +364,7 @@ fn main() {
             is_autostart_enabled,
             get_close_to_tray,
             set_close_to_tray,
-            open_image_file,
+            commands::open_image_file,
         ])
         .on_window_event(on_window_event)
         .build(tauri::generate_context!())

--- a/frontend/src/components/Media/MediaInfoPanel.tsx
+++ b/frontend/src/components/Media/MediaInfoPanel.tsx
@@ -218,7 +218,7 @@ export const MediaInfoPanel: React.FC<MediaInfoPanelProps> = ({
                   e.preventDefault();
                   if (currentImage?.path) {
                     try {
-                      await invoke('open_image_file', { path: currentImage.path });
+                      await invoke<void>('open_image_file', { path: currentImage.path });
                     } catch (err) {
                       console.error('Failed to open file:', err);
                     }

--- a/frontend/src/components/Media/MediaInfoPanel.tsx
+++ b/frontend/src/components/Media/MediaInfoPanel.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { open } from '@tauri-apps/plugin-shell';
+import { openPath } from '@tauri-apps/plugin-opener';
 import {
   X,
   ImageIcon as ImageLucide,
@@ -129,7 +130,7 @@ export const MediaInfoPanel: React.FC<MediaInfoPanelProps> = ({
                   Location
                 </p>
                 {currentImage?.metadata?.latitude &&
-                currentImage?.metadata?.longitude ? (
+                  currentImage?.metadata?.longitude ? (
                   <button
                     type="button"
                     onClick={handleLocationClick}
@@ -213,9 +214,15 @@ export const MediaInfoPanel: React.FC<MediaInfoPanelProps> = ({
             <div className="mt-4 border-t border-black/10 pt-3 dark:border-white/10">
               <button
                 className="w-full rounded-lg bg-black/5 py-2 text-gray-900 hover:bg-black/10 dark:bg-white/10 dark:text-white dark:hover:bg-white/20"
-                onClick={(e) => {
+                onClick={async (e) => {
                   e.preventDefault();
-                  // Button disabled - does nothing
+                  if (currentImage?.path) {
+                    try {
+                      await openPath(currentImage.path);
+                    } catch (err) {
+                      console.error('Failed to open file:', err);
+                    }
+                  }
                 }}
               >
                 Open Original File

--- a/frontend/src/components/Media/MediaInfoPanel.tsx
+++ b/frontend/src/components/Media/MediaInfoPanel.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { open } from '@tauri-apps/plugin-shell';
-import { openPath } from '@tauri-apps/plugin-opener';
+import { invoke } from '@tauri-apps/api/core';
 import {
   X,
   ImageIcon as ImageLucide,
@@ -218,7 +218,7 @@ export const MediaInfoPanel: React.FC<MediaInfoPanelProps> = ({
                   e.preventDefault();
                   if (currentImage?.path) {
                     try {
-                      await openPath(currentImage.path);
+                      await invoke('open_image_file', { path: currentImage.path });
                     } catch (err) {
                       console.error('Failed to open file:', err);
                     }

--- a/frontend/src/components/Media/__tests__/MediaInfoPanel.test.tsx
+++ b/frontend/src/components/Media/__tests__/MediaInfoPanel.test.tsx
@@ -1,9 +1,14 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MediaInfoPanel } from '../MediaInfoPanel';
 import { Image } from '@/types/Media';
+import { openPath } from '@tauri-apps/plugin-opener';
 
 jest.mock('@tauri-apps/plugin-shell', () => ({
   open: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('@tauri-apps/plugin-opener', () => ({
+  openPath: jest.fn().mockResolvedValue(undefined),
 }));
 
 const makeImage = (tags: string[]): Image => ({
@@ -104,11 +109,9 @@ describe('MediaInfoPanel tag list', () => {
       />,
     );
 
-    // Expand on the first image.
     fireEvent.click(screen.getByRole('button', { name: /show more/i }));
     expect(screen.getByText('epsilon')).toBeInTheDocument();
 
-    // Navigating to a different image collapses the list again.
     rerender(
       <MediaInfoPanel
         show
@@ -123,5 +126,17 @@ describe('MediaInfoPanel tag list', () => {
     expect(
       screen.getByRole('button', { name: /show more/i }),
     ).toBeInTheDocument();
+  });
+});
+
+describe('MediaInfoPanel Open Original File button', () => {
+  test('calls openPath with the current image path when clicked', async () => {
+    renderPanel(['alpha']);
+
+    fireEvent.click(screen.getByRole('button', { name: /open original file/i }));
+
+    await waitFor(() => {
+      expect(openPath).toHaveBeenCalledWith('C:\\pics\\img1.jpg');
+    });
   });
 });

--- a/frontend/src/components/Media/__tests__/MediaInfoPanel.test.tsx
+++ b/frontend/src/components/Media/__tests__/MediaInfoPanel.test.tsx
@@ -1,14 +1,14 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MediaInfoPanel } from '../MediaInfoPanel';
 import { Image } from '@/types/Media';
-import { openPath } from '@tauri-apps/plugin-opener';
+import { invoke } from '@tauri-apps/api/core';
 
 jest.mock('@tauri-apps/plugin-shell', () => ({
   open: jest.fn().mockResolvedValue(undefined),
 }));
 
-jest.mock('@tauri-apps/plugin-opener', () => ({
-  openPath: jest.fn().mockResolvedValue(undefined),
+jest.mock('@tauri-apps/api/core', () => ({
+  invoke: jest.fn().mockResolvedValue(undefined),
 }));
 
 const makeImage = (tags: string[]): Image => ({
@@ -130,13 +130,15 @@ describe('MediaInfoPanel tag list', () => {
 });
 
 describe('MediaInfoPanel Open Original File button', () => {
-  test('calls openPath with the current image path when clicked', async () => {
+  test('calls the open_image_file command with the current image path when clicked', async () => {
     renderPanel(['alpha']);
 
     fireEvent.click(screen.getByRole('button', { name: /open original file/i }));
 
     await waitFor(() => {
-      expect(openPath).toHaveBeenCalledWith('C:\\pics\\img1.jpg');
+      expect(invoke).toHaveBeenCalledWith('open_image_file', {
+        path: 'C:\\pics\\img1.jpg',
+      });
     });
   });
 });


### PR DESCRIPTION
…gin-shell (#1165)

###  Addressed Issues:

Fixes #1165


###  Screenshots/Recordings:

<img width="1432" height="745" alt="Screenshot 2026-08-26 125457" src="https://github.com/user-attachments/assets/7b7da9ec-ad36-459f-b8e9-3a50016eef77" />
<img width="1892" height="1020" alt="Screenshot 2026-08-26 125438" src="https://github.com/user-attachments/assets/bf3baf68-cd2e-4f0d-8dfb-7623e7f13a9f" />


###  Additional Notes:
Before: Clicking "Open Original File" did nothing , button was silently disabled

After: Clicking "Open Original File" now opens the image in the default Windows Photos viewer.

### AI Usage Disclosure:
We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact. AI slop is strongly discouraged and may lead to banning and blocking. Do not spam our repos with AI slop.

Check one of the checkboxes below:

- [ ] This PR does not contain AI-generated code at all.
- [x] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools: Claude (Anthropic) — used to analyze the root cause and help write the fix and tests. I reviewed and tested everything myself, including end-to-end in the running app.

## Checklist
<!-- Mark items with [x] to indicate completion -->
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [x] If applicable, I have made corresponding changes or additions to the documentation
- [x] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the “Open Original File” action for image files.
  - Only supported JPG and PNG files within configured library folders can be opened.
  - Added clearer handling for invalid, missing, or unauthorized file paths.
  - Improved compatibility when opening files on Windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->