### PR TITLE
Feat: Unify images and videos into a sortable Favorites gallery

### DIFF
--- a/backend/app/database/images.py
+++ b/backend/app/database/images.py
@@ -656,7 +656,7 @@ def _group_image_rows_with_tags(
     rows: List[Tuple], images_dict: Dict[str, dict]
 ) -> None:
     """
-    Group flat image+tag join rows (the shared 11-column SELECT shape used by
+    Group flat image+tag join rows (the shared 12-column SELECT shape used by
     db_search_images_by_tag and db_get_images_by_ids) into images_dict, keyed
     by image_id, aggregating tag_name into a deduplicated "tags" list.
     Mutates images_dict in place so callers can accumulate across chunks.
@@ -672,6 +672,7 @@ def _group_image_rows_with_tags(
         latitude,
         longitude,
         captured_at,
+        favourited_at,
         tag_name_result,
     ) in rows:
         if image_id not in images_dict:
@@ -686,6 +687,7 @@ def _group_image_rows_with_tags(
                 "latitude": latitude,
                 "longitude": longitude,
                 "captured_at": captured_at if captured_at else None,
+                "favouritedAt": favourited_at if favourited_at else None,
                 "tags": [],
             }
 
@@ -724,6 +726,7 @@ def db_search_images_by_tag(tag_name: str) -> List[dict]:
                 i.latitude,
                 i.longitude,
                 i.captured_at,
+                i.favouritedAt,
                 m.name as tag_name
             FROM images i
             LEFT JOIN image_classes_display ic ON i.id = ic.image_id
@@ -782,6 +785,7 @@ def db_get_images_by_ids(image_ids: List[str]) -> List[dict]:
                     i.latitude,
                     i.longitude,
                     i.captured_at,
+                    i.favouritedAt,
                     m.name as tag_name
                 FROM images i
                 LEFT JOIN image_classes_display ic ON i.id = ic.image_id

--- a/backend/app/database/images.py
+++ b/backend/app/database/images.py
@@ -41,6 +41,7 @@ class ImageRecord(TypedDict, total=False):
     latitude: Optional[float]
     longitude: Optional[float]
     captured_at: Optional[datetime]
+    favouritedAt: Optional[datetime]
 
 
 class UntaggedImageRecord(TypedDict):
@@ -90,6 +91,7 @@ def db_create_images_table() -> None:
             latitude REAL,
             longitude REAL,
             captured_at DATETIME,
+            favouritedAt DATETIME,
             FOREIGN KEY (folder_id) REFERENCES folders(folder_id) ON DELETE CASCADE
         )
     """
@@ -106,6 +108,13 @@ def db_create_images_table() -> None:
     cursor.execute(
         "CREATE INDEX IF NOT EXISTS ix_images_favourite_captured_at ON images(isFavourite, captured_at)"
     )
+
+    # favouritedAt: when the image was last favourited (NULL if never, or
+    # pre-dates this column). Guarded ALTER because shipped databases predate
+    # it and CREATE IF NOT EXISTS won't add it.
+    cursor.execute("PRAGMA table_info(images)")
+    if "favouritedAt" not in {row[1] for row in cursor.fetchall()}:
+        cursor.execute("ALTER TABLE images ADD COLUMN favouritedAt DATETIME")
 
     # Create new image_classes junction table
     cursor.execute(
@@ -193,17 +202,18 @@ def db_get_all_images(tagged: Union[bool, None] = None) -> List[dict]:
     try:
         # Build the query with optional WHERE clause
         query = """
-            SELECT 
-                i.id, 
-                i.path, 
-                i.folder_id, 
-                i.thumbnailPath, 
-                i.metadata, 
+            SELECT
+                i.id,
+                i.path,
+                i.folder_id,
+                i.thumbnailPath,
+                i.metadata,
                 i.isTagged,
                 i.isFavourite,
                 i.latitude,
                 i.longitude,
                 i.captured_at,
+                i.favouritedAt,
                 m.name as tag_name
             FROM images i
             LEFT JOIN image_classes_display ic ON i.id = ic.image_id
@@ -234,6 +244,7 @@ def db_get_all_images(tagged: Union[bool, None] = None) -> List[dict]:
             latitude,
             longitude,
             captured_at,
+            favourited_at,
             tag_name,
         ) in results:
             if image_id not in images_dict:
@@ -255,6 +266,7 @@ def db_get_all_images(tagged: Union[bool, None] = None) -> List[dict]:
                     "captured_at": (
                         captured_at if captured_at else None
                     ),  # SQLite returns string
+                    "favouritedAt": favourited_at if favourited_at else None,
                     "tags": [],
                 }
 
@@ -586,7 +598,11 @@ def db_toggle_image_favourite_status(image_id: str) -> bool:
         cursor.execute(
             """
             UPDATE images
-            SET isFavourite = CASE WHEN isFavourite = 1 THEN 0 ELSE 1 END
+            SET favouritedAt = CASE
+                    WHEN isFavourite = 1 THEN favouritedAt
+                    ELSE CURRENT_TIMESTAMP
+                END,
+                isFavourite = CASE WHEN isFavourite = 1 THEN 0 ELSE 1 END
             WHERE id = ?
             """,
             (image_id,),

--- a/backend/app/database/videos.py
+++ b/backend/app/database/videos.py
@@ -31,6 +31,7 @@ class VideoRecord(TypedDict, total=False):
     isTagged: bool
     isFavourite: bool
     captured_at: Optional[datetime]
+    favouritedAt: Optional[datetime]
 
 
 def _connect() -> sqlite3.Connection:
@@ -59,6 +60,7 @@ def db_create_videos_table() -> None:
             isTagged BOOLEAN DEFAULT 0,
             isFavourite BOOLEAN DEFAULT 0,
             captured_at DATETIME,
+            favouritedAt DATETIME,
             FOREIGN KEY (folder_id) REFERENCES folders(folder_id) ON DELETE CASCADE
         )
     """
@@ -67,6 +69,13 @@ def db_create_videos_table() -> None:
     cursor.execute(
         "CREATE INDEX IF NOT EXISTS ix_videos_captured_at ON videos(captured_at)"
     )
+
+    # favouritedAt: when the video was last favourited (NULL if never, or
+    # pre-dates this column). Guarded ALTER because shipped databases predate
+    # it and CREATE IF NOT EXISTS won't add it.
+    cursor.execute("PRAGMA table_info(videos)")
+    if "favouritedAt" not in {row[1] for row in cursor.fetchall()}:
+        cursor.execute("ALTER TABLE videos ADD COLUMN favouritedAt DATETIME")
 
     conn.commit()
     conn.close()
@@ -123,7 +132,7 @@ def db_get_all_videos() -> List[dict]:
     try:
         cursor.execute(
             """
-            SELECT id, path, folder_id, thumbnailPath, metadata, isTagged, isFavourite, captured_at
+            SELECT id, path, folder_id, thumbnailPath, metadata, isTagged, isFavourite, captured_at, favouritedAt
             FROM videos
             ORDER BY path
             """
@@ -158,6 +167,7 @@ def _build_video_dicts(rows: List[Tuple]) -> List[dict]:
         is_tagged,
         is_favourite,
         captured_at,
+        favourited_at,
     ) in rows:
         videos.append(
             {
@@ -169,6 +179,7 @@ def _build_video_dicts(rows: List[Tuple]) -> List[dict]:
                 "isTagged": bool(is_tagged),
                 "isFavourite": bool(is_favourite),
                 "captured_at": captured_at if captured_at else None,
+                "favouritedAt": favourited_at if favourited_at else None,
                 "tags": tags_by_video.get(video_id) or None,
             }
         )
@@ -231,7 +242,7 @@ def db_get_videos_by_ids(video_ids: List[VideoId]) -> List[dict]:
             cursor.execute(
                 f"""
                 SELECT id, path, folder_id, thumbnailPath, metadata, isTagged,
-                       isFavourite, captured_at
+                       isFavourite, captured_at, favouritedAt
                 FROM videos
                 WHERE id IN ({placeholders})
                 """,
@@ -338,7 +349,11 @@ def db_toggle_video_favourite_status(video_id: str) -> bool:
         cursor.execute(
             """
             UPDATE videos
-            SET isFavourite = CASE WHEN isFavourite = 1 THEN 0 ELSE 1 END
+            SET favouritedAt = CASE
+                    WHEN isFavourite = 1 THEN favouritedAt
+                    ELSE CURRENT_TIMESTAMP
+                END,
+                isFavourite = CASE WHEN isFavourite = 1 THEN 0 ELSE 1 END
             WHERE id = ?
             """,
             (video_id,),

--- a/backend/app/routes/images.py
+++ b/backend/app/routes/images.py
@@ -38,6 +38,7 @@ class ImageData(BaseModel):
     metadata: MetadataModel
     isTagged: bool
     isFavourite: bool
+    favouritedAt: Optional[str] = None
     tags: Optional[List[str]] = None
 
 
@@ -85,6 +86,7 @@ def get_all_images(
                 metadata=image_util_parse_metadata(image["metadata"]),
                 isTagged=image["isTagged"],
                 isFavourite=image.get("isFavourite", False),
+                favouritedAt=image.get("favouritedAt"),
                 tags=image["tags"],
             )
             for image in images

--- a/backend/app/routes/images.py
+++ b/backend/app/routes/images.py
@@ -128,6 +128,7 @@ def search_images_by_tag(tag: str = Query(..., description="Tag name to search f
                 metadata=image_util_parse_metadata(image["metadata"]),
                 isTagged=image["isTagged"],
                 isFavourite=image.get("isFavourite", False),
+                favouritedAt=image.get("favouritedAt"),
                 tags=image["tags"],
             )
             for image in images
@@ -290,6 +291,7 @@ def semantic_search_images(
                     metadata=image_util_parse_metadata(img["metadata"]),
                     isTagged=img["isTagged"],
                     isFavourite=img.get("isFavourite", False),
+                    favouritedAt=img.get("favouritedAt"),
                     tags=img["tags"],
                     score=score,
                 )

--- a/backend/app/routes/videos.py
+++ b/backend/app/routes/videos.py
@@ -36,6 +36,7 @@ class VideoData(BaseModel):
     thumbnailPath: Optional[str]
     metadata: VideoMetadataModel
     isFavourite: bool
+    favouritedAt: Optional[str] = None
     tags: Optional[List[str]] = None
 
 
@@ -59,6 +60,7 @@ def _to_video_data(videos: List[dict]) -> List[VideoData]:
                     thumbnailPath=video["thumbnailPath"],
                     metadata=video["metadata"],
                     isFavourite=video.get("isFavourite", False),
+                    favouritedAt=video.get("favouritedAt"),
                     tags=video["tags"],
                 )
             )

--- a/backend/tests/test_images_db.py
+++ b/backend/tests/test_images_db.py
@@ -400,6 +400,17 @@ class TestSearchAndGetByIds:
         results = db_get_images_by_ids(["img-3", "img-1", "missing"])
         assert [img["id"] for img in results] == ["img-3", "img-1"]
 
+    def test_search_by_tag_and_get_by_ids_carry_favouritedAt(self, folder, test_db):
+        db_bulk_insert_images([make_image_record("img-1", "/photos/a.jpg", folder)])
+        add_tag(test_db, "img-1", 9001, "sunset")
+        assert db_search_images_by_tag("sunset")[0]["favouritedAt"] is None
+        assert db_get_images_by_ids(["img-1"])[0]["favouritedAt"] is None
+
+        db_toggle_image_favourite_status("img-1")
+
+        assert db_search_images_by_tag("sunset")[0]["favouritedAt"] is not None
+        assert db_get_images_by_ids(["img-1"])[0]["favouritedAt"] is not None
+
 
 # ##############################
 # Marking embedded

--- a/backend/tests/test_images_db.py
+++ b/backend/tests/test_images_db.py
@@ -297,6 +297,24 @@ class TestFavouriteStatus:
     def test_missing_image_returns_false(self, test_db):
         assert db_toggle_image_favourite_status("nope") is False
 
+    def test_favouriting_stamps_favouritedAt_unfavouriting_keeps_it(
+        self, folder, test_db
+    ):
+        db_bulk_insert_images([make_image_record("img-1", "/photos/a.jpg", folder)])
+        by_id = {image["id"]: image for image in db_get_all_images()}
+        assert by_id["img-1"]["favouritedAt"] is None
+
+        db_toggle_image_favourite_status("img-1")
+        by_id = {image["id"]: image for image in db_get_all_images()}
+        stamped_at = by_id["img-1"]["favouritedAt"]
+        assert stamped_at is not None
+
+        # Un-favouriting doesn't need to clear it -- the item is filtered out
+        # of "favourites" by isFavourite anyway.
+        db_toggle_image_favourite_status("img-1")
+        by_id = {image["id"]: image for image in db_get_all_images()}
+        assert by_id["img-1"]["favouritedAt"] == stamped_at
+
 
 # ##############################
 # Folder queries and deletion

--- a/backend/tests/test_videos.py
+++ b/backend/tests/test_videos.py
@@ -418,6 +418,8 @@ class TestVideosDatabase:
         record = make_video_record("vid-1", "/videos/a.mp4", test_folder_id)
         db_bulk_insert_videos([record])
         assert db_toggle_video_favourite_status("vid-1") is True
+        favourited_at = db_get_all_videos()[0]["favouritedAt"]
+        assert favourited_at is not None
 
         # Re-scan inserts the same path under a new id; favourite must survive
         rescan = make_video_record("vid-new", "/videos/a.mp4", test_folder_id)
@@ -427,6 +429,22 @@ class TestVideosDatabase:
         assert len(videos) == 1
         assert videos[0]["id"] == "vid-1"
         assert videos[0]["isFavourite"] is True
+        assert videos[0]["favouritedAt"] == favourited_at
+
+    def test_toggling_favourite_stamps_favouritedAt(self, test_db, test_folder_id):
+        db_bulk_insert_videos(
+            [make_video_record("vid-1", "/videos/a.mp4", test_folder_id)]
+        )
+        assert db_get_all_videos()[0]["favouritedAt"] is None
+
+        db_toggle_video_favourite_status("vid-1")
+        stamped_at = db_get_all_videos()[0]["favouritedAt"]
+        assert stamped_at is not None
+
+        # Un-favouriting doesn't need to clear it -- the item is filtered out
+        # of "favourites" by isFavourite anyway.
+        db_toggle_video_favourite_status("vid-1")
+        assert db_get_all_videos()[0]["favouritedAt"] == stamped_at
 
     def test_upsert_keeps_old_thumbnail_when_new_is_null(self, test_db, test_folder_id):
         db_bulk_insert_videos(
@@ -506,12 +524,22 @@ class TestVideosAPI:
         assert data[0]["metadata"]["duration"] == 12.5
 
     def test_toggle_favourite(self, client, test_folder_id):
+        metadata = '{"name": "a.mp4", "date_created": "2026-01-01T00:00:00", "width": 640, "height": 480, "file_location": "/videos/a.mp4", "file_size": 123, "item_type": "video/mp4"}'
         db_bulk_insert_videos(
-            [make_video_record("vid-1", "/videos/a.mp4", test_folder_id)]
+            [
+                make_video_record(
+                    "vid-1", "/videos/a.mp4", test_folder_id, metadata=metadata
+                )
+            ]
         )
         response = client.post("/videos/toggle-favourite", json={"video_id": "vid-1"})
         assert response.status_code == 200
         assert response.json()["isFavourite"] is True
+
+        # The list endpoint -- what the frontend actually reads -- now carries
+        # a favouritedAt timestamp for the item.
+        listed = client.get("/videos/").json()["data"][0]
+        assert listed["favouritedAt"] is not None
 
         response = client.post("/videos/toggle-favourite", json={"video_id": "vid-1"})
         assert response.json()["isFavourite"] is False

--- a/frontend/src/api/api-functions/images.ts
+++ b/frontend/src/api/api-functions/images.ts
@@ -1,13 +1,17 @@
 import { imagesEndpoints } from '../apiEndpoints';
 import { apiClient } from '../axiosConfig';
 import { APIResponse } from '@/types/API';
-import { ScoredImage } from '@/types/Media';
+import { Image, ScoredImage } from '@/types/Media';
+
+export interface GetAllImagesResponse extends APIResponse {
+  data?: Image[];
+}
 
 export const fetchAllImages = async (
   tagged?: boolean,
-): Promise<APIResponse> => {
+): Promise<GetAllImagesResponse> => {
   const params = tagged !== undefined ? { tagged } : {};
-  const response = await apiClient.get<APIResponse>(
+  const response = await apiClient.get<GetAllImagesResponse>(
     imagesEndpoints.getAllImages,
     { params },
   );

--- a/frontend/src/api/api-functions/videos.ts
+++ b/frontend/src/api/api-functions/videos.ts
@@ -1,10 +1,14 @@
 import { videosEndpoints } from '../apiEndpoints';
 import { apiClient } from '../axiosConfig';
 import { APIResponse } from '@/types/API';
-import { ScoredVideo } from '@/types/Media';
+import { ScoredVideo, Video } from '@/types/Media';
 
-export const fetchAllVideos = async (): Promise<APIResponse> => {
-  const response = await apiClient.get<APIResponse>(
+export interface GetAllVideosResponse extends APIResponse {
+  data?: Video[];
+}
+
+export const fetchAllVideos = async (): Promise<GetAllVideosResponse> => {
+  const response = await apiClient.get<GetAllVideosResponse>(
     videosEndpoints.getAllVideos,
   );
   return response.data;

--- a/frontend/src/components/Media/ChronologicalFavoritesGallery.tsx
+++ b/frontend/src/components/Media/ChronologicalFavoritesGallery.tsx
@@ -7,10 +7,22 @@ import { cn } from '@/lib/utils';
 import { Image, Video } from '@/types/Media';
 import { groupImagesByYearMonthFromMetadata } from '@/utils/dateUtils';
 import { MonthMarker } from './ChronologicalGallery';
-import { setCurrentViewIndex as setCurrentImageViewIndex } from '@/features/imageSlice';
-import { setCurrentViewIndex as setCurrentVideoViewIndex } from '@/features/videoSlice';
-import { selectIsImageViewOpen } from '@/features/imageSelectors';
-import { selectIsVideoViewOpen } from '@/features/videoSelectors';
+import {
+  setCurrentViewIndex as setCurrentImageViewIndex,
+  closeImageView,
+} from '@/features/imageSlice';
+import {
+  setCurrentViewIndex as setCurrentVideoViewIndex,
+  closeVideoView,
+} from '@/features/videoSlice';
+import {
+  selectCurrentViewIndex,
+  selectIsImageViewOpen,
+} from '@/features/imageSelectors';
+import {
+  selectCurrentVideoIndex,
+  selectIsVideoViewOpen,
+} from '@/features/videoSelectors';
 import { MediaView } from './MediaView';
 import { VideoPlayerOverlay } from '@/components/VideoPlayer/VideoPlayerOverlay';
 
@@ -48,6 +60,10 @@ export const ChronologicalFavoritesGallery = ({
   const galleryRef = useRef<HTMLDivElement>(null);
   const isImageViewOpen = useSelector(selectIsImageViewOpen);
   const isVideoViewOpen = useSelector(selectIsVideoViewOpen);
+  const currentImageIndex = useSelector(selectCurrentViewIndex);
+  const currentVideoIndex = useSelector(selectCurrentVideoIndex);
+  const previousImageIdsRef = useRef<string[]>([]);
+  const previousVideoIdsRef = useRef<string[]>([]);
 
   const merged = useMemo<FavoriteMediaItem[]>(
     () => [
@@ -125,6 +141,39 @@ export const ChronologicalFavoritesGallery = ({
     });
     return map;
   }, [orderedVideos]);
+
+  // Un-favouriting the item currently open in its viewer (e.g. from the
+  // heart button inside MediaView/VideoPlayerOverlay itself) drops it out of
+  // this gallery's list. The viewer's index is otherwise untouched, so it
+  // would silently show whatever now sits at that index -- or nothing, if
+  // the item was last. Close it instead of drifting to the wrong item.
+  useEffect(() => {
+    const previousIds = previousImageIdsRef.current;
+    const currentIds = orderedImages.map((img) => img.id);
+    if (
+      isImageViewOpen &&
+      currentImageIndex >= 0 &&
+      currentImageIndex < previousIds.length &&
+      !currentIds.includes(previousIds[currentImageIndex])
+    ) {
+      dispatch(closeImageView());
+    }
+    previousImageIdsRef.current = currentIds;
+  }, [orderedImages, isImageViewOpen, currentImageIndex, dispatch]);
+
+  useEffect(() => {
+    const previousIds = previousVideoIdsRef.current;
+    const currentIds = orderedVideos.map((video) => video.id);
+    if (
+      isVideoViewOpen &&
+      currentVideoIndex >= 0 &&
+      currentVideoIndex < previousIds.length &&
+      !currentIds.includes(previousIds[currentVideoIndex])
+    ) {
+      dispatch(closeVideoView());
+    }
+    previousVideoIdsRef.current = currentIds;
+  }, [orderedVideos, isVideoViewOpen, currentVideoIndex, dispatch]);
 
   const renderCard = useCallback(
     (item: FavoriteMediaItem) =>

--- a/frontend/src/components/Media/ChronologicalFavoritesGallery.tsx
+++ b/frontend/src/components/Media/ChronologicalFavoritesGallery.tsx
@@ -1,0 +1,252 @@
+import { useMemo, useRef, useEffect, useCallback } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { ImageCard } from '@/components/Media/ImageCard';
+import { VideoCard } from '@/components/Media/VideoCard';
+import { MEDIA_GRID_CLASS } from '@/constants/layout';
+import { cn } from '@/lib/utils';
+import { Image, Video } from '@/types/Media';
+import { groupImagesByYearMonthFromMetadata } from '@/utils/dateUtils';
+import { MonthMarker } from './ChronologicalGallery';
+import { setCurrentViewIndex as setCurrentImageViewIndex } from '@/features/imageSlice';
+import { setCurrentViewIndex as setCurrentVideoViewIndex } from '@/features/videoSlice';
+import { selectIsImageViewOpen } from '@/features/imageSelectors';
+import { selectIsVideoViewOpen } from '@/features/videoSelectors';
+import { MediaView } from './MediaView';
+import { VideoPlayerOverlay } from '@/components/VideoPlayer/VideoPlayerOverlay';
+
+type FavoriteMediaItem =
+  | ({ mediaType: 'image' } & Image)
+  | ({ mediaType: 'video' } & Video);
+
+type ChronologicalFavoritesGalleryProps = {
+  images: Image[];
+  videos: Video[];
+  showTitle?: boolean;
+  title?: string;
+  titleRight?: React.ReactNode;
+  className?: string;
+  onMonthOffsetsChange?: (markers: MonthMarker[]) => void;
+  scrollContainerRef?: React.RefObject<HTMLElement | null>;
+};
+
+export const ChronologicalFavoritesGallery = ({
+  images,
+  videos,
+  showTitle = false,
+  title = 'Favorites',
+  titleRight,
+  className = '',
+  onMonthOffsetsChange,
+  scrollContainerRef,
+}: ChronologicalFavoritesGalleryProps) => {
+  const dispatch = useDispatch();
+  const monthHeaderRefs = useRef<Map<string, HTMLDivElement | null>>(new Map());
+  const galleryRef = useRef<HTMLDivElement>(null);
+  const isImageViewOpen = useSelector(selectIsImageViewOpen);
+  const isVideoViewOpen = useSelector(selectIsVideoViewOpen);
+
+  const merged = useMemo<FavoriteMediaItem[]>(
+    () => [
+      ...images.map((image) => ({ ...image, mediaType: 'image' as const })),
+      ...videos.map((video) => ({ ...video, mediaType: 'video' as const })),
+    ],
+    [images, videos],
+  );
+
+  const grouped = useMemo(
+    () => groupImagesByYearMonthFromMetadata(merged),
+    [merged],
+  );
+
+  const sortedGrouped = useMemo(() => {
+    return Object.entries(grouped)
+      .sort((a, b) => Number(b[0]) - Number(a[0]))
+      .map(([year, months]) => ({
+        year,
+        months: Object.entries(months).sort(
+          (a, b) => Number(b[0]) - Number(a[0]),
+        ),
+      }));
+  }, [grouped]);
+
+  const chronologicallySortedItems = useMemo(() => {
+    return sortedGrouped.flatMap(({ months }) =>
+      months.flatMap(([, items]) => items),
+    );
+  }, [sortedGrouped]);
+
+  // MediaView/VideoPlayerOverlay each navigate within their own media type,
+  // so the index passed to them must be within the type-filtered sequence,
+  // not the merged one.
+  const chronologicallySortedImages = useMemo(
+    () =>
+      chronologicallySortedItems.filter(
+        (item): item is FavoriteMediaItem & { mediaType: 'image' } =>
+          item.mediaType === 'image',
+      ),
+    [chronologicallySortedItems],
+  );
+
+  const chronologicallySortedVideos = useMemo(
+    () =>
+      chronologicallySortedItems.filter(
+        (item): item is FavoriteMediaItem & { mediaType: 'video' } =>
+          item.mediaType === 'video',
+      ),
+    [chronologicallySortedItems],
+  );
+
+  const imageIndexMap = useMemo(() => {
+    const map = new Map<string, number>();
+    chronologicallySortedImages.forEach((img, idx) => {
+      map.set(img.id, idx);
+    });
+    return map;
+  }, [chronologicallySortedImages]);
+
+  const videoIndexMap = useMemo(() => {
+    const map = new Map<string, number>();
+    chronologicallySortedVideos.forEach((video, idx) => {
+      map.set(video.id, idx);
+    });
+    return map;
+  }, [chronologicallySortedVideos]);
+
+  const recomputeMarkers = useCallback(() => {
+    if (!onMonthOffsetsChange) return;
+    if (monthHeaderRefs.current.size === 0) {
+      onMonthOffsetsChange([]);
+      return;
+    }
+
+    const scroller = scrollContainerRef?.current;
+    const scrollerTop = scroller ? scroller.getBoundingClientRect().top : 0;
+
+    const entries = Array.from(monthHeaderRefs.current.entries()).flatMap(
+      ([key, el]) => {
+        if (!el) return [];
+        const [y, m] = key.split('-');
+        const monthName = new Date(Number(y), Number(m) - 1).toLocaleString(
+          'default',
+          { month: 'long' },
+        );
+        const offset = scroller
+          ? el.getBoundingClientRect().top - scrollerTop + scroller.scrollTop
+          : el.offsetTop;
+        return [{ offset, month: monthName, year: y }];
+      },
+    );
+    entries.sort((a, b) => a.offset - b.offset);
+    onMonthOffsetsChange(entries);
+  }, [onMonthOffsetsChange, scrollContainerRef]);
+
+  useEffect(() => {
+    recomputeMarkers();
+  }, [merged, recomputeMarkers]);
+
+  useEffect(() => {
+    const elementToObserve = scrollContainerRef?.current ?? galleryRef.current;
+    if (!elementToObserve) return;
+
+    const observer = new ResizeObserver(recomputeMarkers);
+
+    observer.observe(elementToObserve);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [recomputeMarkers, scrollContainerRef]);
+
+  return (
+    <>
+      <div ref={galleryRef} className={`space-y-0 ${className}`}>
+        {/* Title */}
+        {showTitle && (
+          <div className="mt-6 mb-6 flex items-center justify-between">
+            <h1 className="text-2xl font-bold">{title}</h1>
+            {titleRight && <div>{titleRight}</div>}
+          </div>
+        )}
+
+        {/* Gallery Content */}
+        {sortedGrouped.map(({ year, months }) => (
+          <div key={year} data-year={year}>
+            {months.map(([month, items]) => {
+              const monthName = new Date(
+                Number(year),
+                Number(month) - 1,
+              ).toLocaleString('default', { month: 'long' });
+
+              return (
+                <div
+                  key={`${year}-${month}`}
+                  className="mb-8"
+                  data-timeline-month={`${year}-${month}`}
+                  id={`timeline-section-${year}-${month}`}
+                  ref={(el) => {
+                    const key = `${year}-${month}`;
+                    if (el) {
+                      monthHeaderRefs.current.set(key, el);
+                    } else {
+                      monthHeaderRefs.current.delete(key);
+                    }
+                  }}
+                >
+                  {/* Sticky Month/Year Header */}
+                  <div className="bg-background sticky top-0 z-10 py-3 backdrop-blur-sm">
+                    <h3 className="flex items-center text-xl font-semibold text-gray-800 dark:text-gray-200">
+                      <div className="bg-primary mr-2 h-6 w-1"></div>
+                      {monthName} {year}
+                      <div className="mt-1 ml-2 text-sm font-normal text-gray-500">
+                        {items.length} {items.length === 1 ? 'item' : 'items'}
+                      </div>
+                    </h3>
+                  </div>
+
+                  {/* Media Grid */}
+                  <div className={cn(MEDIA_GRID_CLASS, 'p-2')}>
+                    {items.map((item) =>
+                      item.mediaType === 'image' ? (
+                        <div key={item.id} className="group relative">
+                          <ImageCard
+                            image={item}
+                            onClick={() =>
+                              dispatch(
+                                setCurrentImageViewIndex(
+                                  imageIndexMap.get(item.id) ?? -1,
+                                ),
+                              )
+                            }
+                            className="w-full transition-transform duration-200 group-hover:scale-105"
+                          />
+                        </div>
+                      ) : (
+                        <div key={item.id} className="group relative">
+                          <VideoCard
+                            video={item}
+                            onClick={() =>
+                              dispatch(
+                                setCurrentVideoViewIndex(
+                                  videoIndexMap.get(item.id) ?? -1,
+                                ),
+                              )
+                            }
+                            className="w-full transition-transform duration-200 group-hover:scale-105"
+                          />
+                        </div>
+                      ),
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        ))}
+      </div>
+      {isImageViewOpen && <MediaView images={chronologicallySortedImages} />}
+      {isVideoViewOpen && (
+        <VideoPlayerOverlay videos={chronologicallySortedVideos} />
+      )}
+    </>
+  );
+};

--- a/frontend/src/components/Media/ChronologicalFavoritesGallery.tsx
+++ b/frontend/src/components/Media/ChronologicalFavoritesGallery.tsx
@@ -18,9 +18,12 @@ type FavoriteMediaItem =
   | ({ mediaType: 'image' } & Image)
   | ({ mediaType: 'video' } & Video);
 
+export type FavoritesSortValue = 'date' | 'custom';
+
 type ChronologicalFavoritesGalleryProps = {
   images: Image[];
   videos: Video[];
+  sortBy?: FavoritesSortValue;
   showTitle?: boolean;
   title?: string;
   titleRight?: React.ReactNode;
@@ -32,6 +35,7 @@ type ChronologicalFavoritesGalleryProps = {
 export const ChronologicalFavoritesGallery = ({
   images,
   videos,
+  sortBy = 'date',
   showTitle = false,
   title = 'Favorites',
   titleRight,
@@ -69,48 +73,88 @@ export const ChronologicalFavoritesGallery = ({
       }));
   }, [grouped]);
 
-  const chronologicallySortedItems = useMemo(() => {
+  // "Custom" order: most-recently-favourited first. SQLite's CURRENT_TIMESTAMP
+  // format (YYYY-MM-DD HH:MM:SS) sorts correctly as a plain string. Items
+  // favourited before this field existed have no timestamp and sort last.
+  const customSorted = useMemo(() => {
+    return [...merged].sort((a, b) =>
+      (b.favouritedAt ?? '').localeCompare(a.favouritedAt ?? ''),
+    );
+  }, [merged]);
+
+  const orderedItems = useMemo(() => {
+    if (sortBy === 'custom') return customSorted;
     return sortedGrouped.flatMap(({ months }) =>
       months.flatMap(([, items]) => items),
     );
-  }, [sortedGrouped]);
+  }, [sortBy, customSorted, sortedGrouped]);
 
   // MediaView/VideoPlayerOverlay each navigate within their own media type,
   // so the index passed to them must be within the type-filtered sequence,
   // not the merged one.
-  const chronologicallySortedImages = useMemo(
+  const orderedImages = useMemo(
     () =>
-      chronologicallySortedItems.filter(
+      orderedItems.filter(
         (item): item is FavoriteMediaItem & { mediaType: 'image' } =>
           item.mediaType === 'image',
       ),
-    [chronologicallySortedItems],
+    [orderedItems],
   );
 
-  const chronologicallySortedVideos = useMemo(
+  const orderedVideos = useMemo(
     () =>
-      chronologicallySortedItems.filter(
+      orderedItems.filter(
         (item): item is FavoriteMediaItem & { mediaType: 'video' } =>
           item.mediaType === 'video',
       ),
-    [chronologicallySortedItems],
+    [orderedItems],
   );
 
   const imageIndexMap = useMemo(() => {
     const map = new Map<string, number>();
-    chronologicallySortedImages.forEach((img, idx) => {
+    orderedImages.forEach((img, idx) => {
       map.set(img.id, idx);
     });
     return map;
-  }, [chronologicallySortedImages]);
+  }, [orderedImages]);
 
   const videoIndexMap = useMemo(() => {
     const map = new Map<string, number>();
-    chronologicallySortedVideos.forEach((video, idx) => {
+    orderedVideos.forEach((video, idx) => {
       map.set(video.id, idx);
     });
     return map;
-  }, [chronologicallySortedVideos]);
+  }, [orderedVideos]);
+
+  const renderCard = useCallback(
+    (item: FavoriteMediaItem) =>
+      item.mediaType === 'image' ? (
+        <div key={item.id} className="group relative">
+          <ImageCard
+            image={item}
+            onClick={() =>
+              dispatch(
+                setCurrentImageViewIndex(imageIndexMap.get(item.id) ?? -1),
+              )
+            }
+            className="w-full transition-transform duration-200 group-hover:scale-105"
+          />
+        </div>
+      ) : (
+        <div key={item.id} className="group relative">
+          <VideoCard
+            video={item}
+            onClick={() =>
+              dispatch(
+                setCurrentVideoViewIndex(videoIndexMap.get(item.id) ?? -1),
+              )
+            }
+            className="w-full transition-transform duration-200 group-hover:scale-105"
+          />
+        </div>
+      ),
+    [dispatch, imageIndexMap, videoIndexMap],
+  );
 
   const recomputeMarkers = useCallback(() => {
     if (!onMonthOffsetsChange) return;
@@ -142,7 +186,7 @@ export const ChronologicalFavoritesGallery = ({
 
   useEffect(() => {
     recomputeMarkers();
-  }, [merged, recomputeMarkers]);
+  }, [merged, sortBy, recomputeMarkers]);
 
   useEffect(() => {
     const elementToObserve = scrollContainerRef?.current ?? galleryRef.current;
@@ -168,85 +212,61 @@ export const ChronologicalFavoritesGallery = ({
           </div>
         )}
 
-        {/* Gallery Content */}
-        {sortedGrouped.map(({ year, months }) => (
-          <div key={year} data-year={year}>
-            {months.map(([month, items]) => {
-              const monthName = new Date(
-                Number(year),
-                Number(month) - 1,
-              ).toLocaleString('default', { month: 'long' });
-
-              return (
-                <div
-                  key={`${year}-${month}`}
-                  className="mb-8"
-                  data-timeline-month={`${year}-${month}`}
-                  id={`timeline-section-${year}-${month}`}
-                  ref={(el) => {
-                    const key = `${year}-${month}`;
-                    if (el) {
-                      monthHeaderRefs.current.set(key, el);
-                    } else {
-                      monthHeaderRefs.current.delete(key);
-                    }
-                  }}
-                >
-                  {/* Sticky Month/Year Header */}
-                  <div className="bg-background sticky top-0 z-10 py-3 backdrop-blur-sm">
-                    <h3 className="flex items-center text-xl font-semibold text-gray-800 dark:text-gray-200">
-                      <div className="bg-primary mr-2 h-6 w-1"></div>
-                      {monthName} {year}
-                      <div className="mt-1 ml-2 text-sm font-normal text-gray-500">
-                        {items.length} {items.length === 1 ? 'item' : 'items'}
-                      </div>
-                    </h3>
-                  </div>
-
-                  {/* Media Grid */}
-                  <div className={cn(MEDIA_GRID_CLASS, 'p-2')}>
-                    {items.map((item) =>
-                      item.mediaType === 'image' ? (
-                        <div key={item.id} className="group relative">
-                          <ImageCard
-                            image={item}
-                            onClick={() =>
-                              dispatch(
-                                setCurrentImageViewIndex(
-                                  imageIndexMap.get(item.id) ?? -1,
-                                ),
-                              )
-                            }
-                            className="w-full transition-transform duration-200 group-hover:scale-105"
-                          />
-                        </div>
-                      ) : (
-                        <div key={item.id} className="group relative">
-                          <VideoCard
-                            video={item}
-                            onClick={() =>
-                              dispatch(
-                                setCurrentVideoViewIndex(
-                                  videoIndexMap.get(item.id) ?? -1,
-                                ),
-                              )
-                            }
-                            className="w-full transition-transform duration-200 group-hover:scale-105"
-                          />
-                        </div>
-                      ),
-                    )}
-                  </div>
-                </div>
-              );
-            })}
+        {sortBy === 'custom' ? (
+          // Flat grid in favourited order -- there's no natural month
+          // grouping for "the order the user favourited things".
+          <div className={cn(MEDIA_GRID_CLASS, 'p-2')}>
+            {orderedItems.map(renderCard)}
           </div>
-        ))}
+        ) : (
+          /* Gallery Content, grouped by year/month */
+          sortedGrouped.map(({ year, months }) => (
+            <div key={year} data-year={year}>
+              {months.map(([month, items]) => {
+                const monthName = new Date(
+                  Number(year),
+                  Number(month) - 1,
+                ).toLocaleString('default', { month: 'long' });
+
+                return (
+                  <div
+                    key={`${year}-${month}`}
+                    className="mb-8"
+                    data-timeline-month={`${year}-${month}`}
+                    id={`timeline-section-${year}-${month}`}
+                    ref={(el) => {
+                      const key = `${year}-${month}`;
+                      if (el) {
+                        monthHeaderRefs.current.set(key, el);
+                      } else {
+                        monthHeaderRefs.current.delete(key);
+                      }
+                    }}
+                  >
+                    {/* Sticky Month/Year Header */}
+                    <div className="bg-background sticky top-0 z-10 py-3 backdrop-blur-sm">
+                      <h3 className="flex items-center text-xl font-semibold text-gray-800 dark:text-gray-200">
+                        <div className="bg-primary mr-2 h-6 w-1"></div>
+                        {monthName} {year}
+                        <div className="mt-1 ml-2 text-sm font-normal text-gray-500">
+                          {items.length} {items.length === 1 ? 'item' : 'items'}
+                        </div>
+                      </h3>
+                    </div>
+
+                    {/* Media Grid */}
+                    <div className={cn(MEDIA_GRID_CLASS, 'p-2')}>
+                      {items.map(renderCard)}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          ))
+        )}
       </div>
-      {isImageViewOpen && <MediaView images={chronologicallySortedImages} />}
-      {isVideoViewOpen && (
-        <VideoPlayerOverlay videos={chronologicallySortedVideos} />
-      )}
+      {isImageViewOpen && <MediaView images={orderedImages} />}
+      {isVideoViewOpen && <VideoPlayerOverlay videos={orderedVideos} />}
     </>
   );
 };

--- a/frontend/src/components/Media/ImageCard.tsx
+++ b/frontend/src/components/Media/ImageCard.tsx
@@ -46,9 +46,10 @@ export function ImageCard({
       onClick={onClick}
     >
       <div className="relative">
-        {/* Selection tick mark */}
+        {/* Selection tick mark -- top-left, so it never overlaps the
+            favourite button at top-right */}
         {isSelected && (
-          <div className="absolute top-2 right-2 z-10 rounded-full bg-[#4088fa] p-1">
+          <div className="absolute top-2 left-2 z-10 rounded-full bg-[#4088fa] p-1">
             <Check className="h-4 w-4 text-white" />
           </div>
         )}

--- a/frontend/src/components/Media/ImageCard.tsx
+++ b/frontend/src/components/Media/ImageCard.tsx
@@ -68,10 +68,10 @@ export function ImageCard({
             )}
           />
           {/* Dark overlay on hover */}
-          <div className="absolute inset-0 bg-black/30 opacity-0 transition-opacity duration-200 group-hover:opacity-100" />
+          <div className="pointer-events-none absolute inset-0 bg-black/30 opacity-0 transition-opacity duration-200 group-hover:opacity-100" />
 
-          {/* Image actions on hover */}
-          <div className="absolute inset-0 flex items-center justify-center gap-2 opacity-0 transition-opacity duration-200 group-hover:opacity-100">
+          {/* Favourite action: top-right, matching VideoCard's placement */}
+          <div className="absolute top-2 right-2 z-20 opacity-0 transition-opacity duration-200 group-hover:opacity-100 focus-within:opacity-100">
             <Button
               variant="ghost"
               size="icon"
@@ -81,7 +81,6 @@ export function ImageCard({
                   : 'bg-white/10 hover:bg-white/20 hover:shadow-lg'
               }`}
               onClick={(e) => {
-                console.log(image);
                 e.stopPropagation();
                 handleToggleFavourite();
               }}

--- a/frontend/src/hooks/__tests__/useMutationFeedback.test.tsx
+++ b/frontend/src/hooks/__tests__/useMutationFeedback.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { rootReducer } from '@/app/store';
+import { useMutationFeedback } from '../useMutationFeedback';
+
+// Mirrors MyFav.tsx: one call owns the (global, single-owner) loader for as
+// long as it's pending, a second, sibling call reports errors only via
+// showLoading: false and must never touch the loader either way.
+const renderWithTwoFeedbackCalls = (isPending: boolean) => {
+  const store = configureStore({ reducer: rootReducer });
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <Provider store={store}>{children}</Provider>
+  );
+
+  renderHook(
+    () => {
+      useMutationFeedback(
+        { isPending },
+        { loadingMessage: 'Loading', showSuccess: false, showError: false },
+      );
+      useMutationFeedback(
+        { isSuccess: false, isError: false },
+        { showLoading: false, showSuccess: false, showError: false },
+      );
+    },
+    { wrapper },
+  );
+
+  return store;
+};
+
+describe('useMutationFeedback', () => {
+  test('a showLoading:false call does not hide a loader a sibling call is showing', () => {
+    const store = renderWithTwoFeedbackCalls(true);
+    expect(store.getState().loader.loading).toBe(true);
+  });
+
+  test('the loader is hidden once the owning call is no longer pending', () => {
+    const store = renderWithTwoFeedbackCalls(false);
+    expect(store.getState().loader.loading).toBe(false);
+  });
+});

--- a/frontend/src/hooks/useMutationFeedback.tsx
+++ b/frontend/src/hooks/useMutationFeedback.tsx
@@ -84,11 +84,16 @@ export const useMutationFeedback = (
 
   const { isPending, isSuccess, isError, error } = mutationState;
 
-  // Handle loading state
+  // Handle loading state. Gated on showLoading entirely -- not just for
+  // showLoader -- so a call with showLoading: false never touches the
+  // (global, single-owner) loader, even once its own isPending goes false.
+  // Otherwise a second feedback call for the same surface would hide a
+  // loader that a sibling call is still legitimately showing.
   useEffect(() => {
-    if (showLoading && isPending) {
+    if (!showLoading) return;
+    if (isPending) {
       dispatch(showLoader(loadingMessage));
-    } else if (!isPending) {
+    } else {
       dispatch(hideLoader());
     }
   }, [isPending, showLoading, loadingMessage, dispatch]);

--- a/frontend/src/pages/Home/MyFav.tsx
+++ b/frontend/src/pages/Home/MyFav.tsx
@@ -6,7 +6,6 @@ import {
 } from '@/components/Media/ChronologicalFavoritesGallery';
 import { MonthMarker } from '@/components/Media/ChronologicalGallery';
 import TimelineScrollbar from '@/components/Timeline/TimelineScrollbar';
-import { Image, Video } from '@/types/Media';
 import { setImages } from '@/features/imageSlice';
 import { selectImages } from '@/features/imageSelectors';
 import { setVideos } from '@/features/videoSlice';
@@ -69,15 +68,26 @@ export const MyFav = () => {
     enabled: !isSearchActive,
   });
 
+  // A single feedback call owns the global loader, kept up for as long as
+  // either query is pending -- two independent calls would each hide it the
+  // moment their own query settles, blanking it while the other still loads.
+  useMutationFeedback(
+    { isPending: isImagesLoading || isVideosLoading },
+    {
+      loadingMessage: 'Loading favorites',
+      showSuccess: false,
+      showError: false,
+    },
+  );
+
   useMutationFeedback(
     {
-      isPending: isImagesLoading,
       isSuccess: isImagesSuccess,
       isError: isImagesError,
       error: imagesError,
     },
     {
-      loadingMessage: 'Loading images',
+      showLoading: false,
       showSuccess: false,
       errorTitle: 'Error',
       errorMessage: 'Failed to load images. Please try again later.',
@@ -86,13 +96,12 @@ export const MyFav = () => {
 
   useMutationFeedback(
     {
-      isPending: isVideosLoading,
       isSuccess: isVideosSuccess,
       isError: isVideosError,
       error: videosError,
     },
     {
-      loadingMessage: 'Loading videos',
+      showLoading: false,
       showSuccess: false,
       errorTitle: 'Error',
       errorMessage: 'Failed to load videos. Please try again later.',
@@ -102,15 +111,13 @@ export const MyFav = () => {
   // Handle fetching lifecycle
   useEffect(() => {
     if (!isSearchActive && isImagesSuccess) {
-      const images = (imageData?.data ?? []) as Image[];
-      dispatch(setImages(images));
+      dispatch(setImages(imageData?.data ?? []));
     }
   }, [imageData, isImagesSuccess, dispatch, isSearchActive]);
 
   useEffect(() => {
     if (!isSearchActive && isVideosSuccess) {
-      const videos = (videoData?.data ?? []) as Video[];
-      dispatch(setVideos(videos));
+      dispatch(setVideos(videoData?.data ?? []));
     }
   }, [videoData, isVideosSuccess, dispatch, isSearchActive]);
 
@@ -120,8 +127,14 @@ export const MyFav = () => {
   );
 
   const favouriteVideos = useMemo(
-    () => videos.filter((video) => video.isFavourite === true),
-    [videos],
+    // The video query is disabled during search, but the store still holds
+    // whatever favourited videos were loaded before search started -- don't
+    // let them leak into the face-search results.
+    () =>
+      isSearchActive
+        ? []
+        : videos.filter((video) => video.isFavourite === true),
+    [videos, isSearchActive],
   );
 
   const favouriteCount = favouriteImages.length + favouriteVideos.length;

--- a/frontend/src/pages/Home/MyFav.tsx
+++ b/frontend/src/pages/Home/MyFav.tsx
@@ -1,15 +1,15 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import {
-  ChronologicalGallery,
-  MonthMarker,
-} from '@/components/Media/ChronologicalGallery';
+import { ChronologicalFavoritesGallery } from '@/components/Media/ChronologicalFavoritesGallery';
+import { MonthMarker } from '@/components/Media/ChronologicalGallery';
 import TimelineScrollbar from '@/components/Timeline/TimelineScrollbar';
-import { Image } from '@/types/Media';
+import { Image, Video } from '@/types/Media';
 import { setImages } from '@/features/imageSlice';
 import { selectImages } from '@/features/imageSelectors';
+import { setVideos } from '@/features/videoSlice';
+import { selectVideos } from '@/features/videoSelectors';
 import { usePictoQuery } from '@/hooks/useQueryExtension';
-import { fetchAllImages } from '@/api/api-functions';
+import { fetchAllImages, fetchAllVideos } from '@/api/api-functions';
 import { RootState } from '@/app/store';
 import { EmptyGalleryState } from '@/components/EmptyStates/EmptyGalleryState';
 import { Heart } from 'lucide-react';
@@ -18,19 +18,43 @@ import { useMutationFeedback } from '@/hooks/useMutationFeedback';
 export const MyFav = () => {
   const dispatch = useDispatch();
   const images = useSelector(selectImages);
+  const videos = useSelector(selectVideos);
   const scrollableRef = useRef<HTMLDivElement>(null);
   const [monthMarkers, setMonthMarkers] = useState<MonthMarker[]>([]);
   const searchState = useSelector((state: RootState) => state.search);
   const isSearchActive = searchState.active;
 
-  const { data, isLoading, isSuccess, isError, error } = usePictoQuery({
+  const {
+    data: imageData,
+    isLoading: isImagesLoading,
+    isSuccess: isImagesSuccess,
+    isError: isImagesError,
+    error: imagesError,
+  } = usePictoQuery({
     queryKey: ['images'],
     queryFn: () => fetchAllImages(),
     enabled: !isSearchActive,
   });
 
+  const {
+    data: videoData,
+    isLoading: isVideosLoading,
+    isSuccess: isVideosSuccess,
+    isError: isVideosError,
+    error: videosError,
+  } = usePictoQuery({
+    queryKey: ['videos'],
+    queryFn: () => fetchAllVideos(),
+    enabled: !isSearchActive,
+  });
+
   useMutationFeedback(
-    { isPending: isLoading, isSuccess, isError, error },
+    {
+      isPending: isImagesLoading,
+      isSuccess: isImagesSuccess,
+      isError: isImagesError,
+      error: imagesError,
+    },
     {
       loadingMessage: 'Loading images',
       showSuccess: false,
@@ -39,25 +63,54 @@ export const MyFav = () => {
     },
   );
 
+  useMutationFeedback(
+    {
+      isPending: isVideosLoading,
+      isSuccess: isVideosSuccess,
+      isError: isVideosError,
+      error: videosError,
+    },
+    {
+      loadingMessage: 'Loading videos',
+      showSuccess: false,
+      errorTitle: 'Error',
+      errorMessage: 'Failed to load videos. Please try again later.',
+    },
+  );
+
   // Handle fetching lifecycle
   useEffect(() => {
-    if (!isSearchActive && isSuccess) {
-      const images = (data?.data ?? []) as Image[];
+    if (!isSearchActive && isImagesSuccess) {
+      const images = (imageData?.data ?? []) as Image[];
       dispatch(setImages(images));
     }
-  }, [data, isSuccess, dispatch, isSearchActive]);
+  }, [imageData, isImagesSuccess, dispatch, isSearchActive]);
+
+  useEffect(() => {
+    if (!isSearchActive && isVideosSuccess) {
+      const videos = (videoData?.data ?? []) as Video[];
+      dispatch(setVideos(videos));
+    }
+  }, [videoData, isVideosSuccess, dispatch, isSearchActive]);
 
   const favouriteImages = useMemo(
     () => images.filter((image) => image.isFavourite === true),
     [images],
   );
 
+  const favouriteVideos = useMemo(
+    () => videos.filter((video) => video.isFavourite === true),
+    [videos],
+  );
+
+  const favouriteCount = favouriteImages.length + favouriteVideos.length;
+
   const title =
     isSearchActive && images.length > 0
       ? `Face Search Results (${images.length} found)`
-      : 'Favourite Image Gallery';
+      : 'Favorites';
 
-  if (favouriteImages.length === 0) {
+  if (favouriteCount === 0) {
     return (
       <div className="p-6">
         <h1 className="mb-6 text-2xl font-bold">{title}</h1>
@@ -69,11 +122,11 @@ export const MyFav = () => {
 
           {/* Text Content */}
           <h2 className="text-foreground mb-3 text-xl font-semibold">
-            No Favourite Images Yet
+            No Favorites Yet
           </h2>
           <p className="text-muted-foreground mb-6 max-w-md">
-            Start building your collection by marking images as favourites.
-            Click the heart icon on any image to add it here.
+            Start building your collection by marking images and videos as
+            favorites. Click the heart icon on any item to add it here.
           </p>
         </div>
       </div>
@@ -87,9 +140,10 @@ export const MyFav = () => {
         ref={scrollableRef}
         className="hide-scrollbar flex-1 overflow-x-hidden overflow-y-auto"
       >
-        {favouriteImages.length > 0 ? (
-          <ChronologicalGallery
+        {favouriteCount > 0 ? (
+          <ChronologicalFavoritesGallery
             images={favouriteImages}
+            videos={favouriteVideos}
             showTitle={true}
             title={title}
             onMonthOffsetsChange={setMonthMarkers}

--- a/frontend/src/pages/Home/MyFav.tsx
+++ b/frontend/src/pages/Home/MyFav.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { ChronologicalFavoritesGallery } from '@/components/Media/ChronologicalFavoritesGallery';
+import {
+  ChronologicalFavoritesGallery,
+  type FavoritesSortValue,
+} from '@/components/Media/ChronologicalFavoritesGallery';
 import { MonthMarker } from '@/components/Media/ChronologicalGallery';
 import TimelineScrollbar from '@/components/Timeline/TimelineScrollbar';
 import { Image, Video } from '@/types/Media';
@@ -9,11 +12,24 @@ import { selectImages } from '@/features/imageSelectors';
 import { setVideos } from '@/features/videoSlice';
 import { selectVideos } from '@/features/videoSelectors';
 import { usePictoQuery } from '@/hooks/useQueryExtension';
+import { usePersistedSort } from '@/hooks/usePersistedSort';
 import { fetchAllImages, fetchAllVideos } from '@/api/api-functions';
 import { RootState } from '@/app/store';
 import { EmptyGalleryState } from '@/components/EmptyStates/EmptyGalleryState';
-import { Heart } from 'lucide-react';
+import { Calendar, Heart, ListOrdered } from 'lucide-react';
 import { useMutationFeedback } from '@/hooks/useMutationFeedback';
+import {
+  GallerySortDropdown,
+  type SortOption,
+} from '@/components/GallerySortDropdown';
+
+const FAV_SORT_OPTIONS: SortOption<FavoritesSortValue>[] = [
+  { value: 'date', label: 'Date', icon: Calendar },
+  { value: 'custom', label: 'Custom', icon: ListOrdered },
+];
+
+const FAV_SORT_STORAGE_KEY = 'pictopy-favorites-sort';
+const FAV_SORT_VALUES = FAV_SORT_OPTIONS.map((option) => option.value);
 
 export const MyFav = () => {
   const dispatch = useDispatch();
@@ -23,6 +39,11 @@ export const MyFav = () => {
   const [monthMarkers, setMonthMarkers] = useState<MonthMarker[]>([]);
   const searchState = useSelector((state: RootState) => state.search);
   const isSearchActive = searchState.active;
+  const [sortBy, setSortBy] = usePersistedSort<FavoritesSortValue>(
+    FAV_SORT_STORAGE_KEY,
+    'date',
+    FAV_SORT_VALUES,
+  );
 
   const {
     data: imageData,
@@ -144,8 +165,18 @@ export const MyFav = () => {
           <ChronologicalFavoritesGallery
             images={favouriteImages}
             videos={favouriteVideos}
+            sortBy={sortBy}
             showTitle={true}
             title={title}
+            titleRight={
+              !isSearchActive && (
+                <GallerySortDropdown
+                  value={sortBy}
+                  onValueChange={setSortBy}
+                  options={FAV_SORT_OPTIONS}
+                />
+              )
+            }
             onMonthOffsetsChange={setMonthMarkers}
             scrollContainerRef={scrollableRef}
           />

--- a/frontend/src/pages/__tests__/MyFav.test.tsx
+++ b/frontend/src/pages/__tests__/MyFav.test.tsx
@@ -89,7 +89,7 @@ describe('MyFav (Favorites) page', () => {
   });
 
   test('renders favourited images and videos mixed together, excluding non-favourites', async () => {
-    (fetchAllImages as jest.Mock).mockResolvedValue({
+    jest.mocked(fetchAllImages).mockResolvedValue({
       success: true,
       data: [
         makeImage(),
@@ -104,7 +104,7 @@ describe('MyFav (Favorites) page', () => {
         }),
       ],
     });
-    (fetchAllVideos as jest.Mock).mockResolvedValue({
+    jest.mocked(fetchAllVideos).mockResolvedValue({
       success: true,
       data: [
         makeVideo(),
@@ -133,11 +133,11 @@ describe('MyFav (Favorites) page', () => {
   });
 
   test('Date sort (default) groups items by month, newest capture date first', async () => {
-    (fetchAllImages as jest.Mock).mockResolvedValue({
+    jest.mocked(fetchAllImages).mockResolvedValue({
       success: true,
       data: [makeImage()],
     });
-    (fetchAllVideos as jest.Mock).mockResolvedValue({
+    jest.mocked(fetchAllVideos).mockResolvedValue({
       success: true,
       data: [makeVideo()],
     });
@@ -156,11 +156,11 @@ describe('MyFav (Favorites) page', () => {
   });
 
   test('Custom sort orders by favourited time (most recent first) with no month grouping', async () => {
-    (fetchAllImages as jest.Mock).mockResolvedValue({
+    jest.mocked(fetchAllImages).mockResolvedValue({
       success: true,
       data: [makeImage()],
     });
-    (fetchAllVideos as jest.Mock).mockResolvedValue({
+    jest.mocked(fetchAllVideos).mockResolvedValue({
       success: true,
       data: [makeVideo()],
     });
@@ -184,11 +184,11 @@ describe('MyFav (Favorites) page', () => {
   });
 
   test('persists the selected sort option across a remount', async () => {
-    (fetchAllImages as jest.Mock).mockResolvedValue({
+    jest.mocked(fetchAllImages).mockResolvedValue({
       success: true,
       data: [makeImage()],
     });
-    (fetchAllVideos as jest.Mock).mockResolvedValue({
+    jest.mocked(fetchAllVideos).mockResolvedValue({
       success: true,
       data: [makeVideo()],
     });
@@ -206,11 +206,11 @@ describe('MyFav (Favorites) page', () => {
   });
 
   test('excludes previously-loaded favourited videos while a face search is active', async () => {
-    (fetchAllImages as jest.Mock).mockResolvedValue({
+    jest.mocked(fetchAllImages).mockResolvedValue({
       success: true,
       data: [],
     });
-    (fetchAllVideos as jest.Mock).mockResolvedValue({
+    jest.mocked(fetchAllVideos).mockResolvedValue({
       success: true,
       data: [],
     });

--- a/frontend/src/pages/__tests__/MyFav.test.tsx
+++ b/frontend/src/pages/__tests__/MyFav.test.tsx
@@ -1,0 +1,235 @@
+import { render, screen } from '@/test-utils';
+import userEvent from '@testing-library/user-event';
+import { MyFav } from '../Home/MyFav';
+import { fetchAllImages, fetchAllVideos } from '@/api/api-functions';
+import { Image, Video } from '@/types/Media';
+
+jest.mock('@/api/api-functions', () => ({
+  fetchAllImages: jest.fn(),
+  fetchAllVideos: jest.fn(),
+}));
+
+jest.mock('@tauri-apps/api/core', () => ({
+  convertFileSrc: (path: string) => path,
+}));
+
+jest.mock('@/hooks/useToggleFav', () => ({
+  useToggleFav: () => ({
+    toggleFavourite: jest.fn(),
+    toggleFavouritePending: false,
+  }),
+}));
+
+jest.mock('@/hooks/useToggleVideoFav', () => ({
+  useToggleVideoFav: () => ({
+    toggleFavourite: jest.fn(),
+    toggleFavouritePending: false,
+  }),
+}));
+
+const imageMetadata = {
+  width: 100,
+  height: 100,
+  file_location: '/photos/summer-photo.jpg',
+  file_size: 1,
+  item_type: 'image/jpeg',
+};
+
+const videoMetadata = {
+  width: 100,
+  height: 100,
+  file_location: '/videos/winter-clip.mp4',
+  file_size: 1,
+  item_type: 'video/mp4',
+};
+
+// The image's capture date is newer than the video's, but the video was
+// favourited more recently than the image -- Date and Custom sort disagree
+// on purpose, so tests can tell them apart.
+const makeImage = (overrides: Partial<Image> = {}): Image => ({
+  id: 'img-1',
+  path: '/photos/summer-photo.jpg',
+  thumbnailPath: '/photos/summer-photo-thumb.jpg',
+  folder_id: 'folder-1',
+  isTagged: false,
+  isFavourite: true,
+  favouritedAt: '2024-01-01 10:00:00',
+  metadata: {
+    ...imageMetadata,
+    name: 'summer-photo.jpg',
+    date_created: '2024-06-01T00:00:00',
+  },
+  ...overrides,
+});
+
+const makeVideo = (overrides: Partial<Video> = {}): Video => ({
+  id: 'vid-1',
+  path: '/videos/winter-clip.mp4',
+  thumbnailPath: '/videos/winter-clip-thumb.jpg',
+  folder_id: 'folder-1',
+  isFavourite: true,
+  favouritedAt: '2024-06-01 10:00:00',
+  metadata: {
+    ...videoMetadata,
+    name: 'winter-clip.mp4',
+    date_created: '2020-01-01T00:00:00',
+  },
+  ...overrides,
+});
+
+const openCustomSort = async (user: ReturnType<typeof userEvent.setup>) => {
+  await user.click(screen.getByRole('button', { name: /Sort by/i }));
+  await user.click(screen.getByRole('menuitem', { name: 'Custom' }));
+};
+
+describe('MyFav (Favorites) page', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+  });
+
+  test('renders favourited images and videos mixed together, excluding non-favourites', async () => {
+    (fetchAllImages as jest.Mock).mockResolvedValue({
+      success: true,
+      data: [
+        makeImage(),
+        makeImage({
+          id: 'img-2',
+          isFavourite: false,
+          metadata: {
+            ...imageMetadata,
+            name: 'not-a-favourite.jpg',
+            date_created: null,
+          },
+        }),
+      ],
+    });
+    (fetchAllVideos as jest.Mock).mockResolvedValue({
+      success: true,
+      data: [
+        makeVideo(),
+        makeVideo({
+          id: 'vid-2',
+          isFavourite: false,
+          metadata: {
+            ...videoMetadata,
+            name: 'not-a-favourite.mp4',
+            date_created: null,
+          },
+        }),
+      ],
+    });
+
+    render(<MyFav />);
+
+    expect(await screen.findByAltText('summer-photo.jpg')).toBeInTheDocument();
+    expect(screen.getByLabelText('Play winter-clip.mp4')).toBeInTheDocument();
+    expect(
+      screen.queryByAltText('not-a-favourite.jpg'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText('Play not-a-favourite.mp4'),
+    ).not.toBeInTheDocument();
+  });
+
+  test('Date sort (default) groups items by month, newest capture date first', async () => {
+    (fetchAllImages as jest.Mock).mockResolvedValue({
+      success: true,
+      data: [makeImage()],
+    });
+    (fetchAllVideos as jest.Mock).mockResolvedValue({
+      success: true,
+      data: [makeVideo()],
+    });
+
+    render(<MyFav />);
+    await screen.findByAltText('summer-photo.jpg');
+
+    const headers = screen
+      .getAllByRole('heading', { level: 3 })
+      .map((h) => h.textContent ?? '');
+    const juneIndex = headers.findIndex((h) => h.includes('June 2024'));
+    const januaryIndex = headers.findIndex((h) => h.includes('January 2020'));
+    expect(juneIndex).toBeGreaterThanOrEqual(0);
+    expect(januaryIndex).toBeGreaterThanOrEqual(0);
+    expect(juneIndex).toBeLessThan(januaryIndex);
+  });
+
+  test('Custom sort orders by favourited time (most recent first) with no month grouping', async () => {
+    (fetchAllImages as jest.Mock).mockResolvedValue({
+      success: true,
+      data: [makeImage()],
+    });
+    (fetchAllVideos as jest.Mock).mockResolvedValue({
+      success: true,
+      data: [makeVideo()],
+    });
+
+    const user = userEvent.setup();
+    render(<MyFav />);
+    await screen.findByAltText('summer-photo.jpg');
+
+    await openCustomSort(user);
+
+    // The video was favourited later than the image, even though the image
+    // has the newer *capture* date -- Custom sort must follow favourited
+    // time, not capture date.
+    const videoEl = screen.getByLabelText('Play winter-clip.mp4');
+    const imageEl = screen.getByAltText('summer-photo.jpg');
+    expect(
+      videoEl.compareDocumentPosition(imageEl) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(screen.queryByText(/June 2024/)).not.toBeInTheDocument();
+  });
+
+  test('persists the selected sort option across a remount', async () => {
+    (fetchAllImages as jest.Mock).mockResolvedValue({
+      success: true,
+      data: [makeImage()],
+    });
+    (fetchAllVideos as jest.Mock).mockResolvedValue({
+      success: true,
+      data: [makeVideo()],
+    });
+
+    const user = userEvent.setup();
+    const { unmount } = render(<MyFav />);
+    await screen.findByAltText('summer-photo.jpg');
+    await openCustomSort(user);
+    unmount();
+
+    // A remount stands in for the reload that used to reset the sort.
+    render(<MyFav />);
+    await screen.findByAltText('summer-photo.jpg');
+    expect(screen.queryByText(/June 2024/)).not.toBeInTheDocument();
+  });
+
+  test('excludes previously-loaded favourited videos while a face search is active', async () => {
+    (fetchAllImages as jest.Mock).mockResolvedValue({
+      success: true,
+      data: [],
+    });
+    (fetchAllVideos as jest.Mock).mockResolvedValue({
+      success: true,
+      data: [],
+    });
+
+    render(<MyFav />, {
+      preloadedState: {
+        search: { active: true, queryImage: 'query.jpg' },
+        images: {
+          images: [makeImage({ id: 'search-hit' })],
+          currentViewIndex: -1,
+        },
+        videos: { videos: [makeVideo()], currentViewIndex: -1 },
+      },
+    });
+
+    expect(await screen.findByAltText('summer-photo.jpg')).toBeInTheDocument();
+    expect(screen.getByText(/Face Search Results/)).toBeInTheDocument();
+    expect(
+      screen.queryByLabelText('Play winter-clip.mp4'),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/__tests__/allPages.test.tsx
+++ b/frontend/src/pages/__tests__/allPages.test.tsx
@@ -2,6 +2,7 @@ import { render, act } from '@testing-library/react';
 import { AITagging } from '@/pages/AITagging/AITagging';
 import Album from '../Album/Album';
 import { Home } from '@/pages/Home/Home';
+import { MyFav } from '@/pages/Home/MyFav';
 import Memories from '../Memories/Memories';
 import Settings from '../SettingsPage/Settings';
 import { Videos } from '../VideosPage/Videos';
@@ -15,6 +16,7 @@ import { store } from '@/app/store';
 const pages = [
   { path: ROUTES.HOME, Component: Home },
   { path: ROUTES.VIDEOS, Component: Videos },
+  { path: ROUTES.FAVOURITES, Component: MyFav },
   { path: ROUTES.SETTINGS, Component: Settings },
   { path: ROUTES.AI, Component: AITagging },
   { path: ROUTES.ALBUMS, Component: Album },

--- a/frontend/src/types/Media.ts
+++ b/frontend/src/types/Media.ts
@@ -18,6 +18,7 @@ export interface Image {
   isTagged: boolean;
   metadata?: ImageMetadata;
   isFavourite?: boolean;
+  favouritedAt?: string | null;
   tags?: string[];
   bboxes?: { x: number; y: number; width: number; height: number }[];
 }
@@ -45,6 +46,7 @@ export interface Video {
   folder_id: string;
   metadata?: VideoMetadata;
   isFavourite?: boolean;
+  favouritedAt?: string | null;
   tags?: string[];
 }
 


### PR DESCRIPTION
## Summary
- Rename the Favorites tab title from "Favourite Image Gallery" to "Favorites"
- Merge favorited images and videos into a single interleaved gallery (previously images-only, videos never appeared even though they could be favorited)
- Move the image favorite heart button to the top-right, matching where it already sits on video cards
- Add a sort dropdown (reusing the existing `GallerySortDropdown`) with two options:
  - **Date** (default) — unchanged chronological, month-grouped view
  - **Custom** — order favorited, most-recently-favorited first
- Add a `favouritedAt` timestamp to the `images`/`videos` tables (guarded migration, safe for existing databases) to power the Custom sort

## Screenshots

<img width="1919" height="1031" alt="image" src="https://github.com/user-attachments/assets/52539894-cd6a-4d96-b80e-88d776ec7350" />
<img width="1919" height="1031" alt="image" src="https://github.com/user-attachments/assets/f629f0bb-8b85-4561-9cfb-f759d345b5d4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Favorites now include images and videos in a unified gallery.
  * Browse favorites chronologically by year and month, or use a custom order.
  * Favorite timestamps are recorded and retained when media is unfavorited.
  * Sorting preferences and improved empty-state messaging are supported.
  * Image favorite controls now appear consistently in the top-right on hover or focus.
* **Bug Fixes**
  * Favorite metadata remains available after media updates and rescans.
  * Open media views now close when the displayed item is removed from favorites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->