### PR TITLE
fix(share): enforce password default when auto-restoring internet mode

### DIFF
--- a/frontend/src/components/Albums/ShareAlbumDialog.tsx
+++ b/frontend/src/components/Albums/ShareAlbumDialog.tsx
@@ -216,6 +216,9 @@ export const ShareAlbumDialog: React.FC<ShareAlbumDialogProps> = ({
     tunnel.refresh().then((current) => {
       if (current) {
         setMode('internet');
+        // Same safer default the manual switch applies: an internet link is
+        // public, so it starts protected however the mode was arrived at.
+        setWithPassword(true);
       }
     });
   }, [isOpen, album?.id, tunnel.refresh]);

--- a/frontend/src/components/Albums/__tests__/ShareAlbumDialog.test.tsx
+++ b/frontend/src/components/Albums/__tests__/ShareAlbumDialog.test.tsx
@@ -241,10 +241,10 @@ describe('ShareAlbumDialog', () => {
       mockTunnelStatus.mockResolvedValue('https://abc123.lhr.life');
       renderDialog([]);
 
-      const passwordToggle = await screen.findByRole('switch', { name: /require a password/i });
-      
-      expect(internetToggle()).toBeChecked();
-      expect(passwordToggle).toBeChecked();
+      await waitFor(() => expect(internetToggle()).toBeChecked());
+      expect(
+        await screen.findByRole('switch', { name: /require a password/i }),
+      ).toBeChecked();
     });
 
     it('reports a tunnel that would not close', async () => {

--- a/frontend/src/components/Albums/__tests__/ShareAlbumDialog.test.tsx
+++ b/frontend/src/components/Albums/__tests__/ShareAlbumDialog.test.tsx
@@ -177,6 +177,7 @@ describe('ShareAlbumDialog', () => {
       );
     });
 
+
     // Failing quietly would leave nothing on screen and no way to reach the
     // page, which is how a missing capability presented in the running app.
     it('hands over the address when the browser cannot be opened', async () => {
@@ -234,6 +235,16 @@ describe('ShareAlbumDialog', () => {
       expect(mockOpenUrl).toHaveBeenLastCalledWith(
         'https://aossie-org.github.io/PictoPy/overview/sharing-albums/#internet-mode',
       );
+    });
+    
+    it('asks for a password by default when auto-restoring internet mode', async () => {
+      mockTunnelStatus.mockResolvedValue('https://abc123.lhr.life');
+      renderDialog([]);
+
+      const passwordToggle = await screen.findByRole('switch', { name: /require a password/i });
+      
+      expect(internetToggle()).toBeChecked();
+      expect(passwordToggle).toBeChecked();
     });
 
     it('reports a tunnel that would not close', async () => {


### PR DESCRIPTION
###  Addressed Issues:

Fixes #1507

Fixes a bug where opening the ShareAlbumDialog with an already-active tunnel restores 'Internet' mode but fails to toggle the safe default "Require a password" on. This resulted in albums being shared publicly over the internet without a password, bypassing the privacy safeguard.

Changes

Added setWithPassword(true) to the auto-restore path in tunnel.refresh().

Added a regression test to ensure auto-restored internet shares default to protected.

Testing

Verified manually on Windows 11: Auto-restoring a tunnel on a new album now checks the password toggle by default.

ShareAlbumDialog.test.tsx passes locally.

### Screenshot:

<img width="612" height="807" alt="Screenshot 2026-09-04 144318" src="https://github.com/user-attachments/assets/5559f33b-2897-404c-a1c2-fb2ab7729e37" />


TODO: If applicable, add screenshots or recordings that demonstrate the interface **before** and **after** the changes.


###  Additional Notes:
<!-- Add any additional information, context, or notes for reviewers -->

### AI Usage Disclosure:

Sorry, claude code is expensive cant afford it!
No AI used, other than writing description.

Check one of the checkboxes below:

- [x] This PR does not contain AI-generated code at all.
- [ ] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools: TODO


## Checklist
<!-- Mark items with [x] to indicate completion -->
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [x] If applicable, I have made corresponding changes or additions to the documentation
- [x] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x ] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [ x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [ x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Internet sharing now enables password protection by default when an existing share is restored after reopening the dialog.

- **Tests**
  - Added coverage to verify password protection is enabled when internet sharing is automatically restored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->