### PR TITLE
Fix/internet mode password default

### DIFF
--- a/frontend/src/components/Albums/ShareAlbumDialog.tsx
+++ b/frontend/src/components/Albums/ShareAlbumDialog.tsx
@@ -216,6 +216,9 @@ export const ShareAlbumDialog: React.FC<ShareAlbumDialogProps> = ({
     tunnel.refresh().then((current) => {
       if (current) {
         setMode('internet');
+        // Same safer default the manual switch applies: an internet link is
+        // public, so it starts protected however the mode was arrived at.
+        setWithPassword(true);
       }
     });
   }, [isOpen, album?.id, tunnel.refresh]);

--- a/frontend/src/components/Albums/ShareAlbumDialog.tsx
+++ b/frontend/src/components/Albums/ShareAlbumDialog.tsx
@@ -201,9 +201,13 @@ export const ShareAlbumDialog: React.FC<ShareAlbumDialogProps> = ({
     if (!isOpen) {
       return;
     }
-    
-    userInteracted.current = false; // Reset interaction flag on open
-    
+
+    // A close and reopen can race an earlier refresh(): the reset below clears
+    // userInteracted, so a lookup still in flight from the previous open has to
+    // be ignored rather than left to restore internet mode on this one.
+    let isMounted = true;
+    userInteracted.current = false;
+
     setMode('lan');
     setExpiry('1440');
     setWithPassword(false);
@@ -213,19 +217,25 @@ export const ShareAlbumDialog: React.FC<ShareAlbumDialogProps> = ({
     setCreatedShare(null);
     setSelectedUrl('');
     setCopied(false);
-    
+
     // A share made earlier is still served by whatever tunnel is up, so ask
     // rather than assume it was a local one. The mode follows the answer:
     // showing an internet link while the help button explains local sharing
     // would describe the wrong thing.
     tunnel.refresh().then((current) => {
-      if (current && !userInteracted.current) { // Prevent overriding user's manual selection
-        setMode('internet');
-        // Same safer default the manual switch applies: an internet link is
-        // public, so it starts protected however the mode was arrived at.
-        setWithPassword(true);
+      // Skip once this open is superseded, or the user has already chosen.
+      if (!isMounted || !current || userInteracted.current) {
+        return;
       }
+      setMode('internet');
+      // Same safer default the manual switch applies: an internet link is
+      // public, so it starts protected however the mode was arrived at.
+      setWithPassword(true);
     });
+
+    return () => {
+      isMounted = false;
+    };
   }, [isOpen, album?.id, tunnel.refresh]);
 
   const handleModeChange = (next: ShareMode) => {

--- a/frontend/src/components/Albums/ShareAlbumDialog.tsx
+++ b/frontend/src/components/Albums/ShareAlbumDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import { useDispatch } from 'react-redux';
 import { QRCodeSVG } from 'qrcode.react';
 import { openUrl } from '@tauri-apps/plugin-opener';
@@ -72,6 +72,7 @@ export const ShareAlbumDialog: React.FC<ShareAlbumDialogProps> = ({
   onClose,
   onChanged,
 }) => {
+  const userInteracted = useRef(false);
   const dispatch = useDispatch();
   const [mode, setMode] = useState<ShareMode>('lan');
   const [expiry, setExpiry] = useState<string>('1440');
@@ -200,6 +201,9 @@ export const ShareAlbumDialog: React.FC<ShareAlbumDialogProps> = ({
     if (!isOpen) {
       return;
     }
+    
+    userInteracted.current = false; // Reset interaction flag on open
+    
     setMode('lan');
     setExpiry('1440');
     setWithPassword(false);
@@ -209,12 +213,13 @@ export const ShareAlbumDialog: React.FC<ShareAlbumDialogProps> = ({
     setCreatedShare(null);
     setSelectedUrl('');
     setCopied(false);
+    
     // A share made earlier is still served by whatever tunnel is up, so ask
     // rather than assume it was a local one. The mode follows the answer:
     // showing an internet link while the help button explains local sharing
     // would describe the wrong thing.
     tunnel.refresh().then((current) => {
-      if (current) {
+      if (current && !userInteracted.current) { // Prevent overriding user's manual selection
         setMode('internet');
         // Same safer default the manual switch applies: an internet link is
         // public, so it starts protected however the mode was arrived at.
@@ -224,6 +229,7 @@ export const ShareAlbumDialog: React.FC<ShareAlbumDialogProps> = ({
   }, [isOpen, album?.id, tunnel.refresh]);
 
   const handleModeChange = (next: ShareMode) => {
+    userInteracted.current = true; // Mark that user took control
     setMode(next);
     setError('');
     setTunnelError('');
@@ -552,6 +558,7 @@ export const ShareAlbumDialog: React.FC<ShareAlbumDialogProps> = ({
                   id="share-password-toggle"
                   checked={withPassword}
                   onCheckedChange={(checked) => {
+                    userInteracted.current = true; // Mark that user took control
                     setWithPassword(checked);
                     setError('');
                   }}

--- a/frontend/src/components/Albums/__tests__/ShareAlbumDialog.test.tsx
+++ b/frontend/src/components/Albums/__tests__/ShareAlbumDialog.test.tsx
@@ -235,15 +235,67 @@ describe('ShareAlbumDialog', () => {
         'https://aossie-org.github.io/PictoPy/overview/sharing-albums/#internet-mode',
       );
     });
-    
+
     it('asks for a password by default when auto-restoring internet mode', async () => {
       mockTunnelStatus.mockResolvedValue('https://abc123.lhr.life');
       renderDialog([]);
 
-      const passwordToggle = await screen.findByRole('switch', { name: /require a password/i });
-      
-      expect(internetToggle()).toBeChecked();
-      expect(passwordToggle).toBeChecked();
+      // Both toggles render in their default state and only flip once the
+      // tunnel status resolves, so wait for the restored state itself rather
+      // than for the switch merely existing.
+      await waitFor(() => {
+        expect(internetToggle()).toBeChecked();
+        expect(
+          screen.getByRole('switch', { name: /require a password/i }),
+        ).toBeChecked();
+      });
+    });
+
+    // A slow status lookup from an earlier open must not land on a later one:
+    // the reset on reopen clears the interaction flag, so without a guard the
+    // stale answer would switch the fresh dialog to internet mode.
+    it('ignores a tunnel check left over from a previous open', async () => {
+      let resolveStale: (value: string | null) => void = () => undefined;
+      mockTunnelStatus
+        .mockReturnValueOnce(
+          new Promise<string | null>((resolve) => {
+            resolveStale = resolve;
+          }),
+        )
+        .mockResolvedValue(null);
+
+      const { rerender } = renderDialog([]);
+
+      // Close and reopen before the first status lookup resolves.
+      rerender(
+        <ShareAlbumDialog
+          album={album}
+          shares={[]}
+          isOpen={false}
+          onClose={jest.fn()}
+          onChanged={jest.fn()}
+        />,
+      );
+      rerender(
+        <ShareAlbumDialog
+          album={album}
+          shares={[]}
+          isOpen={true}
+          onClose={jest.fn()}
+          onChanged={jest.fn()}
+        />,
+      );
+
+      // The leftover lookup now reports a live tunnel, but it belonged to the
+      // dialog that has since closed; the reopened one keeps its defaults.
+      await act(async () => {
+        resolveStale('https://abc123.lhr.life');
+      });
+
+      expect(internetToggle()).not.toBeChecked();
+      expect(
+        screen.getByRole('switch', { name: /require a password/i }),
+      ).not.toBeChecked();
     });
 
     it('does not override user changes if the background tunnel check resolves late', async () => {
@@ -262,8 +314,10 @@ describe('ShareAlbumDialog', () => {
 
       // 3. User manually selects 'Internet'
       await user.click(internetToggle());
-      const passwordToggle = screen.getByRole('switch', { name: /require a password/i });
-      
+      const passwordToggle = screen.getByRole('switch', {
+        name: /require a password/i,
+      });
+
       // Manual click turns password ON by default. The user decides to turn it OFF.
       expect(passwordToggle).toBeChecked();
       await user.click(passwordToggle);

--- a/frontend/src/components/Albums/__tests__/ShareAlbumDialog.test.tsx
+++ b/frontend/src/components/Albums/__tests__/ShareAlbumDialog.test.tsx
@@ -177,7 +177,6 @@ describe('ShareAlbumDialog', () => {
       );
     });
 
-
     // Failing quietly would leave nothing on screen and no way to reach the
     // page, which is how a missing capability presented in the running app.
     it('hands over the address when the browser cannot be opened', async () => {
@@ -245,6 +244,38 @@ describe('ShareAlbumDialog', () => {
       
       expect(internetToggle()).toBeChecked();
       expect(passwordToggle).toBeChecked();
+    });
+
+    it('does not override user changes if the background tunnel check resolves late', async () => {
+      const user = userEvent.setup();
+      
+      // 1. Create a manual promise so we can control EXACTLY when the tunnel answers
+      let resolveTunnel: (value: string | null) => void = () => undefined;
+      mockTunnelStatus.mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveTunnel = resolve;
+        }),
+      );
+
+      // 2. Open the dialog
+      renderDialog([]);
+
+      // 3. User manually selects 'Internet'
+      await user.click(internetToggle());
+      const passwordToggle = screen.getByRole('switch', { name: /require a password/i });
+      
+      // Manual click turns password ON by default. The user decides to turn it OFF.
+      expect(passwordToggle).toBeChecked();
+      await user.click(passwordToggle);
+      expect(passwordToggle).not.toBeChecked();
+
+      // 4. Suddenly, the background tunnel check finally finishes
+      await act(async () => {
+        resolveTunnel('https://abc123.lhr.life');
+      });
+
+      // 5. Verify the password toggle is STILL off (the ref protected the user's choice)
+      expect(passwordToggle).not.toBeChecked();
     });
 
     it('reports a tunnel that would not close', async () => {

--- a/frontend/src/components/Albums/__tests__/ShareAlbumDialog.test.tsx
+++ b/frontend/src/components/Albums/__tests__/ShareAlbumDialog.test.tsx
@@ -177,6 +177,7 @@ describe('ShareAlbumDialog', () => {
       );
     });
 
+
     // Failing quietly would leave nothing on screen and no way to reach the
     // page, which is how a missing capability presented in the running app.
     it('hands over the address when the browser cannot be opened', async () => {
@@ -234,6 +235,16 @@ describe('ShareAlbumDialog', () => {
       expect(mockOpenUrl).toHaveBeenLastCalledWith(
         'https://aossie-org.github.io/PictoPy/overview/sharing-albums/#internet-mode',
       );
+    });
+    
+    it('asks for a password by default when auto-restoring internet mode', async () => {
+      mockTunnelStatus.mockResolvedValue('https://abc123.lhr.life');
+      renderDialog([]);
+
+      const passwordToggle = await screen.findByRole('switch', { name: /require a password/i });
+      
+      expect(internetToggle()).toBeChecked();
+      expect(passwordToggle).toBeChecked();
     });
 
     it('reports a tunnel that would not close', async () => {

--- a/frontend/src/components/Albums/__tests__/ShareAlbumDialog.test.tsx
+++ b/frontend/src/components/Albums/__tests__/ShareAlbumDialog.test.tsx
@@ -248,8 +248,8 @@ describe('ShareAlbumDialog', () => {
 
     it('does not override user changes if the background tunnel check resolves late', async () => {
       const user = userEvent.setup();
-      
-      // 1. Create a manual promise so we can control EXACTLY when the tunnel answers
+
+      // 1. Create a manual promise so we can control when the tunnel answers.
       let resolveTunnel: (value: string | null) => void = () => undefined;
       mockTunnelStatus.mockReturnValueOnce(
         new Promise((resolve) => {


### PR DESCRIPTION
Addressed Issues:
Fixes #1523 

Fixes a bug where opening the ShareAlbumDialog with an already-active tunnel restores 'Internet' mode but fails to toggle the safe default "Require a password" on. This resulted in albums being shared publicly over the internet without a password, bypassing the privacy safeguard.

Changes

Added setWithPassword(true) to the auto-restore path in tunnel.refresh().

Added a regression test to ensure auto-restored internet shares default to protected.

Testing

Verified manually on Windows 11: Auto-restoring a tunnel on a new album now checks the password toggle by default.

ShareAlbumDialog.test.tsx passes locally.

Screenshot:

<img width="612" height="807" alt="Screenshot 2026-09-04 144318" src="https://github.com/user-attachments/assets/624ca463-adad-4b59-a2b5-6124470de578" />

Additional Notes:
AI Usage Disclosure:
Sorry, claude code is expensive cant afford it!
No AI used, other than writing description.

Check one of the checkboxes below:

 This PR does not contain AI-generated code at all.
 This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.
I have used the following AI models and tools: TODO

Checklist
 My PR addresses a single issue, fixes a single bug or makes a single improvement.
 My code follows the project's code style and conventions
 If applicable, I have made corresponding changes or additions to the documentation
 If applicable, I have made corresponding changes or additions to tests
 My changes generate no new warnings or errors
 I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
[x ] I have read the [Contribution Guidelines](https://github.com/AOSSIE-Org/PictoPy/CONTRIBUTING.md)
[ x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
[ x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.
Summary by CodeRabbit
Bug Fixes

Internet sharing now enables password protection by default when an existing share is restored after reopening the dialog.
Tests

Added coverage to verify password protection is enabled when internet sharing is automatically restored.
Also added the suggested changes and reviewed some tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved album sharing defaults when an internet tunnel is already active.
  * Prevented outdated tunnel status results from changing settings after the dialog is closed and reopened.
  * Preserved manual sharing mode and password settings when tunnel status updates arrive later.
  * The password requirement is enabled by default unless the user has already made a manual choice.

* **Tests**
  * Added coverage for automatic restoration, stale results, and preservation of user-selected settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->