### PR TITLE
fix(images): handle all non-JPEG-safe PIL modes in thumbnail generation

### DIFF
--- a/backend/app/utils/images.py
+++ b/backend/app/utils/images.py
@@ -421,9 +421,8 @@ def image_util_generate_thumbnail(
     try:
         with Image.open(image_path) as img:
             img.thumbnail(size)
-
-            # Convert to RGB if the image has an alpha channel or is not RGB
-            if img.mode in ("RGBA", "P"):
+            JPEG_SAFE_MODES = {"RGB", "L", "CMYK", "YCbCr"}
+            if img.mode not in JPEG_SAFE_MODES:
                 img = img.convert("RGB")
 
             img.save(thumbnail_path, "JPEG")  # Always save thumbnails as JPEG


### PR DESCRIPTION
### Summary
`image_util_generate_thumbnail` used a denylist to decide when to convert an image before saving as JPEG:
 
```python
# Before
if img.mode in ("RGBA", "P"):
    img = img.convert("RGB")
```
 
Pillow's JPEG encoder only accepts `RGB`, `L`, `CMYK`, and `YCbCr`. The guard missed `LA` (greyscale + alpha), `I` (32-bit int), and `F` (32-bit float) all valid PNG/HDR modes causing the save to raise `cannot write mode X as JPEG`. Because the thumbnail step gates the database insert, affected images were silently dropped from the gallery with no error shown to the user.
 
Fixed by inverting to an allowlist:
 
```python
# After
JPEG_SAFE_MODES = {"RGB", "L", "CMYK", "YCbCr"}
if img.mode not in JPEG_SAFE_MODES:
    img = img.convert("RGB")
```
 
Any mode not in that set is converted to `RGB` before the save. This is closed by definition new Pillow modes cannot regress it.
 
**Modes now fixed:**
 
| Mode | Description       |
|------|-------------------|
| `LA` | Greyscale + alpha |
| `I`  | 32-bit integer    |
| `F`  | 32-bit float      |
 
---
Issue- #1513 
### Additional Notes:
Only `backend/app/utils/images.py` is changed. No new dependencies. Existing behaviour for `RGB`, `L`, `RGBA`, and `P` mode images is unchanged.
 
### AI Usage Disclosure:
- [ ] This PR does not contain AI-generated code at all.
- [x] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.
I have used the following AI models and tools: Claude (Anthropic) — used to identify the bug and generate the fix. The root cause, diff, and affected modes were verified manually and tested locally with Pillow before submission.
 
## Checklist
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [ ] If applicable, I have made corresponding changes or additions to the documentation
- [ ] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [ ] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thumbnail generation for images using uncommon color modes.
  * Images are now converted only when required for JPEG compatibility, helping preserve supported image formats and color information.
  * Thumbnail creation is more reliable across a wider range of uploaded image types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->