### PR TITLE
Deletion Implementation in Image Viewer

### DIFF
--- a/backend/app/database/images.py
+++ b/backend/app/database/images.py
@@ -1,7 +1,7 @@
 # Standard library imports
 import os
 import sqlite3
-from typing import Any, Dict, List, Mapping, Tuple, TypedDict, Union, Optional
+from typing import Any, Dict, List, Mapping, Set, Tuple, TypedDict, Union, Optional
 import json
 
 from datetime import datetime
@@ -71,6 +71,15 @@ def _connect() -> sqlite3.Connection:
     return conn
 
 
+def _normalise_path(path: ImagePath) -> ImagePath:
+    """Key a path the way the folder scan compares them.
+
+    The scan matches stored paths against paths it just walked off disk, and
+    Windows hands back inconsistent casing.
+    """
+    return os.path.normcase(os.path.abspath(path))
+
+
 def db_create_images_table() -> None:
     conn = _connect()
     cursor = conn.cursor()
@@ -127,6 +136,20 @@ def db_create_images_table() -> None:
     cursor.execute("PRAGMA table_info(image_classes)")
     if "score" not in {row[1] for row in cursor.fetchall()}:
         cursor.execute("ALTER TABLE image_classes ADD COLUMN score REAL")
+
+    # Paths the user removed from the gallery but kept on disk. The folder scan
+    # skips these, otherwise the watcher's next sync-folder would re-import the
+    # file and the photo would reappear. Cascading off folders means removing and
+    # re-adding a folder clears its exclusions, which is the only way back.
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS excluded_image_paths (
+            path TEXT PRIMARY KEY,
+            folder_id TEXT,
+            FOREIGN KEY (folder_id) REFERENCES folders(folder_id) ON DELETE CASCADE
+        )
+    """
+    )
 
     conn.commit()
     conn.close()
@@ -527,7 +550,7 @@ def db_get_image_sync_state_by_folder_ids(
                     # An unreadable blob just means this row gets re-read.
                     pass
 
-            state[os.path.normcase(os.path.abspath(path))] = ImageSyncState(
+            state[_normalise_path(path)] = ImageSyncState(
                 thumbnailPath=thumbnail_path,
                 file_size=_as_int(parsed.get("file_size")),
                 file_mtime=_as_int(parsed.get("file_mtime")),
@@ -572,6 +595,59 @@ def db_delete_images_by_ids(image_ids: List[ImageId]) -> bool:
         logger.error(f"Error deleting images: {e}")
         conn.rollback()
         return False
+    finally:
+        conn.close()
+
+
+def db_exclude_image_paths(entries: List[Tuple[ImagePath, Optional[FolderId]]]) -> bool:
+    """
+    Record image paths the user removed from the gallery but kept on disk.
+
+    Args:
+        entries: (path, folder_id) pairs. folder_id ties the row to its folder so
+            removing the folder clears the exclusion.
+
+    Returns:
+        True if the paths were recorded, False otherwise
+    """
+    if not entries:
+        return True
+
+    conn = _connect()
+    cursor = conn.cursor()
+
+    try:
+        cursor.executemany(
+            """
+            INSERT OR IGNORE INTO excluded_image_paths (path, folder_id)
+            VALUES (?, ?)
+            """,
+            [(_normalise_path(path), folder_id) for path, folder_id in entries],
+        )
+        conn.commit()
+        logger.info(f"Excluded {len(entries)} image path(s) from future scans")
+        return True
+    except sqlite3.Error as e:
+        logger.error(f"Error excluding image paths: {e}")
+        conn.rollback()
+        return False
+    finally:
+        conn.close()
+
+
+def db_get_excluded_image_paths() -> Set[ImagePath]:
+    """Paths the folder scan must not re-import, keyed like the scan compares them."""
+    conn = _connect()
+    cursor = conn.cursor()
+
+    try:
+        cursor.execute("SELECT path FROM excluded_image_paths")
+        return {row[0] for row in cursor.fetchall() if row[0]}
+    except sqlite3.Error as e:
+        # An unreadable exclusion list must not stop the scan; worst case a
+        # removed photo reappears, which is better than importing nothing.
+        logger.error(f"Error getting excluded image paths: {e}")
+        return set()
     finally:
         conn.close()
 

--- a/backend/app/routes/images.py
+++ b/backend/app/routes/images.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, HTTPException, Query, status
 from typing import List, Optional
 from app.database.images import db_get_all_images
 from app.schemas.images import ErrorResponse
-from app.utils.images import image_util_parse_metadata
+from app.utils.images import image_util_parse_metadata, image_util_delete_images
 from pydantic import BaseModel
 from app.database.images import (
     db_toggle_image_favourite_status,
@@ -352,6 +352,70 @@ def toggle_favourite(req: ToggleFavouriteRequest):
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Internal server error: {e}",
+        )
+
+
+class DeleteImagesRequest(BaseModel):
+    image_ids: List[str]
+    # True also deletes each file from its folder on disk. False keeps the files
+    # and only removes them from the gallery.
+    delete_from_device: bool = False
+
+
+class DeleteImagesData(BaseModel):
+    deleted_ids: List[str]
+    failed_paths: List[str]
+
+
+class DeleteImagesResponse(BaseModel):
+    success: bool
+    message: str
+    data: DeleteImagesData
+
+
+@router.delete(
+    "/delete-images",
+    response_model=DeleteImagesResponse,
+    responses={code: {"model": ErrorResponse} for code in [400, 500]},
+)
+def delete_images(request: DeleteImagesRequest):
+    """Delete images from the gallery, optionally from the device as well."""
+    try:
+        if not request.image_ids:
+            raise ValueError("No image IDs provided")
+
+        result = image_util_delete_images(
+            request.image_ids,
+            request.delete_from_device,
+        )
+
+        return DeleteImagesResponse(
+            success=True,
+            message=f"Successfully deleted {len(result['deleted_ids'])} image(s)",
+            data=DeleteImagesData(
+                deleted_ids=result["deleted_ids"],
+                failed_paths=result["failed_paths"],
+            ),
+        )
+
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=ErrorResponse(
+                success=False,
+                error="Validation Error",
+                message=str(e),
+            ).model_dump(),
+        )
+    except Exception as e:
+        logger.error(f"Error deleting images: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=ErrorResponse(
+                success=False,
+                error="Internal server error",
+                message=f"Unable to delete images: {e!s}",
+            ).model_dump(),
         )
 
 

--- a/backend/app/utils/images.py
+++ b/backend/app/utils/images.py
@@ -5,7 +5,7 @@ import uuid
 import datetime
 import json
 import logging
-from typing import List, Optional, Tuple, Dict, Any, Mapping
+from typing import Iterable, List, Optional, Tuple, Dict, Any, Mapping
 from PIL import Image, ExifTags
 from pathlib import Path
 
@@ -18,7 +18,10 @@ from app.database.images import (
     db_insert_image_classes_batch,
     db_get_image_sync_state_by_folder_ids,
     db_get_images_by_folder_ids,
+    db_get_images_by_ids,
     db_delete_images_by_ids,
+    db_exclude_image_paths,
+    db_get_excluded_image_paths,
 )
 from app.models.FaceDetector import FaceDetector
 from app.models.ObjectClassifier import ObjectClassifier
@@ -64,6 +67,10 @@ def image_util_process_folder_images(folder_data: List[Tuple[str, int, bool]]) -
             [folder_id for _, folder_id, _ in folder_data]
         )
 
+        # Photos the user removed from the gallery but kept on disk. Without this
+        # the next sync-folder would import them straight back.
+        excluded_paths = db_get_excluded_image_paths()
+
         # Process each folder in the provided data
         for folder_path, folder_id, recursive in folder_data:
             try:
@@ -72,6 +79,11 @@ def image_util_process_folder_images(folder_data: List[Tuple[str, int, bool]]) -
 
                 # Step 1: Get all image files from current folder
                 image_files = image_util_get_images_from_folder(folder_path, recursive)
+                image_files = [
+                    path
+                    for path in image_files
+                    if os.path.normcase(os.path.abspath(path)) not in excluded_paths
+                ]
 
                 if not image_files:
                     continue  # No images in this folder, continue to next
@@ -433,6 +445,29 @@ def image_util_generate_thumbnail(
         return False
 
 
+def image_util_remove_files(file_paths: Iterable[Optional[str]]) -> List[str]:
+    """Delete files, tolerating ones that are already gone.
+
+    Returns the paths that could not be deleted, so callers can report them
+    instead of pretending the file is gone.
+    """
+    failed: List[str] = []
+
+    for file_path in file_paths:
+        if not file_path:
+            continue
+        try:
+            os.remove(file_path)
+            logger.info(f"Removed file: {file_path}")
+        except FileNotFoundError:
+            pass  # Already gone is the outcome we wanted.
+        except OSError as e:
+            logger.error(f"Error removing file {file_path}: {e}")
+            failed.append(file_path)
+
+    return failed
+
+
 def image_util_remove_obsolete_images(folder_id_list: List[int]) -> int:
     """
     Remove obsolete images that no longer exist in the filesystem.
@@ -446,22 +481,67 @@ def image_util_remove_obsolete_images(folder_id_list: List[int]) -> int:
     existing_db_images = db_get_images_by_folder_ids(folder_id_list)
 
     obsolete_images = []
+    obsolete_thumbnails = []
     for image_id, image_path, thumbnail_path in existing_db_images:
         if not os.path.exists(image_path):
             obsolete_images.append(image_id)
-            # Also remove thumbnail if it exists
-            if thumbnail_path and os.path.exists(thumbnail_path):
-                try:
-                    os.remove(thumbnail_path)
-                    logger.info(f"Removed obsolete thumbnail: {thumbnail_path}")
-                except OSError as e:
-                    logger.error(f"Error removing thumbnail {thumbnail_path}: {e}")
+            obsolete_thumbnails.append(thumbnail_path)
 
     if obsolete_images:
+        image_util_remove_files(obsolete_thumbnails)
         db_delete_images_by_ids(obsolete_images)
         logger.info(f"Removed {len(obsolete_images)} obsolete image(s) from database")
 
     return len(obsolete_images)
+
+
+def image_util_delete_images(
+    image_ids: List[str], delete_from_device: bool = False
+) -> Dict[str, List[str]]:
+    """Delete images from the gallery, optionally deleting the files as well.
+
+    Args:
+        image_ids: Images to delete.
+        delete_from_device: True also deletes each file from its folder on disk.
+            False leaves the files alone and records their paths so a later
+            folder scan does not re-import them.
+
+    Returns:
+        {"deleted_ids": ids removed, "failed_paths": files that could not be deleted}
+    """
+    images = db_get_images_by_ids(image_ids)
+    if not images:
+        return {"deleted_ids": [], "failed_paths": []}
+
+    failed_paths: List[str] = []
+    deletable: List[dict] = []
+
+    if delete_from_device:
+        # Delete the file first: a row is only dropped once its file is actually
+        # gone, so a permission error never leaves the gallery claiming a photo
+        # was deleted while the file is still sitting in the folder.
+        for image in images:
+            failed = image_util_remove_files([image["path"]])
+            if failed:
+                failed_paths.extend(failed)
+            else:
+                deletable.append(image)
+    else:
+        deletable = list(images)
+        # db_get_images_by_ids hands folder_id back as "" when the image has none,
+        # and the foreign key needs a real folder id or NULL.
+        db_exclude_image_paths(
+            [(image["path"], image.get("folder_id") or None) for image in deletable]
+        )
+
+    # Thumbnails are PictoPy's own cache, so they go in both modes.
+    image_util_remove_files([image.get("thumbnailPath") for image in deletable])
+
+    deleted_ids = [image["id"] for image in deletable]
+    if deleted_ids:
+        db_delete_images_by_ids(deleted_ids)
+
+    return {"deleted_ids": deleted_ids, "failed_paths": failed_paths}
 
 
 def image_util_create_folder_path_mapping(

--- a/backend/tests/test_images_delete.py
+++ b/backend/tests/test_images_delete.py
@@ -1,0 +1,211 @@
+"""
+Deleting a photo from inside PictoPy. Two outcomes the user picks between:
+remove it from the gallery only, or delete the file from its folder as well.
+The gallery-only case has to survive the watcher's next sync-folder, which is
+what the exclusion table is for.
+"""
+
+import os
+import sqlite3
+import tempfile
+from typing import Iterator, List
+
+import pytest
+from PIL import Image
+
+from app.database.folders import db_create_folders_table
+from app.database.images import (
+    db_create_images_table,
+    db_get_excluded_image_paths,
+)
+from app.database.yolo_mapping import db_create_YOLO_classes_table
+from app.utils.images import (
+    image_util_delete_images,
+    image_util_process_folder_images,
+    image_util_remove_files,
+)
+
+FOLDER_ID = "folder-1"
+
+
+@pytest.fixture(scope="function")
+def test_db(monkeypatch: pytest.MonkeyPatch) -> Iterator[str]:
+    """Point the image/folder DB modules at a fresh tempfile database."""
+    db_fd, db_path = tempfile.mkstemp()
+    os.close(db_fd)
+
+    monkeypatch.setattr("app.config.settings.DATABASE_PATH", db_path)
+    monkeypatch.setattr("app.database.images.DATABASE_PATH", db_path)
+    monkeypatch.setattr("app.database.folders.DATABASE_PATH", db_path)
+    monkeypatch.setattr("app.database.yolo_mapping.DATABASE_PATH", db_path)
+
+    db_create_YOLO_classes_table()  # mappings (image_classes FK target)
+    db_create_folders_table()  # folders (images.folder_id FK target)
+    db_create_images_table()
+
+    yield db_path
+
+    os.unlink(db_path)
+
+
+@pytest.fixture
+def library(tmp_path, test_db, monkeypatch) -> Iterator[str]:
+    """A folder of real JPEGs, scanned into the database like the app would."""
+    photos = tmp_path / "photos"
+    photos.mkdir()
+    thumbs = tmp_path / "thumbs"
+    thumbs.mkdir()
+    monkeypatch.setattr("app.utils.images.THUMBNAIL_IMAGES_PATH", str(thumbs))
+
+    for index in range(3):
+        Image.new("RGB", (8, 8), (index * 20, 40, 90)).save(
+            photos / f"p{index}.jpg", "JPEG"
+        )
+
+    conn = sqlite3.connect(test_db)
+    conn.execute(
+        "INSERT INTO folders (folder_id, folder_path, last_modified_time, "
+        "AI_Tagging) VALUES (?, ?, 0, 1)",
+        (FOLDER_ID, str(photos)),
+    )
+    conn.commit()
+    conn.close()
+
+    image_util_process_folder_images([(str(photos), FOLDER_ID, False)])
+    yield str(photos)
+
+
+def _rows(db_path: str) -> List[tuple]:
+    conn = sqlite3.connect(db_path)
+    rows = conn.execute("SELECT id, path, thumbnailPath FROM images").fetchall()
+    conn.close()
+    return rows
+
+
+def _first(db_path: str) -> tuple:
+    """(id, path, thumbnailPath) of one image already in the gallery."""
+    return _rows(db_path)[0]
+
+
+class TestRemoveFiles:
+    def test_a_file_is_deleted(self, tmp_path):
+        target = tmp_path / "a.jpg"
+        target.write_bytes(b"x")
+        assert image_util_remove_files([str(target)]) == []
+        assert not target.exists()
+
+    def test_a_file_already_gone_is_not_a_failure(self, tmp_path):
+        """Thumbnails go missing on their own; the outcome we wanted is the same."""
+        assert image_util_remove_files([str(tmp_path / "gone.jpg")]) == []
+
+    def test_empty_and_none_paths_are_skipped(self):
+        assert image_util_remove_files([None, ""]) == []
+
+    def test_a_directory_is_reported_rather_than_raising(self, tmp_path):
+        """os.remove on a directory raises OSError, which callers must survive."""
+        assert image_util_remove_files([str(tmp_path)]) == [str(tmp_path)]
+
+
+class TestGalleryOnlyDelete:
+    def test_the_row_goes_but_the_file_stays(self, library, test_db):
+        image_id, path, _ = _first(test_db)
+
+        result = image_util_delete_images([image_id])
+
+        assert result["deleted_ids"] == [image_id]
+        assert result["failed_paths"] == []
+        assert os.path.exists(path)
+        assert image_id not in [row[0] for row in _rows(test_db)]
+
+    def test_the_thumbnail_goes_because_it_is_our_own_cache(self, library, test_db):
+        image_id, _, thumbnail_path = _first(test_db)
+        assert os.path.exists(thumbnail_path)
+
+        image_util_delete_images([image_id])
+
+        assert not os.path.exists(thumbnail_path)
+
+    def test_the_path_is_recorded_as_excluded(self, library, test_db):
+        image_id, path, _ = _first(test_db)
+
+        image_util_delete_images([image_id])
+
+        expected = os.path.normcase(os.path.abspath(path))
+        assert expected in db_get_excluded_image_paths()
+
+    def test_a_rescan_does_not_bring_it_back(self, library, test_db):
+        """The regression the exclusion table exists to prevent."""
+        image_id, path, _ = _first(test_db)
+        image_util_delete_images([image_id])
+
+        image_util_process_folder_images([(library, FOLDER_ID, False)])
+
+        assert path not in [row[1] for row in _rows(test_db)]
+
+    def test_the_other_photos_are_left_alone(self, library, test_db):
+        image_id, _, _ = _first(test_db)
+
+        image_util_delete_images([image_id])
+
+        assert len(_rows(test_db)) == 2
+
+    def test_removing_the_folder_clears_its_exclusions(self, library, test_db):
+        """Re-adding the folder is the only way back, so the cascade has to work."""
+        image_id, _, _ = _first(test_db)
+        image_util_delete_images([image_id])
+
+        conn = sqlite3.connect(test_db)
+        conn.execute("PRAGMA foreign_keys = ON")
+        conn.execute("DELETE FROM folders WHERE folder_id = ?", (FOLDER_ID,))
+        conn.commit()
+        conn.close()
+
+        assert db_get_excluded_image_paths() == set()
+
+
+class TestDeleteFromDevice:
+    def test_the_file_and_the_row_both_go(self, library, test_db):
+        image_id, path, _ = _first(test_db)
+
+        result = image_util_delete_images([image_id], delete_from_device=True)
+
+        assert result["deleted_ids"] == [image_id]
+        assert not os.path.exists(path)
+        assert image_id not in [row[0] for row in _rows(test_db)]
+
+    def test_no_exclusion_is_recorded(self, library, test_db):
+        """The file is gone, so there is nothing for a later scan to skip."""
+        image_id, _, _ = _first(test_db)
+
+        image_util_delete_images([image_id], delete_from_device=True)
+
+        assert db_get_excluded_image_paths() == set()
+
+    def test_a_file_that_cannot_be_deleted_keeps_its_row(self, library, test_db):
+        """Never claim a photo is gone while the file is still in the folder."""
+        image_id, path, _ = _first(test_db)
+
+        def refuse(file_paths):
+            return [p for p in file_paths if p == path]
+
+        with pytest.MonkeyPatch.context() as patch:
+            patch.setattr("app.utils.images.image_util_remove_files", refuse)
+            result = image_util_delete_images([image_id], delete_from_device=True)
+
+        assert result["deleted_ids"] == []
+        assert result["failed_paths"] == [path]
+        assert image_id in [row[0] for row in _rows(test_db)]
+
+
+class TestUnknownIds:
+    def test_an_unknown_id_deletes_nothing(self, library, test_db):
+        result = image_util_delete_images(["not-a-real-id"])
+
+        assert result == {"deleted_ids": [], "failed_paths": []}
+        assert len(_rows(test_db)) == 3
+
+    def test_an_empty_list_deletes_nothing(self, library, test_db):
+        result = image_util_delete_images([])
+
+        assert result == {"deleted_ids": [], "failed_paths": []}
+        assert len(_rows(test_db)) == 3

--- a/backend/tests/test_images_delete.py
+++ b/backend/tests/test_images_delete.py
@@ -18,6 +18,7 @@ from app.database.images import (
     db_create_images_table,
     db_get_excluded_image_paths,
 )
+from app.database.semantic_labels import db_create_semantic_labels_table
 from app.database.yolo_mapping import db_create_YOLO_classes_table
 from app.utils.images import (
     image_util_delete_images,
@@ -42,6 +43,7 @@ def test_db(monkeypatch: pytest.MonkeyPatch) -> Iterator[str]:
     db_create_YOLO_classes_table()  # mappings (image_classes FK target)
     db_create_folders_table()  # folders (images.folder_id FK target)
     db_create_images_table()
+    db_create_semantic_labels_table()  # image_classes_display view
 
     yield db_path
 

--- a/frontend/src/api/api-functions/images.ts
+++ b/frontend/src/api/api-functions/images.ts
@@ -46,3 +46,26 @@ export const semanticSearchImages = async (
   );
   return response.data;
 };
+
+export interface DeleteImagesRequest {
+  image_ids: string[];
+  /** True also deletes each file from its folder on disk. */
+  delete_from_device: boolean;
+}
+
+export interface DeleteImagesAPIResponse extends APIResponse {
+  data?: {
+    deleted_ids: string[];
+    failed_paths: string[];
+  };
+}
+
+export const deleteImages = async (
+  request: DeleteImagesRequest,
+): Promise<DeleteImagesAPIResponse> => {
+  const response = await apiClient.delete<DeleteImagesAPIResponse>(
+    imagesEndpoints.deleteImages,
+    { data: request },
+  );
+  return response.data;
+};

--- a/frontend/src/api/apiEndpoints.ts
+++ b/frontend/src/api/apiEndpoints.ts
@@ -1,6 +1,7 @@
 export const imagesEndpoints = {
   getAllImages: '/images/',
   setFavourite: '/images/toggle-favourite',
+  deleteImages: '/images/delete-images',
   searchByTag: (tag: string) => `/images/search?tag=${encodeURIComponent(tag)}`,
   semanticSearch: (query: string) =>
     `/images/semantic-search?query=${encodeURIComponent(query)}`,

--- a/frontend/src/components/ConfirmDialog/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog/ConfirmDialog.tsx
@@ -9,6 +9,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
 
 export interface ConfirmDialogProps {
   open: boolean;
@@ -19,6 +20,12 @@ export interface ConfirmDialogProps {
   cancelLabel?: string;
   onConfirm: () => void | Promise<void>;
   destructive?: boolean;
+  /** Offers the caller an extra choice alongside the confirmation. */
+  checkboxLabel?: string;
+  checkboxChecked?: boolean;
+  onCheckboxChange?: (checked: boolean) => void;
+  /** Spells out what the current checkbox state will actually do. */
+  checkboxHint?: string;
 }
 
 export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
@@ -30,6 +37,10 @@ export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
   cancelLabel = 'Cancel',
   onConfirm,
   destructive = true,
+  checkboxLabel,
+  checkboxChecked = false,
+  onCheckboxChange,
+  checkboxHint,
 }) => {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -47,6 +58,28 @@ export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
           </DialogTitle>
           <DialogDescription>{description}</DialogDescription>
         </DialogHeader>
+        {checkboxLabel && (
+          <div className="flex items-start gap-3">
+            <input
+              id="confirm-dialog-checkbox"
+              type="checkbox"
+              checked={checkboxChecked}
+              onChange={(e) => onCheckboxChange?.(e.target.checked)}
+              className="accent-primary mt-0.5 h-4 w-4 cursor-pointer"
+            />
+            <div className="space-y-1">
+              <Label
+                htmlFor="confirm-dialog-checkbox"
+                className="cursor-pointer"
+              >
+                {checkboxLabel}
+              </Label>
+              {checkboxHint && (
+                <p className="text-muted-foreground text-sm">{checkboxHint}</p>
+              )}
+            </div>
+          </div>
+        )}
         <DialogFooter>
           <Button variant="outline" onClick={() => onOpenChange(false)}>
             {cancelLabel}

--- a/frontend/src/components/ConfirmDialog/__tests__/ConfirmDialog.test.tsx
+++ b/frontend/src/components/ConfirmDialog/__tests__/ConfirmDialog.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ConfirmDialog } from '../ConfirmDialog';
+
+const renderDialog = (
+  props: Partial<React.ComponentProps<typeof ConfirmDialog>>,
+) =>
+  render(
+    <ConfirmDialog
+      open
+      onOpenChange={jest.fn()}
+      title="Delete photo"
+      description="Pick what happens to the file."
+      confirmLabel="Delete"
+      onConfirm={jest.fn()}
+      {...props}
+    />,
+  );
+
+describe('ConfirmDialog checkbox', () => {
+  test('is absent unless a label is given, so existing callers are unaffected', () => {
+    renderDialog({});
+
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+  });
+
+  test('renders unchecked by default with its label and hint', () => {
+    renderDialog({
+      checkboxLabel: 'Also delete the file',
+      checkboxHint: 'The file stays in its folder.',
+    });
+
+    expect(screen.getByRole('checkbox')).not.toBeChecked();
+    expect(screen.getByText('Also delete the file')).toBeInTheDocument();
+    expect(
+      screen.getByText('The file stays in its folder.'),
+    ).toBeInTheDocument();
+  });
+
+  test('reports a toggle to the caller', () => {
+    const onCheckboxChange = jest.fn();
+    renderDialog({ checkboxLabel: 'Also delete the file', onCheckboxChange });
+
+    fireEvent.click(screen.getByRole('checkbox'));
+
+    expect(onCheckboxChange).toHaveBeenCalledWith(true);
+  });
+
+  test('shows the checked state the caller passes in', () => {
+    renderDialog({
+      checkboxLabel: 'Also delete the file',
+      checkboxChecked: true,
+    });
+
+    expect(screen.getByRole('checkbox')).toBeChecked();
+  });
+});

--- a/frontend/src/components/Media/MediaView.tsx
+++ b/frontend/src/components/Media/MediaView.tsx
@@ -12,6 +12,7 @@ import { MediaThumbnails } from './MediaThumbnails';
 import { MediaInfoPanel } from './MediaInfoPanel';
 import { ImageViewer } from './ImageViewer';
 import { NavigationButtons } from './NavigationButtons';
+import { ConfirmDialog } from '@/components/ConfirmDialog/ConfirmDialog';
 import type { ImageViewerRef } from './ImageViewer';
 
 // Custom hooks
@@ -19,6 +20,7 @@ import { useImageViewControls } from '@/hooks/useImageViewControls';
 import { useSlideshow } from '@/hooks/useSlideshow';
 import { useKeyboardNavigation } from '@/hooks/useKeyboardNavigation';
 import { useToggleFav } from '../../hooks/useToggleFav';
+import { useDeleteImages } from '@/hooks/useDeleteImages';
 import { useLocation } from 'react-router';
 import { ROUTES } from '@/constants/routes';
 
@@ -48,6 +50,8 @@ export function MediaView({
   const [showInfo, setShowInfo] = useState(false);
   const [showThumbnails, setShowThumbnails] = useState(false);
   const [resetSignal, setResetSignal] = useState(0);
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const [deleteFromDevice, setDeleteFromDevice] = useState(false);
 
   // Custom hooks
   const { viewState, handlers } = useImageViewControls();
@@ -86,6 +90,18 @@ export function MediaView({
 
   const location = useLocation();
   const { toggleFavourite } = useToggleFav();
+  const { deleteImages } = useDeleteImages();
+
+  /** Start unticked every time, so a previous tick never causes a file deletion. */
+  const handleOpenDeleteDialog = useCallback(() => {
+    setDeleteFromDevice(false);
+    setShowDeleteDialog(true);
+  }, []);
+
+  const handleConfirmDelete = useCallback(() => {
+    if (!currentImage?.id) return;
+    deleteImages({ imageIds: [currentImage.id], deleteFromDevice });
+  }, [currentImage, deleteImages, deleteFromDevice]);
 
   // Loop to first image handler for slideshow
   const handleLoopToStart = useCallback(() => {
@@ -180,10 +196,28 @@ export function MediaView({
         onToggleFavourite={handleToggleFavourite}
         isFavourite={currentImage.isFavourite || false}
         onOpenFolder={handleOpenFolder}
+        onDelete={type === 'image' ? handleOpenDeleteDialog : undefined}
         isSlideshowActive={isSlideshowActive}
         onToggleSlideshow={toggleSlideshow}
         onClose={handleClose}
         type={type}
+      />
+
+      <ConfirmDialog
+        open={showDeleteDialog}
+        onOpenChange={setShowDeleteDialog}
+        title="Delete photo"
+        description="Choose whether this photo is only removed from PictoPy, or deleted from your computer as well."
+        confirmLabel="Delete"
+        onConfirm={handleConfirmDelete}
+        checkboxLabel="Also delete the file from the folder on my computer"
+        checkboxChecked={deleteFromDevice}
+        onCheckboxChange={setDeleteFromDevice}
+        checkboxHint={
+          deleteFromDevice
+            ? 'The file will be permanently deleted from its folder. This cannot be undone.'
+            : 'Removed from your PictoPy gallery. The file stays in its folder.'
+        }
       />
 
       {/* Main viewer area */}

--- a/frontend/src/components/Media/MediaViewControls.tsx
+++ b/frontend/src/components/Media/MediaViewControls.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
-import { Info, Heart, Play, Pause, X, Folder } from 'lucide-react';
+import { Info, Heart, Play, Pause, X, Folder, Trash2 } from 'lucide-react';
 
 interface MediaViewControlsProps {
   showInfo: boolean;
   onToggleInfo: () => void;
   onToggleFavourite: () => void;
   onOpenFolder: () => Promise<void>;
+  /** Omit to hide the delete button, for media that cannot be deleted yet. */
+  onDelete?: () => void;
   isFavourite: boolean;
   isSlideshowActive: boolean;
   onToggleSlideshow: () => void;
@@ -19,6 +21,7 @@ export const MediaViewControls: React.FC<MediaViewControlsProps> = ({
   onToggleInfo,
   onToggleFavourite,
   onOpenFolder,
+  onDelete,
   isFavourite,
   isSlideshowActive,
   onToggleSlideshow,
@@ -39,6 +42,17 @@ export const MediaViewControls: React.FC<MediaViewControlsProps> = ({
       >
         <Info className="h-5 w-5" />
       </button>
+
+      {onDelete && (
+        <button
+          onClick={onDelete}
+          className="cursor-pointer rounded-full bg-white/80 p-2.5 text-gray-700 shadow-md transition-all duration-200 hover:bg-rose-500/80 hover:text-white hover:shadow-lg dark:bg-black/50 dark:text-white/90 dark:shadow-none dark:hover:bg-rose-500/80 dark:hover:text-white"
+          aria-label="Delete"
+          title="Delete"
+        >
+          <Trash2 className="h-5 w-5" />
+        </button>
+      )}
 
       <button
         onClick={onOpenFolder}

--- a/frontend/src/components/Media/__tests__/MediaViewControls.test.tsx
+++ b/frontend/src/components/Media/__tests__/MediaViewControls.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MediaViewControls } from '../MediaViewControls';
+
+const renderControls = (onDelete?: () => void) =>
+  render(
+    <MediaViewControls
+      showInfo={false}
+      onToggleInfo={jest.fn()}
+      onToggleFavourite={jest.fn()}
+      onOpenFolder={jest.fn().mockResolvedValue(undefined)}
+      onDelete={onDelete}
+      isFavourite={false}
+      isSlideshowActive={false}
+      onToggleSlideshow={jest.fn()}
+      onClose={jest.fn()}
+    />,
+  );
+
+describe('MediaViewControls delete button', () => {
+  test('is hidden when no delete handler is given', () => {
+    renderControls();
+
+    expect(
+      screen.queryByRole('button', { name: 'Delete' }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('calls the delete handler when clicked', () => {
+    const onDelete = jest.fn();
+    renderControls(onDelete);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    expect(onDelete).toHaveBeenCalledTimes(1);
+  });
+
+  test('sits immediately left of the open folder button', () => {
+    renderControls(jest.fn());
+
+    const labels = screen
+      .getAllByRole('button')
+      .map((button) => button.getAttribute('aria-label'));
+
+    expect(labels.indexOf('Delete')).toBe(labels.indexOf('Open Folder') - 1);
+  });
+});

--- a/frontend/src/features/imageSlice.ts
+++ b/frontend/src/features/imageSlice.ts
@@ -44,6 +44,18 @@ const imageSlice = createSlice({
       }
     },
 
+    removeImages(state, action: PayloadAction<string[]>) {
+      const removed = new Set(action.payload);
+      state.images = state.images.filter((img) => !removed.has(img.id));
+      // Keep the viewer on a real image: deleting a middle one shows the next,
+      // deleting the last steps back, and deleting the only one closes the viewer.
+      if (state.images.length === 0) {
+        state.currentViewIndex = -1;
+      } else if (state.currentViewIndex > state.images.length - 1) {
+        state.currentViewIndex = state.images.length - 1;
+      }
+    },
+
     clearImages(state) {
       state.images = [];
       state.currentViewIndex = -1;
@@ -56,6 +68,7 @@ export const {
   setCurrentViewIndex,
   closeImageView,
   updateImageFavoriteStatus,
+  removeImages,
   clearImages,
 } = imageSlice.actions;
 

--- a/frontend/src/hooks/useDeleteImages.ts
+++ b/frontend/src/hooks/useDeleteImages.ts
@@ -1,0 +1,48 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useDispatch } from 'react-redux';
+import { usePictoMutation } from '@/hooks/useQueryExtension';
+import { useMutationFeedback } from '@/hooks/useMutationFeedback';
+import { deleteImages } from '@/api/api-functions/images';
+import { removeImages } from '@/features/imageSlice';
+
+interface DeleteImagesArgs {
+  imageIds: string[];
+  /** True also deletes each file from its folder on disk. */
+  deleteFromDevice: boolean;
+}
+
+export const useDeleteImages = () => {
+  const dispatch = useDispatch();
+  const queryClient = useQueryClient();
+
+  const deleteImagesMutation = usePictoMutation({
+    mutationFn: async ({ imageIds, deleteFromDevice }: DeleteImagesArgs) =>
+      deleteImages({
+        image_ids: imageIds,
+        delete_from_device: deleteFromDevice,
+      }),
+    autoInvalidateTags: ['images'],
+    onSuccess: (data, { imageIds }) => {
+      // Drop them from the store straight away so the viewer moves on instead of
+      // waiting for the refetch. Fall back to what was asked for if the backend
+      // response has no data, so the UI never keeps showing a deleted photo.
+      dispatch(removeImages(data.data?.deleted_ids ?? imageIds));
+      // Separate calls: autoInvalidateTags is passed through as a single queryKey
+      // and matches by prefix, so neither of these matches ['images'].
+      queryClient.invalidateQueries({ queryKey: ['album-images'] });
+      queryClient.invalidateQueries({ queryKey: ['person-images'] });
+    },
+  });
+
+  useMutationFeedback(deleteImagesMutation, {
+    showLoading: false,
+    showSuccess: false,
+    errorTitle: 'Delete Failed',
+    errorMessage: 'Could not delete the photo. Please try again.',
+  });
+
+  return {
+    deleteImages: (args: DeleteImagesArgs) => deleteImagesMutation.mutate(args),
+    deleteImagesPending: deleteImagesMutation.isPending,
+  };
+};


### PR DESCRIPTION
###  Addressed Issues:

Fixes #1503 : App Image Deletion with Disk/Database Options from inside of Gallery.

**Implemented Feature:**
- Implemented a Photo Deletion Option in the Image Viewer.
- It has two options (which are shown in the conform Dialog in MediaView): Wheather to Delete from Computer of from Pictopy.

- Screenshot of the Media Viewer :  
<img width="733" height="370" alt="WhatsApp Image 2026-09-18 at 19 33 50 (1)" src="https://github.com/user-attachments/assets/c4448152-a0ca-43c5-a708-19cabc5394a2" />
<img width="780" height="368" alt="WhatsApp Image 2026-09-18 at 19 33 50" src="https://github.com/user-attachments/assets/864528e5-532a-4689-8a15-007f6596bad4" />


###  Screenshots/Recordings:

**PictoPy Before:**

<img width="1275" height="709" alt="Screenshot 2026-09-18 at 7 37 53 PM" src="https://github.com/user-attachments/assets/a7839f9a-81c0-4716-a5b1-ac79d5296ce2" />


**PictoPy After:**


https://github.com/user-attachments/assets/04de0bc9-44f7-42ad-9d1d-a0bd3072d47f


###  Additional Notes:

**Files Changed = 11
Test Files = 3
Backend Files =  3
Frontend Files = 7 **

### Backend Changes:

**A. database/images.py:** 

```
def _normalise_path(path: ImagePath) -> ImagePath:
    """Key a path the way the folder scan compares them.

    The scan matches stored paths against paths it just walked off disk, and
    Windows hands back inconsistent casing.
    """
    return os.path.normcase(os.path.abspath(path))

```
**Made this normalize path function to normalize all the paths given from different os into one.**

```
# Paths the user removed from the gallery but kept on disk. The folder scan
    # skips these, otherwise the watcher's next sync-folder would re-import the
    # file and the photo would reappear. Cascading off folders means removing and
    # re-adding a folder clears its exclusions, which is the only way back.
    cursor.execute(
        """
        CREATE TABLE IF NOT EXISTS excluded_image_paths (
            path TEXT PRIMARY KEY,
            folder_id TEXT,
            FOREIGN KEY (folder_id) REFERENCES folders(folder_id) ON DELETE CASCADE
        )
    """
    )
```
**Created a table named excluded-image_paths which stores the path of the image that is only removed from pictopy database and not from the main System Folder.**

**Added Two Functions:**
1. 
```
def db_get_excluded_image_paths() -> Set[ImagePath]:
    """Paths the folder scan must not re-import, keyed like the scan compares them."""
```

**This function sees all the excluded images from the table excluded_image_paths so that it should not import them again after opening and closing the app.**

2.**def db_exclude_image_paths :** It excludes image or deletes the image from pictopy only without touching the main folder.


**B. backend/app/routes/images.py :** 
‍‍def delete_images(request: DeleteImagesRequest):
    """Delete images from the gallery, optionally from the device as well."""

**A function for routing to the frontend in order to delete images from pictopy and optionally from main folder.**



**C. backend/app/utils/images.py:**  The main deletion logic stays here :

**2 main fuctions:

1.image_util_remove_files: 

- Handles user-requested image deletion from PictoPy. It supports two modes: removing an image only from the PictoPy gallery while keeping the original file on disk, or deleting the original file from the device as well.

-  It also removes the associated thumbnail and database record, and for gallery-only deletion it records the file path as excluded so a future folder scan does not re-import the image. The function returns the IDs that were successfully removed and any file paths that could not be deleted.


2.image_util_delete_images**:

Cleans up database entries for images whose original files no longer exist on the filesystem. It identifies those obsolete image records, removes their cached thumbnails, deletes the corresponding database records, and returns the number of obsolete images removed.

D. **backend/tests/test_images_delete.py:** Test file, checks all the possible tests.

### Frontend Changes:

1. **frontend/src/api/api-functions/images.ts:** API connections from the backend.

```
export interface DeleteImagesRequest {
  image_ids: string[];
  /** True also deletes each file from its folder on disk. */
  delete_from_device: boolean;
}

export interface DeleteImagesAPIResponse extends APIResponse {
  data?: {
    deleted_ids: string[];
    failed_paths: string[];
  };
}

export const deleteImages = async (
  request: DeleteImagesRequest,
): Promise<DeleteImagesAPIResponse> => {
  const response = await apiClient.delete<DeleteImagesAPIResponse>(
    imagesEndpoints.deleteImages,
    { data: request },
  );
  return response.data;
};
```

2. **frontend/src/api/apiEndpoints.ts:** deleteImages: '/images/delete-images', 
Added this image endpoint.

**3.frontend/src/components/Media/MediaView.tsx:** Added the confirmDialog.


```
<ConfirmDialog
        open={showDeleteDialog}
        onOpenChange={setShowDeleteDialog}
        title="Delete photo"
        description="Remove this Photo from PictoPy"
        confirmLabel="Delete"
        onConfirm={handleConfirmDelete}
        checkboxLabel="Delete from Computer"
        checkboxChecked={deleteFromDevice}
        onCheckboxChange={setDeleteFromDevice}
        checkboxHint={
          deleteFromDevice
            ? 'The file will be permanently deleted from its folder. This cannot be undone.'
            : 'Removed from your PictoPy gallery. The file stays in its folder.'
        }
        checkboxHintDestructive={deleteFromDevice}
      />

```

**4.  frontend/src/components/Media/MediaViewControls.tsx:** Added the Delete Button:

```
 {onDelete && (
        <button
          onClick={onDelete}
          className="cursor-pointer rounded-full bg-white/80 p-2.5 text-gray-700 shadow-md transition-all duration-200 hover:bg-rose-500/80 hover:text-white hover:shadow-lg dark:bg-black/50 dark:text-white/90 dark:shadow-none dark:hover:bg-rose-500/80 dark:hover:text-white"
          aria-label="Delete"
          title="Delete"
        >
          <Trash2 className="h-5 w-5" />
        </button>
      )}
```

**5. frontend/src/hooks/useDeleteImages.ts:**

```
import { useQueryClient } from '@tanstack/react-query';
import { useDispatch } from 'react-redux';
import { usePictoMutation } from '@/hooks/useQueryExtension';
import { useMutationFeedback } from '@/hooks/useMutationFeedback';
import { deleteImages } from '@/api/api-functions/images';
import { removeImages } from '@/features/imageSlice';

interface DeleteImagesArgs {
  imageIds: string[];
  /** True also deletes each file from its folder on disk. */
  deleteFromDevice: boolean;
}

export const useDeleteImages = () => {
  const dispatch = useDispatch();
  const queryClient = useQueryClient();

  const deleteImagesMutation = usePictoMutation({
    mutationFn: async ({ imageIds, deleteFromDevice }: DeleteImagesArgs) =>
      deleteImages({
        image_ids: imageIds,
        delete_from_device: deleteFromDevice,
      }),
    autoInvalidateTags: ['images'],
    onSuccess: (data, { imageIds }) => {
      // Drop them from the store straight away so the viewer moves on instead of
      // waiting for the refetch. Fall back to what was asked for if the backend
      // response has no data, so the UI never keeps showing a deleted photo.
      dispatch(removeImages(data.data?.deleted_ids ?? imageIds));
      // Separate calls: autoInvalidateTags is passed through as a single queryKey
      // and matches by prefix, so neither of these matches ['images'].
      queryClient.invalidateQueries({ queryKey: ['album-images'] });
      queryClient.invalidateQueries({ queryKey: ['person-images'] });
    },Expand commentComment on lines R25 to R34
  });

  useMutationFeedback(deleteImagesMutation, {
    showLoading: false,
    showSuccess: false,
    errorTitle: 'Delete Failed',
    errorMessage: 'Could not delete the photo. Please try again.',
  });

  return {
    deleteImages: (args: DeleteImagesArgs) => deleteImagesMutation.mutate(args),
    deleteImagesPending: deleteImagesMutation.isPending,
  };
};
```

6. **src/components/Dialog/ConfirmDialog.tsx:** It is the confirmDialog UI/UX code .

7. All other files are test files with all the added tests.




### AI Usage Disclosure:

We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact. AI slop is strongly discouraged and may lead to banning and blocking. Do not spam our repos with AI slop.

Check one of the checkboxes below:

- [ ] This PR does not contain AI-generated code at all.
- [x] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools:  Claude Opus 5


## Checklist
<!-- Mark items with [x] to indicate completion -->
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [x] If applicable, I have made corresponding changes or additions to the documentation
- [x] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

- Added image deletion from the gallery, with an option to also remove files from the device.
- Added confirmation dialogs with optional safety checkboxes for destructive actions.
- Deleted gallery-only images are excluded from future scans.
- Added timestamps showing when images were favourited.

## Bug Fixes

- Preserved valid zero GPS coordinates during image processing.
- Improved deletion handling when files are missing or cannot be removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->