### PR TITLE
fix(logging): replace bare logging.getLogger with project get_logger …

### DIFF
--- a/backend/app/routes/face_clusters.py
+++ b/backend/app/routes/face_clusters.py
@@ -1,4 +1,3 @@
-import logging
 from binascii import Error as Base64Error
 import base64
 from concurrent.futures import CancelledError, Future, ProcessPoolExecutor
@@ -37,8 +36,9 @@ from app.schemas.face_clusters import (
 )
 from app.schemas.images import FaceSearchRequest, InputType
 from app.utils.faceSearch import perform_face_search
+from app.logging.setup_logging import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 router = APIRouter()
 
 

--- a/backend/app/routes/models.py
+++ b/backend/app/routes/models.py
@@ -25,9 +25,9 @@ from app.utils.semantic_labels import (
 )
 from app.utils.model_downloader import ensure_model
 from app.database.metadata import db_get_metadata
-import logging
+from app.logging.setup_logging import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 router = APIRouter()
 

--- a/backend/app/utils/images.py
+++ b/backend/app/utils/images.py
@@ -4,7 +4,6 @@ import os
 import uuid
 import datetime
 import json
-import logging
 from typing import List, Optional, Tuple, Dict, Any, Mapping
 from PIL import Image, ExifTags
 from pathlib import Path
@@ -37,8 +36,6 @@ logger = get_logger(__name__)
 
 # GPS EXIF tag constant
 GPS_INFO_TAG = 34853
-
-logger = logging.getLogger(__name__)
 
 
 def image_util_process_folder_images(folder_data: List[Tuple[str, int, bool]]) -> bool:


### PR DESCRIPTION
### Summary

Three backend modules used Python's stdlib `logging.getLogger` directly instead of the project's `get_logger` from `app.logging.setup_logging`, causing their log output to bypass colour formatting, `[COMPONENT]` prefixes, and environment-level filtering.

`backend/app/utils/images.py` was the most severe case `get_logger` was assigned correctly on line 35, then **silently overwritten** two lines later:

```python
logger = get_logger(__name__)        # line 35 correct
...
logger = logging.getLogger(__name__) # line 41 overwrites the above
```

`backend/app/routes/face_clusters.py` and `backend/app/routes/models.py` simply never adopted the pattern used by all 7 of their sibling route files.

Fixed by removing the duplicate assignment and redundant `import logging` in `images.py`, and replacing `logging.getLogger` with `get_logger` (plus the matching import) in `face_clusters.py` and `models.py`. `get_logger` is a thin wrapper around `logging.getLogger` log propagation and levels are completely unchanged.

### Addressed Issues:
Fixes #1515 

### Additional Notes:
No logic change across any of the three files. Only affects log output formatting and consistency.

### AI Usage Disclosure:
- [x] This PR contains AI-generated code. I have read the [[AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md)](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.

## Checklist
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [ ] If applicable, I have made corresponding changes or additions to the documentation
- [ ] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [x] I have joined the [[Discord server](https://discord.gg/hjUhu33uAn)](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [[Contribution Guidelines](https://claude.ai/CONTRIBUTING.md)](../CONTRIBUTING.md)
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized application logging across face clustering, model routes, and image utilities.
  * Improved consistency of internal log configuration without changing user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->